### PR TITLE
Fix page results by merging them.

### DIFF
--- a/google/cloud/security/common/gcp_api/_base_client.py
+++ b/google/cloud/security/common/gcp_api/_base_client.py
@@ -83,8 +83,7 @@ class BaseClient(object):
             rate_limiter: An instance of RateLimiter to use.
 
         Returns:
-            A list of API response objects (dict), in pages (i.e. another list).
-            [[page result 1], [page result 2], etc.]
+            A list of API response objects (dict).
 
         Raises:
             When the retry is exceeded, exception will be thrown.  This

--- a/google/cloud/security/common/gcp_api/_base_client.py
+++ b/google/cloud/security/common/gcp_api/_base_client.py
@@ -84,7 +84,7 @@ class BaseClient(object):
 
         Returns:
             A list of API response objects (dict), in pages (i.e. another list).
-            [[page result 1], [paget result 2], etc.]
+            [[page result 1], [page result 2], etc.]
 
         Raises:
             When the retry is exceeded, exception will be thrown.  This

--- a/google/cloud/security/common/gcp_api/_base_client.py
+++ b/google/cloud/security/common/gcp_api/_base_client.py
@@ -83,7 +83,8 @@ class BaseClient(object):
             rate_limiter: An instance of RateLimiter to use.
 
         Returns:
-            A list of API response objects (dict).
+            A list of API response objects (dict), in pages (i.e. another list).
+            [[page result 1], [paget result 2], etc.]
 
         Raises:
             When the retry is exceeded, exception will be thrown.  This

--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -129,6 +129,8 @@ class AdminDirectoryClient(_base_client.BaseClient):
         paged_results = self._build_paged_result(
             request, groups_stub, self.rate_limiter)
 
+        # TODO: Refactor this to a helper function, where a key string can
+        # be passed in, to extract the right values to merge.
         groups = []
         for page in paged_results:
             groups.extend(page.get('groups', []))

--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -97,10 +97,13 @@ class AdminDirectoryClient(_base_client.BaseClient):
         request = members_stub.list(groupKey=group_key,
                                     maxResults=FLAGS.max_results_admin_api)
 
-        results = self._build_paged_result(
+        paged_results = self._build_paged_result(
             request, members_stub, self.rate_limiter)
 
-        return [item.get('members', []) for item in results]
+        group_members = []
+        for page in paged_results:
+            group_members.extend(page.get('members', []))
+        return group_members
 
 
     def get_groups(self, customer_id='my_customer'):
@@ -123,7 +126,10 @@ class AdminDirectoryClient(_base_client.BaseClient):
         groups_stub = self.service.groups()
         request = groups_stub.list(customer=customer_id)
 
-        results = self._build_paged_result(
+        paged_results = self._build_paged_result(
             request, groups_stub, self.rate_limiter)
 
-        return [item.get('groups', []) for item in results]
+        groups = []
+        for page in paged_results:
+            groups.extend(page.get('groups', []))
+        return groups


### PR DESCRIPTION
The paged results need to merged.  Otherwise, the transform() in the pipelines will be borked.
```
[[page result 1], [page result 2], etc.]
```