### PR TITLE
Configurable Scanner Rules Path

### DIFF
--- a/configs/forseti_conf.yaml.sample
+++ b/configs/forseti_conf.yaml.sample
@@ -99,6 +99,13 @@ scanner:
     # gs://bucket-name/path/for/output
     output_path: OUTPUT_PATH
 
+    # Rules path (do not include filename).
+    # If GCS location, the format of the path should be:
+    # gs://bucket-name/path/for/rules_path
+    # if no rules_path is specified, rules are
+    # searched in /path/to/forseti_security/rules/
+    # rules_path: RULES_PATH
+
     scanners:
         - name: bigquery
           enabled: true

--- a/google/cloud/security/scanner/scanner_builder.py
+++ b/google/cloud/security/scanner/scanner_builder.py
@@ -73,12 +73,16 @@ class ScannerBuilder(object):
 
                 # Simple way to find the path to folders directory no matter
                 # where forseti runs.
-                scanner_path = inspect.getfile(scanner_class)
-                rules_path = scanner_path.split('/google/cloud/security')[0]
+                rules_path = self.scanner_configs.get('rules_path')
+                if rules_path is None:
+                    scanner_path = inspect.getfile(scanner_class)
+                    rules_path = scanner_path.split('/google/cloud/security')[0]
+                    rules_path += '/rules'
+
                 rules_filename = (scanner_requirements_map.REQUIREMENTS_MAP
                                   .get(scanner.get('name'))
                                   .get('rules_filename'))
-                rules = '{}/rules/{}'.format(rules_path, rules_filename)
+                rules = '{}/{}'.format(rules_path, rules_filename)
                 LOGGER.info('Initializing the rules engine:\nUsing rules: %s',
                             rules)
 


### PR DESCRIPTION
Hi,
we need more flexibility in where to fetch rules for the scanners.

I've added a `rules_path` config key to define that.
If not specified rules will be searched as usual inside `rules/` within the module path

--------

Here's a handy checklist to ensure your PR goes smoothly.

- [X] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [X] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [X] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [X] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests)
still pass
- [X] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](.github/CONTRIBUTING.md).
