### PR TITLE
Rename OrgRule* to "IamRule*"

### DIFF
--- a/google/cloud/security/scanner/audit/iam_rules_engine.py
+++ b/google/cloud/security/scanner/audit/iam_rules_engine.py
@@ -14,7 +14,7 @@
 
 """Rules engine for organizations, folders, and projects.
 
-Builds the RuleBook (OrgRuleBook) from the rule definitions (file either
+Builds the RuleBook (IamRuleBook) from the rule definitions (file either
 stored locally or in GCS) and compares a policy against the RuleBook to
 determine whether there are violations.
 """
@@ -101,17 +101,17 @@ def _check_required_members(rule_members=None, policy_members=None):
     return violating_members
 
 
-class OrgRulesEngine(bre.BaseRulesEngine):
+class IamRulesEngine(bre.BaseRulesEngine):
     """Rules engine for org resources."""
 
     def __init__(self, rules_file_path):
-        super(OrgRulesEngine, self).__init__(
+        super(IamRulesEngine, self).__init__(
             rules_file_path=rules_file_path)
         self.rule_book = None
 
     def build_rule_book(self):
-        """Build OrgRuleBook from the rules definition file."""
-        self.rule_book = OrgRuleBook(self._load_rule_definitions())
+        """Build IamRuleBook from the rules definition file."""
+        self.rule_book = IamRuleBook(self._load_rule_definitions())
 
     def find_policy_violations(self, resource, policy, force_rebuild=False):
         """Determine whether policy violates rules.
@@ -143,7 +143,7 @@ class OrgRulesEngine(bre.BaseRulesEngine):
             self.rule_book.add_rules(rules)
 
 
-class OrgRuleBook(bre.BaseRuleBook):
+class IamRuleBook(bre.BaseRuleBook):
     """The RuleBook for organization resources.
 
     Rules from the rules definition file are parsed and placed into a
@@ -182,7 +182,7 @@ class OrgRuleBook(bre.BaseRuleBook):
             rule_defs: The parsed dictionary of rules from the YAML
                        definition file.
         """
-        super(OrgRuleBook, self).__init__()
+        super(IamRuleBook, self).__init__()
         self._rules_sema = threading.BoundedSemaphore(value=1)
         self.resource_rules_map = {}
         if not rule_defs:
@@ -200,7 +200,7 @@ class OrgRuleBook(bre.BaseRuleBook):
         return not self == other
 
     def __repr__(self):
-        return 'OrgRuleBook <{}>'.format(self.resource_rules_map)
+        return 'IamRuleBook <{}>'.format(self.resource_rules_map)
 
     def add_rules(self, rule_defs):
         """Add rules to the rule book.

--- a/google/cloud/security/scanner/audit/rules_engine.md
+++ b/google/cloud/security/scanner/audit/rules_engine.md
@@ -5,11 +5,11 @@ The "rules engine" takes in a rules file (see the `samples/` directory for examp
 * Organizations
 * Projects
 
-# High level overview of `OrgRulesEngine`
+# High level overview of `IamRulesEngine`
 
-With the `OrgRulesEngine`, Forseti Scanner integrates with Forseti Inventory to get IAM policy data for organizations and projects and runs it against the rule definitions. `OrgRulesEngine` was designed with the organization resources' hierarchy in mind, so rules can "roll up" to the resource ancestors (e.g. a project under some org can look for both the rules for that project as well as for that org).
+With the `IamRulesEngine`, Forseti Scanner integrates with Forseti Inventory to get IAM policy data for organizations and projects and runs it against the rule definitions. `IamRulesEngine` was designed with the organization resources' hierarchy in mind, so rules can "roll up" to the resource ancestors (e.g. a project under some org can look for both the rules for that project as well as for that org).
 
-The `OrgRulesEngine` breaks up an IAM policy by policy binding. If a policy binding violates a rule in its "rule book", it will report a rule violation. In the runner script (`scanner.py`), the rule violations are collected into a CSV file.
+The `IamRulesEngine` breaks up an IAM policy by policy binding. If a policy binding violates a rule in its "rule book", it will report a rule violation. In the runner script (`scanner.py`), the rule violations are collected into a CSV file.
 
 # Creating your own rules engine
 
@@ -23,4 +23,4 @@ The general design for a rules engine would be:
    * The `find_policy_violations()` method searches the rule book and compares the policy against the rule (if found) in the book.
 3. Create or reuse the runner script to instantiate your rules engine and run it. (e.g. `scanner.py`)
 
-Refer to `scanner.py` for an example of how the `OrgRulesEngine` works in conjunction with Forseti Inventory.
+Refer to `scanner.py` for an example of how the `IamRulesEngine` works in conjunction with Forseti Inventory.

--- a/google/cloud/security/scanner/scanner.py
+++ b/google/cloud/security/scanner/scanner.py
@@ -46,7 +46,7 @@ from google.cloud.security.common.gcp_type.resource import ResourceType
 from google.cloud.security.common.gcp_type.resource_util import ResourceUtil
 from google.cloud.security.common.util import log_util
 from google.cloud.security.common.util.email_util import EmailUtil
-from google.cloud.security.scanner.audit.org_rules_engine import OrgRulesEngine
+from google.cloud.security.scanner.audit.iam_rules_engine import IamRulesEngine
 
 # Setup flags
 FLAGS = flags.FLAGS
@@ -84,7 +84,7 @@ def main(_):
                      'Use "forseti_scanner --helpfull" for help.'))
         sys.exit(1)
 
