### PR TITLE
Howto structure

### DIFF
--- a/_docs/guides/best-practices.md
+++ b/_docs/guides/best-practices.md
@@ -35,7 +35,7 @@ privilege separation because the service account key must be local to
 `forseti_inventory`. By using a separate service account, the key scope is
 limited to GSuite Groups if the machine is compromised.
 
-If you [enable]({% link _docs/howto/gsuite-group-collection.md %})
+If you [enable]({% link _docs/howto/configure/gsuite-group-collection.md %})
 GSuite Group inventory and create a service account, a good name
 for the service account would be `forseti-security-gsuite-groups`.
 

--- a/_docs/howto/configure/configuring-forseti.md
+++ b/_docs/howto/configure/configuring-forseti.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Forseti
-order: 106
+order: 206
 ---
 
 # {{ page.title }}

--- a/_docs/howto/configure/configuring-forseti.md
+++ b/_docs/howto/configure/configuring-forseti.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Forseti
-order: 9
+order: 106
 ---
 
 # {{ page.title }}

--- a/_docs/howto/configure/email-notification.md
+++ b/_docs/howto/configure/email-notification.md
@@ -1,6 +1,6 @@
 ---
 title: Enabling Email Notifications
-order: 102
+order: 202
 ---
 #  {{ page.title }}
 

--- a/_docs/howto/configure/email-notification.md
+++ b/_docs/howto/configure/email-notification.md
@@ -1,6 +1,6 @@
 ---
 title: Enabling Email Notifications
-order: 5
+order: 102
 ---
 #  {{ page.title }}
 

--- a/_docs/howto/configure/gsuite-group-collection.md
+++ b/_docs/howto/configure/gsuite-group-collection.md
@@ -1,6 +1,6 @@
 ---
 title: Enabling GSuite Google Groups Collection
-order: 103
+order: 203
 ---
 #  {{ page.title }}
 

--- a/_docs/howto/configure/gsuite-group-collection.md
+++ b/_docs/howto/configure/gsuite-group-collection.md
@@ -1,6 +1,6 @@
 ---
 title: Enabling GSuite Google Groups Collection
-order: 6
+order: 103
 ---
 #  {{ page.title }}
 

--- a/_docs/howto/configure/index.md
+++ b/_docs/howto/configure/index.md
@@ -1,0 +1,13 @@
+---
+title: Enable or Change Forseti Security features
+order: 101
+---
+# {{ page.title }}
+
+Learn how to enable or change features about Forseti Security.
+
+- [Enabling Email Notifications]({% link _docs/howto/configure/email-notification.md %})
+- [Enabling GSuite Google Groups Collection]({% link _docs/howto/configure/gsuite-group-collection.md %})
+- [Collecting and Storing New Data in Forseti Inventory]({% link _docs/howto/configure/inventory-new-data.md %})
+- [Defining Rules for Forseti Scanner]({% link _docs/howto/configure/scanner-rules.md %})
+- [Configuring Forseti]({% link _docs/howto/configure/configuring-forseti.md %})

--- a/_docs/howto/configure/index.md
+++ b/_docs/howto/configure/index.md
@@ -4,7 +4,7 @@ order: 101
 ---
 # {{ page.title }}
 
-Learn how to enable or change features about Forseti Security.
+Learn how to enable or change features of Forseti Security.
 
 - [Enabling Email Notifications]({% link _docs/howto/configure/email-notification.md %})
 - [Enabling GSuite Google Groups Collection]({% link _docs/howto/configure/gsuite-group-collection.md %})

--- a/_docs/howto/configure/index.md
+++ b/_docs/howto/configure/index.md
@@ -1,6 +1,6 @@
 ---
-title: Configure Forseti Security Features
-order: 101
+title: Configure Features
+order: 201
 ---
 # {{ page.title }}
 

--- a/_docs/howto/configure/index.md
+++ b/_docs/howto/configure/index.md
@@ -1,5 +1,5 @@
 ---
