### PR TITLE
Make the api clients cleaner to create.

### DIFF
--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -45,7 +45,7 @@ class AdminDirectoryClient(_base_client.BaseClient):
     """GSuite Admin Directory API Client."""
 
     API_NAME = 'admin'
-    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 86400  #pylint: enable=invalid-name
+    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 86400  # pylint: disable=invalid-name
 
     REQUIRED_SCOPES = frozenset([
         'https://www.googleapis.com/auth/admin.directory.group.readonly'

--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -14,6 +14,7 @@
 
 """Wrapper for Admin Directory  API client."""
 
+import gflags as flags
 from googleapiclient.errors import HttpError
 from httplib2 import HttpLib2Error
 from oauth2client.contrib.gce import AppAssertionCredentials
@@ -24,41 +25,42 @@ from google.cloud.security.common.gcp_api import _base_client
 from google.cloud.security.common.gcp_api import errors as api_errors
 from google.cloud.security.common.util import metadata_server
 
+FLAGS = flags.FLAGS
 
-DEFAULT_MAX_QUERIES = 150000
-DEFAULT_RATE_BUCKET_SECONDS = 86400
+flags.DEFINE_string('domain_super_admin_email', None,
+                    'An email address of a super-admin in the GSuite domain.')
 
-REQUIRED_SCOPES = frozenset([
-    'https://www.googleapis.com/auth/admin.directory.group.readonly'
-])
+flags.DEFINE_string('service_account_email', None,
+                    'The email of the service account.')
+
+flags.DEFINE_string('service_account_credentials_file', None,
+                    'The file with credentials for the service account.'
+                    'NOTE: This is only required when running locally.')
+
+flags.DEFINE_integer('max_admin_api_calls_per_day', 150000,
+                     'Admin SDK queries per day.')
 
 
 class AdminDirectoryClient(_base_client.BaseClient):
     """GSuite Admin Directory API Client."""
 
     API_NAME = 'admin'
+    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 86400
 
-    def __init__(self, credentials=None, rate_limiter=None):
+    REQUIRED_SCOPES = frozenset([
+        'https://www.googleapis.com/auth/admin.directory.group.readonly'
+    ])
+
+    def __init__(self):
         super(AdminDirectoryClient, self).__init__(
-            credentials=credentials, api_name=self.API_NAME)
-        if rate_limiter:
-            self.rate_limiter = rate_limiter
-        else:
-            self.rate_limiter = self.get_rate_limiter()
+            credentials=self._build_proper_credentials(),
+            api_name=self.API_NAME)
+        self.rate_limiter = RateLimiter(
+            FLAGS.max_admin_api_calls_per_day,
+            self.DEFAULT_QUOTA_TIMESPAN_PER_SECONDS)
 
-    @staticmethod
-    def get_rate_limiter():
-        """Return an appriopriate rate limiter."""
-        return RateLimiter(
-            DEFAULT_MAX_QUERIES,
-            DEFAULT_RATE_BUCKET_SECONDS)
-
-    @staticmethod
-    def build_proper_credentials(configs):
+    def _build_proper_credentials(self):
         """Build proper credentials required for accessing the directory API.
-
-        Args:
-            configs: Dictionary of configurations.
 
         Returns:
             Credentials as built by oauth2client.
@@ -68,18 +70,18 @@ class AdminDirectoryClient(_base_client.BaseClient):
         """
 
         if metadata_server.can_reach_metadata_server():
-            return AppAssertionCredentials(REQUIRED_SCOPES)
+            return AppAssertionCredentials(self.REQUIRED_SCOPES)
 
         try:
             credentials = ServiceAccountCredentials.from_json_keyfile_name(
-                configs.get('service_account_credentials_file'),
-                scopes=REQUIRED_SCOPES)
+                FLAGS.service_account_credentials_file,
+                scopes=self.REQUIRED_SCOPES)
         except (ValueError, KeyError, TypeError) as e:
             raise api_errors.ApiExecutionError(
-                'Error building admin api credential', e)
+                'Error building admin api credential:\n%s', e)
 
         return credentials.create_delegated(
-            configs.get('domain_super_admin_email'))
+            FLAGS.domain_super_admin_email)
 
     def get_groups(self, customer_id='my_customer'):
         """Get all the groups for a given customer_id.

--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -45,7 +45,7 @@ class AdminDirectoryClient(_base_client.BaseClient):
     """GSuite Admin Directory API Client."""
 
     API_NAME = 'admin'
-    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 86400  # pylint: enable=invalid-name
+    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 86400  #pylint: enable=invalid-name
 
     REQUIRED_SCOPES = frozenset([
         'https://www.googleapis.com/auth/admin.directory.group.readonly'

--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -45,7 +45,6 @@ class AdminDirectoryClient(_base_client.BaseClient):
     """GSuite Admin Directory API Client."""
 
     API_NAME = 'admin'
-    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 86400
 
     REQUIRED_SCOPES = frozenset([
         'https://www.googleapis.com/auth/admin.directory.group.readonly'
@@ -57,7 +56,7 @@ class AdminDirectoryClient(_base_client.BaseClient):
             api_name=self.API_NAME)
         self.rate_limiter = RateLimiter(
             FLAGS.max_admin_api_calls_per_day,
-            self.DEFAULT_QUOTA_TIMESPAN_PER_SECONDS)
+            86400)
 
     def _build_proper_credentials(self):
         """Build proper credentials required for accessing the directory API.

