### PR TITLE
fix the bucket sample rule

### DIFF
--- a/samples/scanner/bucket_rules.yaml
+++ b/samples/scanner/bucket_rules.yaml
@@ -11,6 +11,8 @@ rules:
   - name: sample bucket acls rule to search for exposed buckets
     bucket: '*'
     entity: AllAuthenticatedUsers
+    email: '*'
+    domain: '*'
     role: '*' 
     resource:
         - resource_ids:


### PR DESCRIPTION
These fields are needed or else the bucket scanner would trip.