-title: Enable or Change Forseti Security features
+title: Configure Forseti Security Features
 order: 101
 ---
 # {{ page.title }}

--- a/_docs/howto/configure/inventory-new-data.md
+++ b/_docs/howto/configure/inventory-new-data.md
@@ -1,6 +1,6 @@
 ---
 title: Collecting and Storing New Data in Forseti Inventory
-order: 104
+order: 204
 ---
 #  {{ page.title }}
 

--- a/_docs/howto/configure/inventory-new-data.md
+++ b/_docs/howto/configure/inventory-new-data.md
@@ -1,6 +1,6 @@
 ---
 title: Collecting and Storing New Data in Forseti Inventory
-order: 7
+order: 104
 ---
 #  {{ page.title }}
 

--- a/_docs/howto/configure/scanner-rules.md
+++ b/_docs/howto/configure/scanner-rules.md
@@ -1,6 +1,6 @@
 ---
 title: Defining Rules for Forseti Scanner
-order: 8
+order: 105
 ---
 #  {{ page.title }}
 

--- a/_docs/howto/configure/scanner-rules.md
+++ b/_docs/howto/configure/scanner-rules.md
@@ -1,6 +1,6 @@
 ---
 title: Defining Rules for Forseti Scanner
-order: 105
+order: 205
 ---
 #  {{ page.title }}
 

--- a/_docs/howto/deploy/change-gcp-deployment.md
+++ b/_docs/howto/deploy/change-gcp-deployment.md
@@ -1,6 +1,6 @@
 ---
 title: Changing a Deployment
-order: 5
+order: 104
 ---
 #  {{ page.title }}
 

--- a/_docs/howto/deploy/gcp-deployment.md
+++ b/_docs/howto/deploy/gcp-deployment.md
@@ -1,6 +1,6 @@
 ---
 title: Deploying Forseti on Google Cloud Platform
-order: 2
+order: 102
 ---
 #  {{ page.title }}
 

--- a/_docs/howto/deploy/index.md
+++ b/_docs/howto/deploy/index.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy Forseti Security
+title: Deploy
 order: 101
 ---
 # {{ page.title }}

--- a/_docs/howto/deploy/index.md
+++ b/_docs/howto/deploy/index.md
@@ -1,0 +1,11 @@
+---
+title: Deploy Forseti Security
+order: 101
+---
+# {{ page.title }}
+
+Learn about the different methods to deploy Forseti Security and change a deployment.
+
+- [Deploying Forseti on Google Cloud Platform]({% link _docs/howto/gcp-deployment.md %})
+- [Deploying Forseti in a Local Environment]({% link _docs/howto/local-deployment.md %})
+- [Changing a Deployment]({% link _docs/howto/change-gcp-deployment.md %})

--- a/_docs/howto/deploy/index.md
+++ b/_docs/howto/deploy/index.md
@@ -6,6 +6,6 @@ order: 101
 
 Learn about the different methods to deploy Forseti Security and change a deployment.
 
-- [Deploying Forseti on Google Cloud Platform]({% link _docs/howto/gcp-deployment.md %})
-- [Deploying Forseti in a Local Environment]({% link _docs/howto/local-deployment.md %})
-- [Changing a Deployment]({% link _docs/howto/change-gcp-deployment.md %})
+- [Deploying Forseti on Google Cloud Platform]({% link _docs/howto/deploy/gcp-deployment.md %})
+- [Deploying Forseti in a Local Environment]({% link _docs/howto/deploy/local-deployment.md %})
+- [Changing a Deployment]({% link _docs/howto/deploy/change-gcp-deployment.md %})

--- a/_docs/howto/deploy/local-deployment.md
+++ b/_docs/howto/deploy/local-deployment.md
@@ -1,6 +1,6 @@
 ---
 title: Deploying Forseti in a Local Environment
