### PR TITLE
Get the Group Users for the Group Rules Engine

### DIFF
--- a/google/cloud/security/common/data_access/group_dao.py
+++ b/google/cloud/security/common/data_access/group_dao.py
@@ -1,0 +1,55 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provides the data access object (DAO) for Groups."""
+
+from google.cloud.security.common.data_access import dao
+from google.cloud.security.common.data_access.sql_queries import select_data
+from google.cloud.security.common.gcp_type import group_member
+from google.cloud.security.common.util import log_util
+
+LOGGER = log_util.get_logger(__name__)
+
+
+class GroupDao(dao.Dao):
+    """Data access object (DAO) for Organizations."""
+
+    def __init__(self):
+        super(GroupDao, self).__init__()
+
+    def get_group_users(self, resource_name, timestamp):
+        """Get the group members who are users.
+
+        Args:
+            timestamp: The timestamp of the snapshot.
+
+        Returns:
+             A dict containing the group (gcp_type.group) and a list of
+            their members (gcp_type.group_members) who are user type.
+        """
+        sql = select_data.GROUP_USERS.format(timestamp)
+        rows = self.execute_sql_with_fetch(resource_name, sql, None)
+        group_users = {}
+        for row in rows:
+            # TODO: Determine if parenting is needed here, similar to
+            # project IAM policies.
+            group_user = group_member.GroupMember(
+                row.get('member_role'),
+                row.get('member_type'),
+                row.get('member_id'))
+            if row.get('group_id') not in group_users:
+                group_users[row.get('group_id')] = [group_user]
+            else:
+                group_users[row.get('group_id')].append(group_user)
+        return group_users

--- a/google/cloud/security/common/data_access/group_dao.py
+++ b/google/cloud/security/common/data_access/group_dao.py
@@ -23,7 +23,7 @@ LOGGER = log_util.get_logger(__name__)
 
 
 class GroupDao(dao.Dao):
-    """Data access object (DAO) for Organizations."""
+    """Data access object (DAO) for Groups."""
 
     def __init__(self):
         super(GroupDao, self).__init__()

--- a/google/cloud/security/common/data_access/sql_queries/select_data.py
+++ b/google/cloud/security/common/data_access/sql_queries/select_data.py
@@ -64,3 +64,9 @@ LATEST_SNAPSHOT_TIMESTAMP = """
 GROUP_IDS = """
     SELECT group_id from groups_{0};
 """
+
+GROUP_USERS = """
+    SELECT group_id, member_role, member_type, member_id
+    FROM group_members_{0}
+    WHERE member_status = "ACTIVE" and member_type = "USER";
+"""

--- a/google/cloud/security/common/gcp_type/group_member.py
+++ b/google/cloud/security/common/gcp_type/group_member.py
@@ -36,9 +36,9 @@ class GroupMember(object):
         self.member_type = member_type
         self.member_email = member_email
 
-        if (not self.member_role or 
-            not self.member_type or
-            not self.member_email):
+        if (not self.member_role or
+                not self.member_type or
+                not self.member_email):
             raise errors.InvalidGroupMemberError(
                 ('Invalid group member: role={}, type={}, email={}'
                  .format(self.member_role,

--- a/google/cloud/security/common/gcp_type/group_member.py
+++ b/google/cloud/security/common/gcp_type/group_member.py
@@ -24,22 +24,23 @@ from google.cloud.security.common.gcp_type import errors
 class GroupMember(object):
     """Group Member."""
 
-    def __init__(self, rule_def_member):
+    def __init__(self, member_role, member_type, member_email):
         """Initialize.
 
         Args:
-            rule_def_member: Dictionary of the Google Group Member from the
-                rule definition.
+            member_role: String of the member role, e.g. owner, member, etc.
+            member_type: String of the member type, e.g. group, user, etc.
+            member_email: String of the member email
         """
-        self.role = rule_def_member.get('role')
-        self.type = rule_def_member.get('type')
-        self.email = rule_def_member.get('email')
+        self.member_role = member_role
+        self.member_type = member_type
+        self.member_email = member_email
 
-        if (not self.role or
-                not self.type or
-                not self.email):
+        if (not self.member_role or 
+            not self.member_type or
+            not self.member_email):
             raise errors.InvalidGroupMemberError(
                 ('Invalid group member: role={}, type={}, email={}'
-                 .format(self.role,
-                         self.type,
-                         self.email)))
+                 .format(self.member_role,
+                         self.member_type,
+                         self.member_email)))

--- a/google/cloud/security/scanner/audit/group_rules_engine.py
+++ b/google/cloud/security/scanner/audit/group_rules_engine.py
@@ -156,7 +156,10 @@ class GroupRuleBook(bre.BaseRuleBook):
                 rule_members = []
                 rule_def_members = rule_def.get('members')
                 for rule_def_member in rule_def_members:
-                    rule_members.append(GroupMember(rule_def_member))
+                    rule_members.append(
+                        GroupMember(rule_def_member.get('role'),
+                                    rule_def_member.get('type'),
+                                    rule_def_member.get('email')))
 
                 rule = Rule(rule_name=rule_def.get('name'),
                             rule_index=rule_index,

--- a/tests/scanner/group_rules_engine_test.py
+++ b/tests/scanner/group_rules_engine_test.py
@@ -69,9 +69,12 @@ class GroupRulesEngineTest(basetest.TestCase):
         self.assertEquals(len(expected_members), len(rule.members))
 
         expected_member = expected_members[0]
-        self.assertEquals(expected_member.get('email') , rule.members[0].email)
-        self.assertEquals(expected_member.get('role'), rule.members[0].role)
-        self.assertEquals(expected_member.get('type'), rule.members[0].type)
+        self.assertEquals(expected_member.get('email') ,
+                          rule.members[0].member_email)
+        self.assertEquals(expected_member.get('role'),
+                          rule.members[0].member_role)
+        self.assertEquals(expected_member.get('type'),
+                          rule.members[0].member_type)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some notes:
(0) Only getting group members of USER type, which I think is relevant to the defined rule.

(1) It seems better to select from the GroupMember table, rather than the raw GroupMember json because the select statement can be (more easily) targeted toward fetching ACTIVE, USER only, vs fetching json.

(2) Not clear how to handle the hierarchy or parenting just yet.  So, leaving a TODO in place.  I'm sure this will become obvious in the next step (when doing traversals to find violations).

(3) Tried subclassing the group dao from the (base) dao.  It works, and the code is cleaner.  But there is still much more to be done here, or replaced by ORM.

(4) No tests here just yet, as this is still much in flux.  Will make sure there is test coverage before wrapping up work here.