### PR TITLE
Abstracting paging through results in GCP API requests

### DIFF
--- a/google/cloud/security/common/gcp_api/_base_client.py
+++ b/google/cloud/security/common/gcp_api/_base_client.py
@@ -75,6 +75,8 @@ class BaseClient(object):
     def _build_paged_result(self, request, api_stub, rate_limiter):
         """Execute results and page through the results.
 
+        Use of this method requires the API having a .list_next() method.
+
         Args:
             request: GCP API client request object.
             api_stub: The API stub used to build the request.
@@ -87,9 +89,16 @@ class BaseClient(object):
             When the retry is exceeded, exception will be thrown.  This
             exception is not wrapped by the retry library, and will be handled
             upstream.
+
+            UnsupportedApiMethodError when the api_stub does not have the required
+            list_next() method.
         """
+        if not hasattr(api_stub, 'list_next')
+            raise api_errors.UnsupportedApiMethodError
+
         results = []
         response = []
+
         while request is not None:
             try:
                 with rate_limiter:

--- a/google/cloud/security/common/gcp_api/_base_client.py
+++ b/google/cloud/security/common/gcp_api/_base_client.py
@@ -93,7 +93,7 @@ class BaseClient(object):
             try:
                 with rate_limiter:
                     response = self._execute(request)
-                    results.extend(response)
+                    results.append(response)
                     request = api_stub.list_next(request, response)
             except (HttpError, HttpLib2Error) as e:
                 raise api_errors.ApiExecutionError(api_stub, e)

--- a/google/cloud/security/common/gcp_api/_base_client.py
+++ b/google/cloud/security/common/gcp_api/_base_client.py
@@ -81,7 +81,7 @@ class BaseClient(object):
             rate_limiter: An instance of RateLimiter to use.
 
         Returns:
-            API response object.
+            A list of API response objects (dict).
 
         Raises:
             When the retry is exceeded, exception will be thrown.  This
@@ -89,11 +89,12 @@ class BaseClient(object):
             upstream.
         """
         results = []
+        response = []
         while request is not None:
             try:
                 with rate_limiter:
-                    response = self._execute(request)
-                    results.append(response)
+                    response.append(self._execute(request))
+                    results.extend(response)
                     request = api_stub.list_next(request, response)
             except (HttpError, HttpLib2Error) as e:
                 raise api_errors.ApiExecutionError(api_stub, e)

--- a/google/cloud/security/common/gcp_api/_base_client.py
+++ b/google/cloud/security/common/gcp_api/_base_client.py
@@ -90,11 +90,12 @@ class BaseClient(object):
             exception is not wrapped by the retry library, and will be handled
             upstream.
 
-            UnsupportedApiMethodError when the api_stub does not have the required
-            list_next() method.
+            api_errors.ApiExecutionError when there is no list_next() method
+            on the api_stub.
         """
-        if not hasattr(api_stub, 'list_next')
-            raise api_errors.UnsupportedApiMethodError
+        if not hasattr(api_stub, 'list_next'):
+            raise api_errors.ApiExecutionError(
+                api_stub, 'No list_next() method.')
 
         results = []
         response = []

--- a/google/cloud/security/common/gcp_api/_base_client.py
+++ b/google/cloud/security/common/gcp_api/_base_client.py
@@ -15,6 +15,8 @@
 """Base GCP client which uses the discovery API."""
 
 from apiclient import discovery
+from googleapiclient.errors import HttpError
+from httplib2 import HttpLib2Error
 from oauth2client.client import GoogleCredentials
 from retrying import retry
 
@@ -97,4 +99,3 @@ class BaseClient(object):
                 raise api_errors.ApiExecutionError(api_stub, e)
 
         return results
-

--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -16,8 +16,6 @@
 
 import gflags as flags
 
-from googleapiclient.errors import HttpError
-from httplib2 import HttpLib2Error
 from oauth2client.service_account import ServiceAccountCredentials
 from ratelimiter import RateLimiter
 
@@ -127,4 +125,3 @@ class AdminDirectoryClient(_base_client.BaseClient):
                                            self.rate_limiter)
 
         return [group for group in results.get('groups', [])]
-

--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -97,11 +97,8 @@ class AdminDirectoryClient(_base_client.BaseClient):
         request = members_stub.list(groupKey=group_key,
                                     maxResults=FLAGS.max_results_admin_api)
 
-        try:
-            results = self._build_paged_result(
-                request, members_stub, self.rate_limiter)
-        except api_errors.UnsupportedApiError:
-            raise api_errors.ApiExecutionError
+        results = self._build_paged_result(
+            request, members_stub, self.rate_limiter)
 
         return [item.get('members', []) for item in results]
 
@@ -126,10 +123,7 @@ class AdminDirectoryClient(_base_client.BaseClient):
         groups_stub = self.service.groups()
         request = groups_stub.list(customer=customer_id)
 
-        try:
-            results = self._build_paged_result(
-                request, groups_stub, self.rate_limiter)
-        except api_errors.UnsupportedApiError:
-            raise api_errors.ApiExecutionError
+        results = self._build_paged_result(
+            request, groups_stub, self.rate_limiter)
 
         return [item.get('groups', []) for item in results]

