### PR TITLE
Sync 1.0.1 release-version with src-path

### DIFF
--- a/deployment-templates/deploy-forseti.yaml.sample
+++ b/deployment-templates/deploy-forseti.yaml.sample
@@ -55,7 +55,7 @@ resources:
     database-name: forseti_security
     organization-id: YOUR_ORG_ID
     release-version: "1.0.1"
-    src-path: https://github.com/GoogleCloudPlatform/forseti-security/archive/v1.0.tar.gz
+    src-path: https://github.com/GoogleCloudPlatform/forseti-security/archive/v1.0.1.tar.gz
     cloudsqlproxy-os-arch: linux.amd64
     db-port: 3306
     # Remove or comment out the email properties if you do not want to send email.


### PR DESCRIPTION
This fixes people updating deployment templates and still not deploying 1.0.1 unless they spot src-path doesn't match release-version.

Would it be better to interpolate release-version into src-path ?