### PR TITLE
Add ratelimiter for cloudsql and push the rate limiter down to the _execute()

### DIFF
--- a/google/cloud/security/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/security/common/gcp_api/cloud_resource_manager.py
@@ -65,10 +65,9 @@ class CloudResourceManagerClient(_base_client.BaseClient):
         projects_api = self.service.projects()
 
         try:
-            with self.rate_limiter:
-                request = projects_api.get(projectId=project_id)
-                response = self._execute(request)
-                return response
+            request = projects_api.get(projectId=project_id)
+            response = self._execute(request, self.rate_limiter)
+            return response
         except (HttpError, HttpLib2Error) as e:
             raise api_errors.ApiExecutionError(project_id, e)
 
@@ -96,14 +95,13 @@ class CloudResourceManagerClient(_base_client.BaseClient):
 
         # TODO: Convert this over to _base_client._build_paged_result().
         try:
-            with self.rate_limiter:
-                while request is not None:
-                    response = self._execute(request)
-                    yield response
+            while request is not None:
+                response = self._execute(request, self.rate_limiter)
+                yield response
 
-                    request = projects_api.list_next(
-                        previous_request=request,
-                        previous_response=response)
+                request = projects_api.list_next(
+                    previous_request=request,
+                    previous_response=response)
         except (HttpError, HttpLib2Error) as e:
             raise api_errors.ApiExecutionError(resource_name, e)
 
@@ -121,10 +119,9 @@ class CloudResourceManagerClient(_base_client.BaseClient):
         projects_api = self.service.projects()
 
         try:
-            with self.rate_limiter:
-                request = projects_api.getIamPolicy(
-                    resource=project_identifier, body={})
-                return self._execute(request)
+            request = projects_api.getIamPolicy(
+                resource=project_identifier, body={})
+            return self._execute(request, self.rate_limiter)
         except (HttpError, HttpLib2Error) as e:
             raise api_errors.ApiExecutionError(resource_name, e)
 
@@ -140,10 +137,9 @@ class CloudResourceManagerClient(_base_client.BaseClient):
         organizations_api = self.service.organizations()
 
         try:
-            with self.rate_limiter:
-                request = organizations_api.get(name=org_name)
-                response = self._execute(request)
-                return response
+            request = organizations_api.get(name=org_name)
+            response = self._execute(request, self.rate_limiter)
+            return response
         except (HttpError, HttpLib2Error) as e:
             raise api_errors.ApiExecutionError(org_name, e)
 
@@ -161,17 +157,16 @@ class CloudResourceManagerClient(_base_client.BaseClient):
         next_page_token = None
 
         try:
-            with self.rate_limiter:
-                while True:
-                    req_body = {}
-                    if next_page_token:
-                        req_body['pageToken'] = next_page_token
-                    request = organizations_api.search(body=req_body)
-                    response = self._execute(request)
-                    yield response
-                    next_page_token = response.get('nextPageToken')
-                    if not next_page_token:
-                        break
+            while True:
+                req_body = {}
+                if next_page_token:
+                    req_body['pageToken'] = next_page_token
+                request = organizations_api.search(body=req_body)
+                response = self._execute(request, self.rate_limiter)
+                yield response
+                next_page_token = response.get('nextPageToken')
+                if not next_page_token:
+                    break
         except (HttpError, HttpLib2Error) as e:
             raise api_errors.ApiExecutionError(resource_name, e)
 
@@ -192,11 +187,10 @@ class CloudResourceManagerClient(_base_client.BaseClient):
         organizations_api = self.service.organizations()
         resource_id = 'organizations/%s' % org_id
         try:
-            with self.rate_limiter:
-                request = organizations_api.getIamPolicy(
-                    resource=resource_id, body={})
-                return {'org_id': org_id,
-                        'iam_policy': self._execute(request)}
+            request = organizations_api.getIamPolicy(
+                resource=resource_id, body={})
+            return {'org_id': org_id,
+                    'iam_policy': self._execute(request, self.rate_limiter)}
         except (HttpError, HttpLib2Error) as e:
             raise api_errors.ApiExecutionError(resource_name, e)
 
@@ -215,10 +209,9 @@ class CloudResourceManagerClient(_base_client.BaseClient):
         folders_api = self.service.folders()
 
         try:
-            with self.rate_limiter:
-                request = folders_api.get(name=folder_name)
-                response = self._execute(request)
-                return response
+            request = folders_api.get(name=folder_name)
+            response = self._execute(request, self.rate_limiter)
+            return response
         except (HttpError, HttpLib2Error) as e:
             raise api_errors.ApiExecutionError(folder_name, e)
 
@@ -241,18 +234,17 @@ class CloudResourceManagerClient(_base_client.BaseClient):
         lifecycle_state_filter = kwargs.get('lifecycle_state')
 
         try:
