### PR TITLE
Remove usage of db password for command options.

### DIFF
--- a/docs/prerequisites/PREREQUISITES-LOCALLY.md
+++ b/docs/prerequisites/PREREQUISITES-LOCALLY.md
@@ -17,9 +17,20 @@
   1. Configure Users Access Control
      * Change password for root user.
      * Create a new user with [read/write privileges](https://cloud.google.com/sql/docs/mysql/users?hl=en_US#privileges).
+     * Do not set password for the new user, as the permissioning will be provided by the sqlproxy.
   1. Create New Database
      * Enter a name.
-  1. Follow these instructions to establish a secure connection using [SQL Proxy](https://cloud.google.com/sql/docs/mysql-connect-proxy#connecting_mysql_client)
+  1. For local development, we recommend authenticating the
+     [SQL Proxy](https://cloud.google.com/sql/docs/mysql-connect-proxy#connecting_mysql_client)
+     with gcloud using your own credential.
+
+     ```sh
+     # in separate terminal
+     $ gcloud auth application-default login
+     $ <path_to_cloud_sql_proxy>/cloud_sql_proxy -instances=<my_cloud_sql_instance_name>=tcp:3306
+
+     # --db_host will now point to 127.0.0.1
+     ```
 
 ## Install the `protoc` compiler
 Download the [protoc pre-built binary](https://github.com/google/protobuf/releases).

--- a/google/cloud/security/common/data_access/_db_connector.py
+++ b/google/cloud/security/common/data_access/_db_connector.py
@@ -29,7 +29,7 @@ flags.DEFINE_string('db_host', '127.0.0.1',
                     'Cloud SQL instance hostname/IP address')
 flags.DEFINE_string('db_name', 'forseti_security', 'Cloud SQL database name')
 flags.DEFINE_string('db_user', 'root', 'Cloud SQL user')
-flags.DEFINE_string('db_passwd', None, 'Cloud SQL password')
+
 
 # pylint: disable=too-few-public-methods
 # TODO: Investigate improving so we can avoid the pylint disable.
@@ -45,22 +45,11 @@ class _DbConnector(object):
         configs = FLAGS.FlagValuesDict()
 
         try:
-            # If specifying the passwd argument, MySQL expects a string,
-            # which would not be correct if there is no password (i.e.
-            # using cloud_sql_proxy to connect without a db password).
-            if 'db_passwd' in configs and configs['db_passwd']:
-                self.conn = MySQLdb.connect(
-                    host=configs['db_host'],
-                    user=configs['db_user'],
-                    passwd=configs['db_passwd'],
-                    db=configs['db_name'],
-                    local_infile=1)
-            else:
-                self.conn = MySQLdb.connect(
-                    host=configs['db_host'],
-                    user=configs['db_user'],
-                    db=configs['db_name'],
-                    local_infile=1)
+            self.conn = MySQLdb.connect(
+                host=configs['db_host'],
+                user=configs['db_user'],
+                db=configs['db_name'],
+                local_infile=1)
         except OperationalError as e:
             LOGGER.error('Unable to create mysql connector:\n%s', e)
             raise MySQLError('DB Connector', e)

--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -20,7 +20,6 @@ Usage:
       --organization_id <organization_id> (required) \\
       --db_host <Cloud SQL database hostname/IP> \\
       --db_user <Cloud SQL database user> \\
-      --db_passwd <Cloud SQL database password> \\
       --db_name <Cloud SQL database name (required)> \\
       --max_crm_api_calls_per_100_seconds <QPS * 100, default 400> \\
       --sendgrid_api_key <API key to auth SendGrid email service> \\

--- a/google/cloud/security/scanner/samples/rules.yaml
+++ b/google/cloud/security/scanner/samples/rules.yaml
@@ -5,7 +5,7 @@ rules:
       - type: organization
         applies_to: self_and_children
         resource_ids:
-          - 660570133860
+          - YOUR_ORG_ID
     inherit_from_parents: true
     bindings:
       - role: roles/*

--- a/google/cloud/security/scanner/samples/rules.yaml
+++ b/google/cloud/security/scanner/samples/rules.yaml
@@ -5,7 +5,7 @@ rules:
       - type: organization
         applies_to: self_and_children
         resource_ids:
-          - YOUR_ORG_ID
+          - 660570133860
     inherit_from_parents: true
     bindings:
       - role: roles/*

--- a/google/cloud/security/scanner/scanner.py
+++ b/google/cloud/security/scanner/scanner.py
@@ -21,7 +21,6 @@ Usage:
       --organization_id <organization_id> (required) \\
       --db_host <Cloud SQL database hostname/IP> \\
       --db_user <Cloud SQL database user> \\
-      --db_passwd <Cloud SQL database password> \\
       --db_name <Cloud SQL database name (required)> \\
       --sendgrid_api_key <API key to auth SendGrid email service> \\
       --email_sender <email address of the email sender> \\

--- a/scripts/dev_scanner.sh.sample
+++ b/scripts/dev_scanner.sh.sample
@@ -20,7 +20,6 @@ PYTHONPATH=./ python google/cloud/security/scanner/scanner.py \
         --output_path <output path> \
         --db_host 127.0.0.1 \
         --db_user root \
-        --db_passwd <database password> \
         --db_name <database name> \
         --organization_id <org id> \
         --sendgrid_api_key <Sendgrid API key> \


### PR DESCRIPTION
- Cloud SQL Proxy will be required for access.

- Cloud SQL Proxy permissioning will be:
  (1) service account on GCP env
  (2) developer on local env 

- This change only affects the local env, as the GCP env does not use db password.

Addresses #154 