--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -45,6 +45,7 @@ class AdminDirectoryClient(_base_client.BaseClient):
     """GSuite Admin Directory API Client."""
 
     API_NAME = 'admin'
+    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 86400  # pylint: enable=invalid-name
 
     REQUIRED_SCOPES = frozenset([
         'https://www.googleapis.com/auth/admin.directory.group.readonly'
@@ -56,7 +57,7 @@ class AdminDirectoryClient(_base_client.BaseClient):
             api_name=self.API_NAME)
         self.rate_limiter = RateLimiter(
             FLAGS.max_admin_api_calls_per_day,
-            86400)
+            self.DEFAULT_QUOTA_TIMESPAN_PER_SECONDS)
 
     def _build_proper_credentials(self):
         """Build proper credentials required for accessing the directory API.

--- a/google/cloud/security/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/security/common/gcp_api/cloud_resource_manager.py
@@ -36,7 +36,7 @@ class CloudResourceManagerClient(_base_client.BaseClient):
     """Resource Manager Client."""
 
     API_NAME = 'cloudresourcemanager'
-    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 100  # pylint: disable=invalid-name
+    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 100  #pylint: disable=invalid-name
 
     def __init__(self):
         super(CloudResourceManagerClient, self).__init__(

--- a/google/cloud/security/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/security/common/gcp_api/cloud_resource_manager.py
@@ -36,7 +36,7 @@ class CloudResourceManagerClient(_base_client.BaseClient):
     """Resource Manager Client."""
 
     API_NAME = 'cloudresourcemanager'
-    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 100  #pylint: disable=invalid-name
+    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 100  # pylint: disable=invalid-name
 
     def __init__(self):
         super(CloudResourceManagerClient, self).__init__(

--- a/google/cloud/security/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/security/common/gcp_api/cloud_resource_manager.py
@@ -36,13 +36,14 @@ class CloudResourceManagerClient(_base_client.BaseClient):
     """Resource Manager Client."""
 
     API_NAME = 'cloudresourcemanager'
+    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 100  # pylint: disable=invalid-name
 
     def __init__(self):
         super(CloudResourceManagerClient, self).__init__(
             api_name=self.API_NAME)
         self.rate_limiter = RateLimiter(
             FLAGS.max_crm_api_calls_per_100_seconds,
-            100)
+            self.DEFAULT_QUOTA_TIMESPAN_PER_SECONDS)
 
     def get_project(self, project_id):
         """Get all the projects from organization.