--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -98,26 +98,17 @@ class AdminDirectoryClient(_base_client.BaseClient):
         members_stub = self.service.members()
         request = members_stub.list(groupKey=group_key,
                                     maxResults=FLAGS.max_results_admin_api)
-        results_by_member = []
+        results = self._build_paged_result(request, members_stub,
+                                           self.rate_limiter)
 
-        # TODO: Investigate yielding results to handle large group lists.
-        while request is not None:
-            try:
-                with self.rate_limiter:
-                    response = self._execute(request)
-                    results_by_member.extend(response.get('members', []))
-                    request = members_stub.list_next(request, response)
-            except (HttpError, HttpLib2Error) as e:
-                raise api_errors.ApiExecutionError(members_stub, e)
+        return [member for member in results.get('members', [])]
 
-        return results_by_member
 
     def get_groups(self, customer_id='my_customer'):
         """Get all the groups for a given customer_id.
 
-        A note on customer_id='my_customer'.
-        This is a magic string instead of using the real
-        customer id. See:
+        A note on customer_id='my_customer'. This is a magic string instead
+        of using the real customer id. See:
 
         https://developers.google.com/admin-sdk/directory/v1/guides/manage-groups#get_all_domain_groups
 
@@ -132,16 +123,8 @@ class AdminDirectoryClient(_base_client.BaseClient):
         """
         groups_stub = self.service.groups()
         request = groups_stub.list(customer=customer_id)
-        results_by_group = []
+        results = self._build_paged_result(request, groups_stub,
+                                           self.rate_limiter)
 
-        # TODO: Investigate yielding results to handle large group lists.
-        while request is not None:
-            try:
-                with self.rate_limiter:
-                    response = self._execute(request)
-                    results_by_group.extend(response.get('groups', []))
-                    request = groups_stub.list_next(request, response)
-            except (HttpError, HttpLib2Error) as e:
-                raise api_errors.ApiExecutionError(groups_stub, e)
+        return [group for group in results.get('groups', [])]
 
-        return results_by_group

--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -99,7 +99,7 @@ class AdminDirectoryClient(_base_client.BaseClient):
         results = self._build_paged_result(request, members_stub,
                                            self.rate_limiter)
 
-        return [member for member in results.get('members', [])]
+        return [item.get('members', []) for item in results]
 
 
     def get_groups(self, customer_id='my_customer'):
@@ -124,4 +124,4 @@ class AdminDirectoryClient(_base_client.BaseClient):
         results = self._build_paged_result(request, groups_stub,
                                            self.rate_limiter)
 
-        return [group for group in results.get('groups', [])]
+        return [item.get('groups', []) for item in results]

--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -96,8 +96,12 @@ class AdminDirectoryClient(_base_client.BaseClient):
         members_stub = self.service.members()
         request = members_stub.list(groupKey=group_key,
                                     maxResults=FLAGS.max_results_admin_api)
-        results = self._build_paged_result(request, members_stub,
-                                           self.rate_limiter)
+
+        try:
+            results = self._build_paged_result(
+                request, members_stub, self.rate_limiter)
+        except api_errors.UnsupportedApiError:
+            raise api_errors.ApiExecutionError
 
         return [item.get('members', []) for item in results]
 
@@ -121,7 +125,11 @@ class AdminDirectoryClient(_base_client.BaseClient):
         """
         groups_stub = self.service.groups()
         request = groups_stub.list(customer=customer_id)
-        results = self._build_paged_result(request, groups_stub,
-                                           self.rate_limiter)
+
+        try:
+            results = self._build_paged_result(
+                request, groups_stub, self.rate_limiter)
+        except api_errors.UnsupportedApiError:
+            raise api_errors.ApiExecutionError
 
         return [item.get('groups', []) for item in results]

--- a/google/cloud/security/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/security/common/gcp_api/cloud_resource_manager.py
@@ -93,6 +93,7 @@ class CloudResourceManagerClient(_base_client.BaseClient):
                                   (filter_key, filterargs[filter_key]))
         request = projects_api.list(filter=' '.join(project_filter))
 
+        # TODO: Convert this over to _base_client._build_paged_result().
         try:
             with self.rate_limiter:
                 while request is not None:

--- a/google/cloud/security/common/gcp_api/errors.py
+++ b/google/cloud/security/common/gcp_api/errors.py
@@ -40,11 +40,6 @@ class UnsupportedApiError(Error):
     pass
 
 
-class UnsupportedApiMethodError(Error):
-    """Error for unsupported API method calls."""
-    pass
-
-
 class UnsupportedApiVersionError(Error):
     """Error for unsupported API version."""
     pass

--- a/google/cloud/security/common/gcp_api/errors.py
+++ b/google/cloud/security/common/gcp_api/errors.py
@@ -40,6 +40,11 @@ class UnsupportedApiError(Error):
     pass
 
 
+class UnsupportedApiMethodError(Error):
+    """Error for unsupported API method calls."""
+    pass
+
+
 class UnsupportedApiVersionError(Error):
     """Error for unsupported API version."""
     pass


### PR DESCRIPTION
I'm open to making the change to cloud_resource_manager.py if you have a suggestion, but as it seems to be a different implementation I punted.