### PR TITLE
Add support for 'all protocols and ports' firewall

### DIFF
--- a/google/cloud/security/scanner/scanners/iap_scanner.py
+++ b/google/cloud/security/scanner/scanners/iap_scanner.py
@@ -174,7 +174,7 @@ class _RunData(object):
                 bool: whether the entry is relevant to the source being
                       evaluated
             """
-            if firewall_entry.get('IPProtocol') not in (6, '6', 'tcp'):
+            if firewall_entry.get('IPProtocol') not in (None, 6, '6', 'tcp', 'all'):
                 return False
             if not firewall_entry.get('ports'):
                 return True

--- a/google/cloud/security/scanner/scanners/iap_scanner.py
+++ b/google/cloud/security/scanner/scanners/iap_scanner.py
@@ -174,7 +174,8 @@ class _RunData(object):
                 bool: whether the entry is relevant to the source being
                       evaluated
             """
-            if firewall_entry.get('IPProtocol') not in (None, 6, '6', 'tcp', 'all'):
+            if firewall_entry.get('IPProtocol') not in (
+                    None, 6, '6', 'tcp', 'all'):
                 return False
             if not firewall_entry.get('ports'):
                 return True


### PR DESCRIPTION
Tested by creating such a firewall in GCE and verifying that it creates a firewall with allowed.IPProtocol=='all'