--- a/google/cloud/security/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/security/common/gcp_api/cloud_resource_manager.py
@@ -36,14 +36,14 @@ class CloudResourceManagerClient(_base_client.BaseClient):
     """Resource Manager Client."""
 
     API_NAME = 'cloudresourcemanager'
-    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 100
+    DEFAULT_QUOTA = 100
 
     def __init__(self):
         super(CloudResourceManagerClient, self).__init__(
             api_name=self.API_NAME)
         self.rate_limiter = RateLimiter(
             FLAGS.max_crm_api_calls_per_100_seconds,
-            self.DEFAULT_QUOTA_TIMESPAN_PER_SECONDS)
+            self.DEFAULT_QUOTA)
 
     def get_project(self, project_id):
         """Get all the projects from organization.

--- a/google/cloud/security/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/security/common/gcp_api/cloud_resource_manager.py
@@ -36,14 +36,14 @@ class CloudResourceManagerClient(_base_client.BaseClient):
     """Resource Manager Client."""
 
     API_NAME = 'cloudresourcemanager'
-    DEFAULT_API_RATE_PER_SECONDS = 100
+    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 100
 
-    def __init__(self, credentials=None):
+    def __init__(self):
         super(CloudResourceManagerClient, self).__init__(
-            credentials=credentials, api_name=self.API_NAME)
+            api_name=self.API_NAME)
         self.rate_limiter = RateLimiter(
             FLAGS.max_crm_api_calls_per_100_seconds,
-            self.DEFAULT_API_RATE_PER_SECONDS)
+            self.DEFAULT_QUOTA_TIMESPAN_PER_SECONDS)
 
     def get_project(self, project_id):
         """Get all the projects from organization.
@@ -183,7 +183,6 @@ class CloudResourceManagerClient(_base_client.BaseClient):
         """
         orgs_stub = self.service.organizations()
         resource_id = 'organizations/%s' % org_id
-
         try:
             with self.rate_limiter:
                 request = orgs_stub.getIamPolicy(

--- a/google/cloud/security/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/security/common/gcp_api/cloud_resource_manager.py
@@ -36,14 +36,13 @@ class CloudResourceManagerClient(_base_client.BaseClient):
     """Resource Manager Client."""
 
     API_NAME = 'cloudresourcemanager'
-    DEFAULT_QUOTA = 100
 
     def __init__(self):
         super(CloudResourceManagerClient, self).__init__(
             api_name=self.API_NAME)
         self.rate_limiter = RateLimiter(
             FLAGS.max_crm_api_calls_per_100_seconds,
-            self.DEFAULT_QUOTA)
+            100)
 
     def get_project(self, project_id):
         """Get all the projects from organization.

--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -72,8 +72,6 @@ flags.DEFINE_string('service_account_credentials_file', None,
                     'The file with credentials for the service account.'
                     'NOTE: This is only required when running locally.')
 flags.DEFINE_string('organization_id', None, 'Organization ID.')
-flags.DEFINE_integer('max_crm_api_calls_per_100_seconds', 400,
-                     'Cloud Resource Manager queries per 100 seconds.')
 
 flags.mark_flag_as_required('organization_id')
 
@@ -252,10 +250,7 @@ def main(_):
     # rate limit getting should be from the module
     # rate limit setting should be passed into the creation of the client
     # credentials should be built inside the client and never exposed here