-order: 3
+order: 103
 ---
 #  {{ page.title }}
 

--- a/_docs/howto/index.md
+++ b/_docs/howto/index.md
@@ -7,13 +7,13 @@ hide:
 
 [How to deploy Forseti Security]({% link _docs/howto/deploy/index.md %})
 
-- [Deploying Forseti on Google Cloud Platform]({% link _docs/howto/gcp-deployment.md %})
-- [Deploying Forseti in a Local Environment]({% link _docs/howto/local-deployment.md %})
-- [Changing a Deployment]({% link _docs/howto/change-gcp-deployment.md %})
+- [Deploying Forseti on Google Cloud Platform]({% link _docs/howto/deploy/gcp-deployment.md %})
+- [Deploying Forseti in a Local Environment]({% link _docs/howto/deploy/local-deployment.md %})
+- [Changing a Deployment]({% link _docs/howto/deploy/change-gcp-deployment.md %})
 
 [Enable or change features of Forseti Security]({% link _docs/howto/configure/index.md %})
 
-- [Enabling Email Notifications]({% link _docs/howto/email-notification.md %})
-- [Enabling GSuite Google Groups Collection]({% link _docs/howto/gsuite-group-collection.md %})
-- [Collecting and Storing New Data in Forseti Inventory]({% link _docs/howto/inventory-new-data.md %})
-- [Defining Rules for Forseti Scanner]({% link _docs/howto/scanner-rules.md %})
+- [Enabling Email Notifications]({% link _docs/howto/configure/email-notification.md %})
+- [Enabling GSuite Google Groups Collection]({% link _docs/howto/configure/gsuite-group-collection.md %})
+- [Collecting and Storing New Data in Forseti Inventory]({% link _docs/howto/configure/inventory-new-data.md %})
+- [Defining Rules for Forseti Scanner]({% link _docs/howto/configure/scanner-rules.md %})

--- a/_docs/howto/index.md
+++ b/_docs/howto/index.md
@@ -5,13 +5,13 @@ hide:
   right_sidebar: true
 ---
 
-How to deploy Forseti Security.
+[How to deploy Forseti Security]({% link _docs/howto/deploy/index.md %})
 
 - [Deploying Forseti on Google Cloud Platform]({% link _docs/howto/gcp-deployment.md %})
 - [Deploying Forseti in a Local Environment]({% link _docs/howto/local-deployment.md %})
 - [Changing a Deployment]({% link _docs/howto/change-gcp-deployment.md %})
 
-Enable or change features about Forseti Security.
+[Enable or change features of Forseti Security]({% link _docs/howto/configure/index.md %})
 
 - [Enabling Email Notifications]({% link _docs/howto/email-notification.md %})
 - [Enabling GSuite Google Groups Collection]({% link _docs/howto/gsuite-group-collection.md %})

--- a/_docs/howto/rule-violations.md
+++ b/_docs/howto/rule-violations.md
@@ -1,7 +1,0 @@
----
-title: Scanner rule violations
-order: 10
----
-#  {{ page.title }}
-
-TBD

--- a/_docs/quickstarts/explain/index.md
+++ b/_docs/quickstarts/explain/index.md
@@ -29,10 +29,10 @@ clients won't be supported until a first stable API version is released.
 
 Before you set up and deploy IAM Explain, you'll need the following:
 
-  - A running Forseti instance with [group collection enabled]({% link _docs/howto/gsuite-group-collection.md %})
+  - A running Forseti instance with [group collection enabled]({% link _docs/howto/configure/gsuite-group-collection.md %})
   - A service account with the Cloud SQL Client role. For security purposes,
   it's best to create a separate service account for IAM Explain. However, you
