### PR TITLE
Adjusting the instance type.

### DIFF
--- a/deployment-templates/explain-instance.py
+++ b/deployment-templates/explain-instance.py
@@ -48,7 +48,7 @@ def GenerateConfig(context):
                 'https://www.googleapis.com/compute/v1/projects/{}'
                 '/zones/{}/machineTypes/{}'.format(
                 context.env['project'], context.properties['zone'],
-                'n1-standard-2')),
+                context.properties['instance-type')),
             'disks': [{
                 'deviceName': 'boot',
                 'type': 'PERSISTENT',

--- a/samples/deployment-manager/deploy-explain.yaml.sample
+++ b/samples/deployment-manager/deploy-explain.yaml.sample
@@ -38,3 +38,4 @@ resources:
     # branch-name: ""
     release-version: "1.0.2"
     src-path: https://github.com/GoogleCloudPlatform/forseti-security
+    instance-type: n1-standard-2

--- a/samples/deployment-manager/deploy-forseti.yaml.sample
+++ b/samples/deployment-manager/deploy-forseti.yaml.sample
@@ -48,7 +48,7 @@ resources:
     # GCE instance properties
     image-project: ubuntu-os-cloud
     image-family: ubuntu-1604-lts
-    instance-type: n1-standard-1
+    instance-type: n1-standard-2
     zone: $(ref.cloudsql-instance.region)-c
 
     service-account: GCP_SERVICE_ACCOUNT

--- a/samples/deployment-manager/deploy-forseti.yaml.sample
+++ b/samples/deployment-manager/deploy-forseti.yaml.sample
@@ -48,7 +48,7 @@ resources:
     # GCE instance properties
     image-project: ubuntu-os-cloud
     image-family: ubuntu-1604-lts
-    instance-type: g1-small
+    instance-type: n1-standard-1
     zone: $(ref.cloudsql-instance.region)-c
 
     service-account: GCP_SERVICE_ACCOUNT


### PR DESCRIPTION
We've had a few issues raised about running out of CPU on forseti installations. I've increased the machine type. I've also standardized the way instance-type is loaded between forseti and forseti+explain deployments.