### PR TITLE
Update resource coverage for appengine and grantable roles

### DIFF
--- a/_includes/resource_coverage.md
+++ b/_includes/resource_coverage.md
@@ -21,6 +21,7 @@ an issue or contribute!
 | Cloud SQL Inventory             | Done          | Done          | Open          |
 | BigQuery                        | Done          | In Progress   | Open          |
 | Dasher Users                    | Open          | Open          | Open          |
+| Roles                           | Open          | Open          | Open          |
 | GAE                             | Done          | Open          | Open          |
 | GCE Instances                   | Done          | In Progress   | Open          |
 | GCE Instance Groups             | Done          | In Progress   | Open          |

--- a/_includes/resource_coverage.md
+++ b/_includes/resource_coverage.md
@@ -5,26 +5,26 @@ an issue or contribute!
 
 | Resource                        | Inventory     | Scanner       | Enforcer      |
 | ------------------------------- | ------------- | ------------- | ------------- |
-| Organizations                   | Done          | N/A           | Open          |
-| Org IAM Policies                | Done          | Done          | Open          |
-| Projects                        | Done          | N/A           | Open          |
-| Project IAM Policies            | Done          | Done          | Open          |
-| Groups                          | Done          | Done          | Open          |
-| GroupMembers                    | Done          | Done          | Open          |
-| Folders                         | Done          | In Progress   | Open          |
-| Firewall Rules                  | Done          | Open          | Done          |
-| Networks                        | Open          | Open          | Open          |
-| Subnetworks                     | Open          | Open          | Open          |
-| Load Balancer Forwarding Rules  | Done          | In Progress   | Open          |
+| BigQuery                        | Done          | In Progress   | Open          |
 | Buckets                         | Done          | Done          | Open          |
 | BucketACL                       | Done          | Done          | Open          |
 | Cloud SQL Inventory             | Done          | Done          | Open          |
-| BigQuery                        | Done          | In Progress   | Open          |
-| Dasher Users                    | Open          | Open          | Open          |
-| Roles                           | Open          | Open          | Open          |
+| Firewall Rules                  | Done          | Open          | Done          |
+| Folders                         | Done          | In Progress   | Open          |
 | GAE                             | Done          | Open          | Open          |
 | GCE Instances                   | Done          | In Progress   | Open          |
 | GCE Instance Groups             | Done          | In Progress   | Open          |
 | GCE Instance Group Managers     | Done          | In Progress   | Open          |
 | GCE Instance Templates          | Done          | In Progress   | Open          |
 | GCE Backend Services            | Done          | In Progress   | Open          |
+| Groups                          | Done          | Done          | Open          |
+| GroupMembers                    | Done          | Done          | Open          |
+| GSuite Users                    | Open          | Open          | Open          |
+| Load Balancer Forwarding Rules  | Done          | In Progress   | Open          |
+| Networks                        | Open          | Open          | Open          |
+| Organizations                   | Done          | N/A           | Open          |
+| Org IAM Policies                | Done          | Done          | Open          |
+| Projects                        | Done          | N/A           | Open          |
+| Project IAM Policies            | Done          | Done          | Open          |
+| Roles                           | Open          | Open          | Open          |
+| Subnetworks                     | Open          | Open          | Open          |

--- a/_includes/resource_coverage.md
+++ b/_includes/resource_coverage.md
@@ -21,8 +21,7 @@ an issue or contribute!
 | Cloud SQL Inventory             | Done          | Done          | Open          |
 | BigQuery                        | Done          | In Progress   | Open          |
 | Dasher Users                    | Open          | Open          | Open          |
-| GrantableRoles                  | In Progress   | Open          | Open          |
-| GAE                             | In Progress   | Open          | Open          |
+| GAE                             | Done          | Open          | Open          |
 | GCE Instances                   | Done          | In Progress   | Open          |
 | GCE Instance Groups             | Done          | In Progress   | Open          |
 | GCE Instance Group Managers     | Done          | In Progress   | Open          |


### PR DESCRIPTION
Update the resource coverage:
- appengine inventory is done is PR #342
- change grantable roles to roles in general with the upcoming list roles api in Q3