-    rules_engine = OrgRulesEngine(rules_file_path=FLAGS.rules)
+    rules_engine = IamRulesEngine(rules_file_path=FLAGS.rules)
     rules_engine.build_rule_book()
 
     snapshot_timestamp = _get_timestamp()

--- a/tests/scanner/scanner_test.py
+++ b/tests/scanner/scanner_test.py
@@ -30,7 +30,7 @@ from google.cloud.security.common.gcp_type import organization
 from google.cloud.security.common.gcp_type import project
 from google.cloud.security.common.gcp_type import resource
 from google.cloud.security.scanner import scanner
-from google.cloud.security.scanner.audit import org_rules_engine as ore
+from google.cloud.security.scanner.audit import iam_rules_engine as ire
 from google.cloud.security.scanner.audit import rules as audit_rules
 from tests.inventory.pipelines.test_data import fake_iam_policies
 
@@ -61,7 +61,7 @@ class ScannerRunnerTest(basetest.TestCase):
         with self.assertRaises(SystemExit):
             self.scanner.main(self.fake_main_argv)
 
-    @mock.patch.object(ore.OrgRulesEngine, 'build_rule_book', autospec=True)
+    @mock.patch.object(ire.IamRulesEngine, 'build_rule_book', autospec=True)
     @mock.patch.object(scanner, '_get_timestamp')
     def test_no_timestamp_raises_systemexit(self, mock_get_timestamp, mock_build_rule_book):
         """Test that no org or project policies raises SystemExit/calls sys.exit()."""
@@ -71,7 +71,7 @@ class ScannerRunnerTest(basetest.TestCase):
         self.assertEqual(1, mock_build_rule_book.call_count)
         self.scanner.LOGGER.warn.assert_called_with('No snapshot timestamp found. Exiting.')
 
-    @mock.patch.object(ore.OrgRulesEngine, 'build_rule_book')
+    @mock.patch.object(ire.IamRulesEngine, 'build_rule_book')
     @mock.patch.object(scanner, '_get_timestamp')
     @mock.patch.object(scanner, '_get_org_policies')
     @mock.patch.object(scanner, '_get_project_policies')
@@ -89,7 +89,7 @@ class ScannerRunnerTest(basetest.TestCase):
             self.scanner.main(self.fake_main_argv)
         self.scanner.LOGGER.warn.assert_called_with('No policies found. Exiting.')
 
-    @mock.patch.object(ore.OrgRulesEngine, 'build_rule_book', autospec=True)
+    @mock.patch.object(ire.IamRulesEngine, 'build_rule_book', autospec=True)
     @mock.patch.object(scanner, '_get_timestamp')
     @mock.patch.object(scanner, '_get_org_policies')
     @mock.patch.object(scanner, '_get_project_policies')


### PR DESCRIPTION
This is the first step in trying to make the "Rules Engine" modular. The current OrgRulesEngine is actually specifically for IAM rules. Thus, the module name and class name should reflect that.