-    max_crm_calls = configs.get('max_crm_api_calls_per_100_seconds', 400)
-    crm_rate_limiter = RateLimiter(max_crm_calls, 100)
-    crm_api_client = crm.CloudResourceManagerClient(
-        rate_limiter=crm_rate_limiter)
+    crm_api_client = crm.CloudResourceManagerClient()
 
     # TODO: Make rate limiter configurable.
     admin_directory_rate_limiter = (

--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -25,6 +25,8 @@ Usage:
       --db_host <Cloud SQL database hostname/IP> \\
       --db_user <Cloud SQL database user> \\
       --db_name <Cloud SQL database name (required)> \\
+      --max_crm_api_calls_per_100_seconds 400 \
+      --max_admin_api_calls_per_day 150000 \
       --sendgrid_api_key <API key to auth SendGrid email service> \\
       --email_sender <email address of the email sender> \\
       --email_recipient <email address of the email recipient>
@@ -64,13 +66,6 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_bool('inventory_groups', False,
                   'Whether to inventory GSuite Groups.')
-flags.DEFINE_string('domain_super_admin_email', None,
-                    'An email address of a super-admin in the GSuite domain.')
-flags.DEFINE_string('service_account_email', None,
-                    'The email of the service account.')
-flags.DEFINE_string('service_account_credentials_file', None,
-                    'The file with credentials for the service account.'
-                    'NOTE: This is only required when running locally.')
 flags.DEFINE_string('organization_id', None, 'Organization ID.')
 
 flags.mark_flag_as_required('organization_id')
@@ -239,27 +234,9 @@ def main(_):
 
     configs = FLAGS.FlagValuesDict()
 
-    # It's better to build the ratelimiters once for each API
-    # and reuse them across multiple instances of the Client.
-    # Otherwise, there is a gap where the ratelimiter from one pipeline
-    # is not used for the next pipeline using the same API. This could
-    # lead to unnecessary quota errors.
-    #
-    # TODO: Move the building of the rate limiter and credential
-    # to the api client:
-    # rate limit getting should be from the module
-    # rate limit setting should be passed into the creation of the client
-    # credentials should be built inside the client and never exposed here
-    crm_api_client = crm.CloudResourceManagerClient()
-
-    # TODO: Make rate limiter configurable.
-    admin_directory_rate_limiter = (
-        ad.AdminDirectoryClient.get_rate_limiter())
     try:
-        credentials = ad.AdminDirectoryClient.build_proper_credentials(configs)
-        admin_api_client = ad.AdminDirectoryClient(
-            credentials=credentials,
-            rate_limiter=admin_directory_rate_limiter)
+        crm_api_client = crm.CloudResourceManagerClient()
+        admin_api_client = ad.AdminDirectoryClient()
     except api_errors.ApiExecutionError as e:
         LOGGER.error('Unable to build api client.\n%s', e)
         sys.exit()

--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -40,7 +40,6 @@ from datetime import datetime
 import sys
 
 import gflags as flags
-from ratelimiter import RateLimiter
 
 # TODO: Investigate improving so we can avoid the pylint disable.
 # pylint: disable=line-too-long

--- a/scripts/dev_inventory.sh.sample
+++ b/scripts/dev_inventory.sh.sample
@@ -21,6 +21,7 @@ PYTHONPATH=./ python google/cloud/security/inventory/inventory_loader.py \
         --domain_super_admin_email <an email address of a gsuite super-admin to impersonate for group fetching> \
         --organization_id <organization id> \
         --max_crm_api_calls_per_100_seconds 400 \
+        --max_admin_api_calls_per_day 150000 \
         --db_host 127.0.0.1 \
         --db_user root \
         --db_name <database name> \

--- a/tests/common/gcp_api/crm_test.py
+++ b/tests/common/gcp_api/crm_test.py
@@ -1,0 +1,200 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests the Storage client."""
+
+import mock
+
+from googleapiclient.errors import HttpError
+from httplib2 import HttpLib2Error
+
+from google.apputils import basetest
+from google.cloud.security.common.gcp_api import _base_client
+from google.cloud.security.common.gcp_api import _supported_apis
+from google.cloud.security.common.gcp_api import cloud_resource_manager as crm
+from google.cloud.security.common.gcp_api import errors as api_errors
+from google.cloud.security.common.gcp_type.resource import LifecycleState
+from google.cloud.security.common.util import log_util
+
+
+class CloudResourceManagerTest(basetest.TestCase):
+    """Test the Cloud Resource Manager API Client."""
+
+    MAX_CRM_API_CALLS_PER_100_SECONDS = 88888
+
+    @mock.patch.object(crm, 'FLAGS')
+    @mock.patch.object(_base_client.BaseClient, '__init__', autospec=True)
+    def setUp(self, mock_base_client, mock_flags):
+        """Set up."""
+
+        mock_flags.max_crm_api_calls_per_100_seconds = (
+            self.MAX_CRM_API_CALLS_PER_100_SECONDS)
+        self.crm_api_client = crm.CloudResourceManagerClient()
+
+    def test_api_client_is_initialized(self):
+        """Test that the api client is initialized."""
+
+        self.assertEquals(
+            self.MAX_CRM_API_CALLS_PER_100_SECONDS,
+            self.crm_api_client.rate_limiter.max_calls)
+        self.assertEquals(
+            crm.CloudResourceManagerClient.DEFAULT_QUOTA_TIMESPAN_PER_SECONDS,
+            self.crm_api_client.rate_limiter.period)
+
+    def test_get_project(self):
+        """Test can get project."""
+
+        mock_project_stub = mock.MagicMock()
+        self.crm_api_client.service = mock.MagicMock()
+        self.crm_api_client.service.projects.return_value = mock_project_stub
+
+        project_id = '11111'
+        self.crm_api_client.get_project(project_id)
+        self.crm_api_client.service.projects.assert_called_once_with()
+        mock_project_stub.get.assert_called_once_with(projectId=project_id)
+
+        # test the error handling
+        crm.LOGGER = mock.MagicMock()
+        self.crm_api_client._execute = mock.MagicMock()
+        self.crm_api_client._execute.side_effect = HttpLib2Error
+
+        self.crm_api_client.get_project(project_id)
+        self.assertEquals(1, crm.LOGGER.error.call_count)
+
+    def test_get_projects(self):
+        """Test get projects."""
+
+        mock_project_stub = mock.MagicMock()
+        mock_project_stub.list_next.return_value = None
+        self.crm_api_client.service = mock.MagicMock()
+        self.crm_api_client.service.projects.return_value = mock_project_stub
+        
+        fake_projects = {
+            'projects': [
+                {
+                    'name': 'project1',
+                    'projectId': 'project1',
+                    'projectNumber': '25621943694',
+                    'lifecycleState': 'ACTIVE',
+                },
+                {
+                    'name': 'project2',
+                    'projectId': 'project2',
+                    'projectNumber': '94226340476',
+                    'lifecycleState': 'DELETE_REQUESTED',
+                },
+                {
+                    'name': 'project3',
+                    'projectId': 'project3',
+                    'projectNumber': '133851422272',
+                    'lifecycleState': 'ACTIVE',
+                }]
+            }
+
+        expected_projects = [{
+            'projects': [
+                {
+                    'name': 'project1',
+                    'projectId': 'project1',
+                    'projectNumber': '25621943694',
+                    'lifecycleState': 'ACTIVE',
+                },
+                {
+                    'name': 'project3',
+                    'projectId': 'project3',
+                    'projectNumber': '133851422272',
+                    'lifecycleState': 'ACTIVE',
+                }]
+            }]
+
+        self.crm_api_client._execute = mock.MagicMock(
+            return_value=fake_projects)
+        
+        org_id = '11111'
+        result = list(self.crm_api_client.get_projects(
+            'foo', org_id, lifecycleState=LifecycleState.ACTIVE))
+        self.assertEquals(expected_projects[0], result[0])
+
+
+    def test_get_project_iam_policies(self):
+        """Test get project IAM policies."""
+
+        self.crm_api_client = crm.CloudResourceManagerClient()
+        mock_project_stub = mock.MagicMock()
+        self.crm_api_client.service = mock.MagicMock()
+        self.crm_api_client.service.projects.return_value = mock_project_stub
+
+        project_id = '11111'
+        self.crm_api_client.get_project_iam_policies('foo', project_id)
+        self.crm_api_client.service.projects.assert_called_once_with()
+        mock_project_stub.getIamPolicy.assert_called_once_with(
+            resource=project_id, body={})
+
+        # test the error handling
+        self.crm_api_client._execute = mock.MagicMock()
+        self.crm_api_client._execute.side_effect = HttpLib2Error
+
+        with self.assertRaises(api_errors.ApiExecutionError):
+            self.crm_api_client.get_project_iam_policies('foo', project_id)
+
+    def test_get_organization(self):
+        """Test get organizations."""
+
+        self.crm_api_client = crm.CloudResourceManagerClient()
+        mock_orgs_stub = mock.MagicMock()
+        self.crm_api_client.service = mock.MagicMock()
+        self.crm_api_client.service.organizations.return_value = mock_orgs_stub
+
+        org_name = 'foo'
+        self.crm_api_client.get_organization(org_name)
+        self.crm_api_client.service.organizations.assert_called_once_with()
+        mock_orgs_stub.get.assert_called_once_with(name=org_name)
+
+        # test the error handling
+        crm.LOGGER = mock.MagicMock()
+        self.crm_api_client._execute = mock.MagicMock()
+        self.crm_api_client._execute.side_effect = HttpLib2Error
+
+        self.crm_api_client.get_organization(org_name)
+        self.assertEquals(1, crm.LOGGER.error.call_count)
+
+    def test_get_org_iam_policies(self):
+        """Test get org IAM policies."""
+
+        self.crm_api_client = crm.CloudResourceManagerClient()
+        mock_orgs_stub = mock.MagicMock()
+        self.crm_api_client.service = mock.MagicMock()
+        self.crm_api_client.service.organizations.return_value = mock_orgs_stub
+
+        org_id = '11111'
+        response = '22222'
+        expected_result = {'org_id': org_id, 'iam_policy': response}
+        self.crm_api_client._execute = mock.MagicMock(return_value=response)
+        result = self.crm_api_client.get_org_iam_policies('foo', org_id)
+
+        self.assertEquals(expected_result, next(result))
+        self.crm_api_client.service.organizations.assert_called_once_with()
+        mock_orgs_stub.getIamPolicy.assert_called_once_with(
+            resource='organizations/11111', body={})
+
+        # test the error handling
+        self.crm_api_client._execute = mock.MagicMock()
+        self.crm_api_client._execute.side_effect = HttpLib2Error
+
+        with self.assertRaises(api_errors.ApiExecutionError):
+            self.crm_api_client.get_project_iam_policies('foo', org_id)
+
+
+if __name__ == '__main__':
+    basetest.main()

--- a/tests/inventory/pipelines/test_data/fake_projects.py
+++ b/tests/inventory/pipelines/test_data/fake_projects.py
@@ -37,7 +37,7 @@ FAKE_PROJECTS = [
         },
         'projectId': 'project2',
         'projectNumber': '94226340476',
-        'lifecycleState': 'ACTIVE',
+        'lifecycleState': 'DELETE_REQUESTED',
         'createTime': '2016-11-13T05:32:10.930Z'
       },
       {

--- a/tests/inventory/pipelines/test_data/fake_projects.py
+++ b/tests/inventory/pipelines/test_data/fake_projects.py
@@ -37,7 +37,7 @@ FAKE_PROJECTS = [
         },
         'projectId': 'project2',
         'projectNumber': '94226340476',
-        'lifecycleState': 'DELETE_REQUESTED',
+        'lifecycleState': 'ACTIVE',
         'createTime': '2016-11-13T05:32:10.930Z'
       },
       {


### PR DESCRIPTION
This is in initial attempt to make the api clients cleaner to create.  I'd like to get some feedbacks before also doing this for the admin api module.

- move the quota flag to the api module
- i'm not sure if there really should be a get_rate_limiter static method; seems like we can do without it
- re-use the same api client, so that we can re-use the same rate limiter inside the client