### PR TITLE
Don't fail pipeline on an error with IAM policy.

### DIFF
--- a/google/cloud/security/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/security/common/gcp_api/cloud_resource_manager.py
@@ -114,16 +114,17 @@ class CloudResourceManagerClient(_BaseClient):
         """
         projects_stub = self.service.projects()
 
-        try:
-            for project_number in project_numbers:
+        for project_number in project_numbers:
+            try:
                 with self.rate_limiter:
                     request = projects_stub.getIamPolicy(
                         resource=project_number, body={})
                     response = self._execute(request)
                     yield {'project_number': project_number,
                            'iam_policy': response}
-        except (HttpError, HttpLib2Error) as e:
-            raise ApiExecutionError(resource_name, e)
+            except (HttpError, HttpLib2Error) as e:
+                LOGGER.error('Unable to get IAM policies for project %s:\n%s',
+                             project_number, e)
 
     def get_organization(self, org_name):
         """Get organizations.

--- a/google/cloud/security/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/security/common/gcp_api/cloud_resource_manager.py
@@ -117,7 +117,7 @@ class CloudResourceManagerClient(_BaseClient):
                     resource=project_number, body={})
                 response = self._execute(request)
                 return {'project_number': project_number,
-                       'iam_policy': response}
+                        'iam_policy': response}
         except (HttpError, HttpLib2Error) as e:
             raise ApiExecutionError(resource_name, e)
 

--- a/google/cloud/security/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/security/common/gcp_api/cloud_resource_manager.py
@@ -97,31 +97,29 @@ class CloudResourceManagerClient(_BaseClient):
         except (HttpError, HttpLib2Error) as e:
             raise ApiExecutionError(resource_name, e)
 
-    def get_project_iam_policies(self, resource_name, project_numbers):
+    def get_project_iam_policies(self, resource_name, project_number):
         """Get all the iam policies of given project numbers.
 
         Args:
             resource_name: String of the resource's name.
-            project_numbers: MySQLdb cursor object of project numbers.
+            project_number: Integer of project number.
 
-        Yields:
-            An iterable of iam policies as per-project dictionary.
+        Returns:
+            Per-project dictionary of iam policies.
             Example: {project_number: policy}
             https://cloud.google.com/resource-manager/reference/rest/Shared.Types/Policy
         """
         projects_stub = self.service.projects()
 
-        for project_number in project_numbers:
-            try:
-                with self.rate_limiter:
-                    request = projects_stub.getIamPolicy(
-                        resource=project_number, body={})
-                    response = self._execute(request)
-                    yield {'project_number': project_number,
-                           'iam_policy': response}
-            except (HttpError, HttpLib2Error) as e:
-                LOGGER.error('Unable to get IAM policies for project %s:\n%s',
-                             project_number, e)
+        try:
+            with self.rate_limiter:
+                request = projects_stub.getIamPolicy(
+                    resource=project_number, body={})
+                response = self._execute(request)
+                return {'project_number': project_number,
+                       'iam_policy': response}
+        except (HttpError, HttpLib2Error) as e:
+            raise ApiExecutionError(resource_name, e)
 
     def get_organization(self, org_name):
         """Get organizations.

--- a/google/cloud/security/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/security/common/gcp_api/cloud_resource_manager.py
@@ -108,9 +108,6 @@ class CloudResourceManagerClient(_BaseClient):
             An iterable of iam policies as per-project dictionary.
             Example: {project_number: policy}
             https://cloud.google.com/resource-manager/reference/rest/Shared.Types/Policy
-
-        Raises:
-            ApiExecutionError: An error has occurred when executing the API.
         """
         projects_stub = self.service.projects()
 

--- a/google/cloud/security/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/security/common/gcp_api/cloud_resource_manager.py
@@ -97,16 +97,15 @@ class CloudResourceManagerClient(_BaseClient):
         except (HttpError, HttpLib2Error) as e:
             raise ApiExecutionError(resource_name, e)
 
-    def get_project_iam_policies(self, resource_name, project_number):
+    def get_project_iam_policies(self, resource_name, project_identifier):
         """Get all the iam policies of given project numbers.
 
         Args:
             resource_name: String of the resource's name.
-            project_number: Integer of project number.
+            project_identifier: Either the project number or the project id.
 
         Returns:
-            Per-project dictionary of iam policies.
-            Example: {project_number: policy}
+            IAM policies of the project.
             https://cloud.google.com/resource-manager/reference/rest/Shared.Types/Policy
         """
         projects_stub = self.service.projects()
@@ -114,10 +113,8 @@ class CloudResourceManagerClient(_BaseClient):
         try:
             with self.rate_limiter:
                 request = projects_stub.getIamPolicy(
-                    resource=project_number, body={})
-                response = self._execute(request)
-                return {'project_number': project_number,
-                        'iam_policy': response}
+                    resource=project_identifier, body={})
+                return self._execute(request)
         except (HttpError, HttpLib2Error) as e:
             raise ApiExecutionError(resource_name, e)
 

