### PR TITLE
Fix bigquery scanner initialization

### DIFF
--- a/google/cloud/security/scanner/scanners/bigquery_scanner.py
+++ b/google/cloud/security/scanner/scanners/bigquery_scanner.py
@@ -24,13 +24,15 @@ LOGGER = log_util.get_logger(__name__)
 class BigqueryScanner(base_scanner.BaseScanner):
     """Pipeline to pull Big Query acls data from DAO"""
 
-    def __init__(self, snapshot_timestamp):
+    def __init__(self, global_configs, snapshot_timestamp):
         """Initialization.
 
         Args:
+            global_configs (dict): Global configurations.
             snapshot_timestamp (str): The snapshot timestamp
         """
         super(BigqueryScanner, self).__init__(
+            global_configs,
             snapshot_timestamp)
         self.snapshot_timestamp = snapshot_timestamp
 


### PR DESCRIPTION
Hi,
the BigQuery scanner constructor is broken. 

It required only `snapshot_timestamp`, but now also `global_configs` is passed to it in the main `scanner.py`.

Here is a fix.

-------

Here's a handy checklist to ensure your PR goes smoothly.

- [X] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [X] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [X] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [X] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests)
still pass
- [X] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](.github/CONTRIBUTING.md).