-  can use your [Forseti Security service account]({% link _docs/howto/local-deployment.md %}#creating-service-accounts)
+  can use your [Forseti Security service account]({% link _docs/howto/deploy/local-deployment.md %}#creating-service-accounts)
   if you want.
   - An SQL instance. You can use the SQL instance you created when you
   set up Forseti Security, or create a new, separate SQL instance for IAM

--- a/_docs/quickstarts/forseti-security/index.md
+++ b/_docs/quickstarts/forseti-security/index.md
@@ -102,8 +102,8 @@ to use for your resources.
   - Set up [Inventory]({% link _docs/quickstarts/inventory/index.md %}),
   [Scanner]({% link _docs/quickstarts/scanner/index.md %}),
   and [Enforcer]({% link _docs/quickstarts/enforcer/index.md %}).
-  - Set up Forseti to send [email notifications]({% link _docs/howto/email-notification.md %}).
-  - Enable [GSuite Google Groups collection]({% link _docs/howto/gsuite-group-collection.md %})
+  - Set up Forseti to send [email notifications]({% link _docs/howto/configure/email-notification.md %}).
+  - Enable [GSuite Google Groups collection]({% link _docs/howto/configure/gsuite-group-collection.md %})
   for processing by Forseti.
-  - Learn how to [change a deployment]({% link _docs/howto/change-gcp-deployment.md %}).
+  - Learn how to [change a deployment]({% link _docs/howto/deploy/change-gcp-deployment.md %}).
 

--- a/_docs/quickstarts/inventory/index.md
+++ b/_docs/quickstarts/inventory/index.md
@@ -29,4 +29,4 @@ To display Inventory flag options, run the following commands:
 {% include _howto/config_inventory.md %}
 
 ## What's next
-- Learn more about [configuring Forseti]({% link _docs/howto/configuring-forseti.md %}).
+- Learn more about [configuring Forseti]({% link _docs/howto/configure/configuring-forseti.md %}).

--- a/_docs/quickstarts/scanner/index.md
+++ b/_docs/quickstarts/scanner/index.md
@@ -17,7 +17,7 @@ Engine vulnerability scanning. Learn more about
 ## Scanners
 
 Forseti Scanner can run multiple scanners at a time. To configure which scanners
-to run, see [Configuring Forseti page: Configuring Scanner]({% link _docs/howto/configuring-forseti.md %}).
+to run, see [Configuring Forseti page: Configuring Scanner]({% link _docs/howto/configure/configuring-forseti.md %}).
 
 ## Running Forseti Scanner
 
@@ -39,6 +39,6 @@ manually.
 
 ## What's next
 
-- Read about [configuring Forseti]({% link _docs/howto/configuring-forseti.md %})
-- Learn about [defining rules]({% link _docs/howto/scanner-rules.md %}).
-- Read about how Scanner outputs [rule violations]({% link _docs/howto/rule-violations.md %}).
+- Read about [configuring Forseti]({% link _docs/howto/configure/configuring-forseti.md %})
+- Learn about [defining rules]({% link _docs/howto/configure/scanner-rules.md %}).
+- Read about how Scanner outputs [rule violations]({% link _docs/howto/configure/rule-violations.md %}).

--- a/_docs/quickstarts/scanner/index.md
+++ b/_docs/quickstarts/scanner/index.md
@@ -41,4 +41,4 @@ manually.
 
 - Read about [configuring Forseti]({% link _docs/howto/configure/configuring-forseti.md %})
 - Learn about [defining rules]({% link _docs/howto/configure/scanner-rules.md %}).
-- Read about how Scanner outputs [rule violations]({% link _docs/howto/configure/rule-violations.md %}).
+- Read about how Scanner outputs [policy violations]({% link _docs/quickstarts/scanner/policy-violations.md %}).


### PR DESCRIPTION
Creating a sub-structure for the How-to guides so the ToC is more readable. Also removing the scanner rule violations PH since we have policy violations under the scanner quickstart (see http://forsetisecurity.org/docs/quickstarts/scanner/policy-violations). If there's unique content that should be separate, we can create a new page when the content is ready.