--- a/google/cloud/security/inventory/pipelines/load_projects_iam_policies_pipeline.py
+++ b/google/cloud/security/inventory/pipelines/load_projects_iam_policies_pipeline.py
@@ -18,7 +18,6 @@ import json
 
 from google.cloud.security.common.data_access.errors import CSVFileError
 from google.cloud.security.common.data_access.errors import MySQLError
-from google.cloud.security.common.gcp_api._base_client import ApiExecutionError
 # TODO: Investigate improving so the pylint disable isn't needed.
 # pylint: disable=line-too-long
 from google.cloud.security.common.gcp_api.cloud_resource_manager import CloudResourceManagerClient

--- a/google/cloud/security/inventory/pipelines/load_projects_iam_policies_pipeline.py
+++ b/google/cloud/security/inventory/pipelines/load_projects_iam_policies_pipeline.py
@@ -22,8 +22,10 @@ from google.cloud.security.common.gcp_api._base_client import ApiExecutionError
 # TODO: Investigate improving so the pylint disable isn't needed.
 # pylint: disable=line-too-long
 from google.cloud.security.common.gcp_api.cloud_resource_manager import CloudResourceManagerClient
+from google.cloud.security.common.util.log_util import LogUtil
 from google.cloud.security.inventory import transform_util
 from google.cloud.security.inventory.errors import LoadDataPipelineError
+
 
 
 LOGGER = LogUtil.setup_logging(__name__)

--- a/google/cloud/security/inventory/pipelines/load_projects_iam_policies_pipeline.py
+++ b/google/cloud/security/inventory/pipelines/load_projects_iam_policies_pipeline.py
@@ -26,6 +26,7 @@ from google.cloud.security.inventory import transform_util
 from google.cloud.security.inventory.errors import LoadDataPipelineError
 
 
+LOGGER = LogUtil.setup_logging(__name__)
 RESOURCE_NAME = 'project_iam_policies'
 RAW_PROJECT_IAM_POLICIES = 'raw_project_iam_policies'
 

--- a/google/cloud/security/inventory/pipelines/load_projects_iam_policies_pipeline.py
+++ b/google/cloud/security/inventory/pipelines/load_projects_iam_policies_pipeline.py
@@ -62,8 +62,10 @@ def run(dao=None, cycle_timestamp=None, configs=None, crm_rate_limiter=None):
     iam_policy_maps = []
     for project_number in project_numbers:
         try:
-            iam_policy_map = crm_client.get_project_iam_policies(
+            iam_policy = crm_client.get_project_iam_policies(
                 RESOURCE_NAME, project_number)
+            iam_policy_map = {'project_number': project_number,
+                              'iam_policy': iam_policy}
             iam_policy_maps.append(iam_policy_map)
         except ApiExecutionError as e:
             LOGGER.error('Unable to get IAM policies for project %s:\n%s',

--- a/google/cloud/security/inventory/pipelines/load_projects_iam_policies_pipeline.py
+++ b/google/cloud/security/inventory/pipelines/load_projects_iam_policies_pipeline.py
@@ -53,21 +53,18 @@ def run(dao=None, cycle_timestamp=None, configs=None, crm_rate_limiter=None):
         raise LoadDataPipelineError(e)
 
     crm_client = CloudResourceManagerClient(rate_limiter=crm_rate_limiter)
-    try:
-        # Retrieve data from GCP.
-        # Flatten the iterator since we will use it twice, and it is faster
-        # than cloning to 2 iterators.
-        iam_policies_map = crm_client.get_project_iam_policies(
-            RESOURCE_NAME, project_numbers)
-        # TODO: Investigate improving so the pylint disable isn't needed.
-        # pylint: disable=redefined-variable-type
-        iam_policies_map = list(iam_policies_map)
+    # Retrieve data from GCP.
+    # Flatten the iterator since we will use it twice, and it is faster
+    # than cloning to 2 iterators.
+    iam_policies_map = crm_client.get_project_iam_policies(
+        RESOURCE_NAME, project_numbers)
+    # TODO: Investigate improving so the pylint disable isn't needed.
+    # pylint: disable=redefined-variable-type
+    iam_policies_map = list(iam_policies_map)
 
-        # Flatten and relationalize data for upload to cloud sql.
-        flattened_iam_policies = (
-            transform_util.flatten_iam_policies(iam_policies_map))
-    except ApiExecutionError as e:
-        raise LoadDataPipelineError(e)
+    # Flatten and relationalize data for upload to cloud sql.
+    flattened_iam_policies = (
+        transform_util.flatten_iam_policies(iam_policies_map))
 
     # Load flattened iam policies into cloud sql.
     # Load raw iam policies into cloud sql.


### PR DESCRIPTION
Previously, we had a stance where we failed the entire pipeline if there was even a single error with an IAM policy.  We want to change this, so that if there is problem with the IAM policy of one project, we flag it but keep going with getting the IAM policies for other projects.

For this PR, we are flagging by logging.  There will be some more work to do, if we want to flag it in the database.

Fixes #128.
