### PR TITLE
Support instance loading for regional IGs

### DIFF
--- a/google/cloud/security/common/gcp_api/compute.py
+++ b/google/cloud/security/common/gcp_api/compute.py
@@ -280,34 +280,3 @@ class ComputeClient(_base_client.BaseClient):
 
         return self._flatten_aggregated_list_results(
             paged_results, 'instanceGroupManagers')
-
-    def get_regional_instance_groups(self, project_id):
-        """Get the regional instance groups for a project.
-
-        Args:
-            project_id (str): The project id.
-
-        Return:
-            list: A list of regional instance groups for this project.
-
-        Raise:
-            api_errors.ApiExecutionError: If API raises an error.
-        """
-        instance_groups_api = self.service.regionInstanceGroups()
-        list_request = instance_groups_api.aggregatedList(
-            project=project_id)
-        list_next_request = instance_groups_api.aggregatedList_next
-
-        paged_results = self._build_paged_result(
-            list_request, instance_groups_api, self.rate_limiter,
-            next_stub=list_next_request)
-
-        instance_groups = self._flatten_aggregated_list_results(
-            paged_results, 'instanceGroups')
-        for instance_group in instance_groups:
-            instance_group['instance_urls'] = self.get_instance_group_instances(
-                project_id,
-                # Turn a zone URL into a zone name
-                os.path.basename(instance_group.get('zone')),
-                instance_group.get('name'))
-        return instance_groups

--- a/google/cloud/security/common/gcp_api/compute.py
+++ b/google/cloud/security/common/gcp_api/compute.py
@@ -171,8 +171,9 @@ class ComputeClient(_base_client.BaseClient):
         Return:
             list: instance URLs for this instance group.
 
-        Raise:
+        Raises:
             api_errors.ApiExecutionError: if API raises an error.
+            ValueError: invalid combination of parameters
         """
         if not bool(zone) ^ bool(region):
             raise ValueError('One and only one of zone and region must be '


### PR DESCRIPTION
Fixes #502 

Tested by creating a regional instance group in my test project and:
- Looking at InstanceGroups.aggregatedList and InstanceGroupManagers.aggregatedList in the API explorer -- awesome, they return the regional ones too, no need for changes to the resource pipeline. And the gcp_type objects already supported regional groups and managers.
- Creating an IAP-enabled backend service using the regional instance group, running inventory and scan, and verifying the email.
- Using MySQL to validate that instance_urls is correctly populated for the regional instance group.

I've also created a regional instance group in project iap-1-174217 in your test org and added it to an IAP-enabled backend service. In that group, I've selected an instance template that does *not* have a tag, but then manually added a tag to an instance created for the group. So, if you run the scan, backend service should show as being directly accessible from source "tag-match".