-            with self.rate_limiter:
-                while True:
-                    req_body = {}
-                    if next_page_token:
-                        req_body['pageToken'] = next_page_token
-                    if lifecycle_state_filter:
-                        req_body['lifecycleState'] = lifecycle_state_filter
-                    request = folders_api.search(body=req_body)
-                    response = self._execute(request)
-                    yield response
-                    next_page_token = response.get('nextPageToken')
-                    if not next_page_token:
-                        break
+            while True:
+                req_body = {}
+                if next_page_token:
+                    req_body['pageToken'] = next_page_token
+                if lifecycle_state_filter:
+                    req_body['lifecycleState'] = lifecycle_state_filter
+                request = folders_api.search(body=req_body)
+                response = self._execute(request, self.rate_limiter)
+                yield response
+                next_page_token = response.get('nextPageToken')
+                if not next_page_token:
+                    break
         except (HttpError, HttpLib2Error) as e:
             raise api_errors.ApiExecutionError(resource_name, e)

--- a/google/cloud/security/common/gcp_api/cloudsql.py
+++ b/google/cloud/security/common/gcp_api/cloudsql.py
@@ -28,7 +28,7 @@ from googleapiclient.errors import HttpError
 FLAGS = flags.FLAGS
 
 # This API is also limited to 100K queries per day.
-# But operationally, will use the per-100 seconds rate limit. 
+# But operationally, will use the per-100 seconds rate limit.
 flags.DEFINE_integer('max_sqladmin_api_calls_per_100_seconds', 100,
                      'Cloud SQL Admin queries per 100 seconds.')
 

--- a/google/cloud/security/common/gcp_api/cloudsql.py
+++ b/google/cloud/security/common/gcp_api/cloudsql.py
@@ -14,13 +14,23 @@
 
 """Wrapper for SQL API client."""
 
-
+import gflags as flags
 from httplib2 import HttpLib2Error
+from ratelimiter import RateLimiter
+
 
 from google.cloud.security.common.gcp_api import _base_client
 from google.cloud.security.common.gcp_api import errors as api_errors
 from google.cloud.security.common.util import log_util
 from googleapiclient.errors import HttpError
+
+
+FLAGS = flags.FLAGS
+
+# This API is also limited to 100K queries per day.
+# But operationally, will use the per-100 seconds rate limit. 
+flags.DEFINE_integer('max_sqladmin_api_calls_per_100_seconds', 100,
+                     'Cloud SQL Admin queries per 100 seconds.')
 
 LOGGER = log_util.get_logger(__name__)
 
@@ -29,10 +39,14 @@ class CloudsqlClient(_base_client.BaseClient):
     """CloudSQL Client."""
 
     API_NAME = 'sqladmin'
+    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 100  # pylint: disable=invalid-name
 
     def __init__(self, credentials=None):
         super(CloudsqlClient, self).__init__(
             credentials=credentials, api_name=self.API_NAME)
+        self.rate_limiter = RateLimiter(
+            FLAGS.max_sqladmin_api_calls_per_100_seconds,
+            self.DEFAULT_QUOTA_TIMESPAN_PER_SECONDS)
 
     def get_instances(self, project_id):
         """Gets all CloudSQL instances for a project.
@@ -52,7 +66,7 @@ class CloudsqlClient(_base_client.BaseClient):
         instances_api = self.service.instances()
         try:
             instances_request = instances_api.list(project=project_id)
-            instances = instances_request.execute()
+            instances = self._execute(instances_request, self.rate_limiter)
             return instances
         except (HttpError, HttpLib2Error) as e:
             LOGGER.error(api_errors.ApiExecutionError(project_id, e))

--- a/google/cloud/security/common/gcp_api/storage.py
+++ b/google/cloud/security/common/gcp_api/storage.py
@@ -53,6 +53,7 @@ class StorageClient(_base_client.BaseClient):
     def __init__(self, credentials=None):
         super(StorageClient, self).__init__(
             credentials=credentials, api_name=self.API_NAME)
+        # Storage API has no rate limits.
 
     def put_text_file(self, local_file_path, full_bucket_path):
         """Put a text object into a bucket.

--- a/google/cloud/security/common/gcp_api/storage.py
+++ b/google/cloud/security/common/gcp_api/storage.py
@@ -53,7 +53,7 @@ class StorageClient(_base_client.BaseClient):
     def __init__(self, credentials=None):
         super(StorageClient, self).__init__(
             credentials=credentials, api_name=self.API_NAME)
-        # Storage API has no rate limits.
+        # Storage API has unlimited rate.
 
     def put_text_file(self, local_file_path, full_bucket_path):
         """Put a text object into a bucket.


### PR DESCRIPTION
There are 2 changes here:
- add rate limiter for sql api calls
- push down the rate limiter context usage to the _execute() of the base client so that the rate limiter is used more consistently everywhere