### PR TITLE
Make the projects inventory pipeline depends on folders.

### DIFF
--- a/google/cloud/security/inventory/pipeline_requirements_map.py
+++ b/google/cloud/security/inventory/pipeline_requirements_map.py
@@ -102,7 +102,7 @@ REQUIREMENTS_MAP = {
          'dao_name': 'organization_dao'},
     'projects':
         {'module_name': 'load_projects_pipeline',
-         'depends_on': 'organizations',
+         'depends_on': 'folders',
          'api_name': 'crm_api',
          'dao_name': 'project_dao'},
     'projects_iam_policies':

--- a/tests/inventory/test_data/fake_runnable_pipelines.py
+++ b/tests/inventory/test_data/fake_runnable_pipelines.py
@@ -17,9 +17,6 @@
 ALL_ENABLED = [
     'organizations',
     'folders',
-    'groups',
-    'group_members',
-    'org_iam_policies',
     'projects',
     'bigquery_datasets',
     'buckets',
@@ -27,19 +24,24 @@ ALL_ENABLED = [
     'cloudsql',
     'firewall_rules',
     'forwarding_rules',
-    'project_iam_policies'                                       
+    'project_iam_policies',
+    'groups',
+    'group_members',
+    'org_iam_policies',
 ]
 
 ALL_DISABLED = []
 
 ONE_RESOURCE_IS_ENABLED = [
     'organizations',
+    'folders',
     'projects',
     'firewall_rules',
 ]
 
 TWO_RESOURCES_ARE_ENABLED = [
     'organizations',
+    'folders',
     'projects',
     'cloudsql',
     'firewall_rules',
@@ -47,31 +49,33 @@ TWO_RESOURCES_ARE_ENABLED = [
 
 THREE_RESOURCES_ARE_ENABLED_GROUP_MEMBERS = [
     'organizations',
-    'groups',
-    'group_members',
+    'folders',
     'projects',
     'cloudsql',
     'firewall_rules',
+    'groups',
+    'group_members',
 ]
 
 THREE_RESOURCES_ARE_ENABLED_GROUPS = [
     'organizations',
-    'groups',
+    'folders',
     'projects',
     'cloudsql',
     'firewall_rules',
+    'groups',
 ]
 
 CORE_RESOURCES_ARE_ENABLED = [
     'organizations',
     'folders',
-    'groups',
-    'group_members',
-    'org_iam_policies',
     'projects',
     'buckets',
     'buckets_acl',
     'firewall_rules',
     'forwarding_rules',
-    'project_iam_policies'                                       
+    'project_iam_policies',
+    'groups',
+    'group_members',
+    'org_iam_policies',
 ]


### PR DESCRIPTION
Otherwise the scanner will complain if we only inventory org and projects.