### PR TITLE
Initialize All Tables

### DIFF
--- a/google/cloud/security/common/data_access/dao.py
+++ b/google/cloud/security/common/data_access/dao.py
@@ -121,7 +121,7 @@ class Dao(_db_connector.DbConnector):
         """
         return object_class(**row)
 
-    def _create_snapshot_table(self, resource_name, timestamp):
+    def create_snapshot_table(self, resource_name, timestamp):
         """Creates a snapshot table.
 
         Args:
@@ -190,7 +190,7 @@ class Dao(_db_connector.DbConnector):
         """
         with csv_writer.write_csv(resource_name, data) as csv_file:
             try:
-                snapshot_table_name = self._get_snapshot_table(
+                snapshot_table_name = self._create_snapshot_table_name(
                     resource_name, timestamp)
                 load_data_sql = load_data_sql_provider.provide_load_data_sql(
                     resource_name, csv_file.name, snapshot_table_name)

--- a/google/cloud/security/common/data_access/dao.py
+++ b/google/cloud/security/common/data_access/dao.py
@@ -165,7 +165,7 @@ class Dao(_db_connector.DbConnector):
             str: String of the created snapshot table.
         """
         try:
-            snapshot_table_name = self._create_snapshot_table(
+            snapshot_table_name = self.create_snapshot_table(
                 resource_name, timestamp)
         except OperationalError:
             # TODO: find a better way to handle this. I want this method

--- a/google/cloud/security/common/data_access/violation_dao.py
+++ b/google/cloud/security/common/data_access/violation_dao.py
@@ -60,7 +60,7 @@ class ViolationDao(dao.Dao):
                     ('PARTIAL_SUCCESS', 'SUCCESS'))
 
             # Create the violations snapshot table.
-            snapshot_table = self._create_snapshot_table(
+            snapshot_table = self.create_snapshot_table(
                 resource_name, snapshot_timestamp)
         # TODO: Remove this exception handling by moving the check for
         # violations table outside of the scanners.

--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -149,7 +149,6 @@ def _start_snapshot_cycle(inventory_dao):
     for resource_name in dao.CREATE_TABLE_MAP:
         inventory_dao.create_snapshot_table(resource_name, cycle_timestamp)
     LOGGER.debug('All tables created.')
-    
 
     LOGGER.info('Inventory snapshot cycle started: %s', cycle_timestamp)
     return cycle_time, cycle_timestamp

--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -144,6 +144,13 @@ def _start_snapshot_cycle(inventory_dao):
         LOGGER.error('Unable to insert new snapshot cycle: %s', e)
         sys.exit()
 
+    # Ensure all the tables are created, to support client usage & joins,
+    # which expect the tables to exist even if empty.
+    for resource_name in dao.CREATE_TABLE_MAP:
+        inventory_dao.create_snapshot_table(resource_name, cycle_timestamp)
+    LOGGER.debug('All tables created.')
+    
+
     LOGGER.info('Inventory snapshot cycle started: %s', cycle_timestamp)
     return cycle_time, cycle_timestamp
 

--- a/tests/common/data_access/dao_test.py
+++ b/tests/common/data_access/dao_test.py
@@ -58,7 +58,7 @@ class DaoTest(ForsetiTestCase):
         self.dao.conn.cursor.return_value = cursor_mock
         cursor_mock.fetchall.return_value = fetch_mock
 
-        actual_tablename = self.dao._create_snapshot_table(
+        actual_tablename = self.dao.create_snapshot_table(
             self.resource_projects, self.fake_timestamp)
 
         expected_tablename = ('%s_%s' %

--- a/tests/common/data_access/violation_dao_test.py
+++ b/tests/common/data_access/violation_dao_test.py
@@ -116,7 +116,7 @@ class ViolationDaoTest(ForsetiTestCase):
               * self.dao.conn
               * self.dao.conn.commit
               * self.dao.get_latest_snapshot_timestamp
-              * self.dao._create_snapshot_table
+              * self.dao.create_snapshot_table
 
         Expect:
             * Assert that get_latest_snapshot_timestamp() gets called.
@@ -130,7 +130,7 @@ class ViolationDaoTest(ForsetiTestCase):
 
         self.dao.get_latest_snapshot_timestamp = mock.MagicMock(
             return_value = self.fake_snapshot_timestamp)
-        self.dao._create_snapshot_table = mock.MagicMock(
+        self.dao.create_snapshot_table = mock.MagicMock(
             return_value=self.fake_table_name)
         self.dao.conn = conn_mock
         self.dao.execute_sql_with_commit = commit_mock

--- a/tests/common/data_access/violation_dao_test.py
+++ b/tests/common/data_access/violation_dao_test.py
@@ -120,7 +120,7 @@ class ViolationDaoTest(ForsetiTestCase):
 
         Expect:
             * Assert that get_latest_snapshot_timestamp() gets called.
-            * Assert that _create_snapshot_table() gets called.
+            * Assert that create_snapshot_table() gets called.
             * Assert that conn.commit() is called 3x.
               was called == # of formatted/flattened RuleViolations).
         """
@@ -143,7 +143,7 @@ class ViolationDaoTest(ForsetiTestCase):
             ('PARTIAL_SUCCESS', 'SUCCESS'))
 
         # Assert that the snapshot table was created.
-        self.dao._create_snapshot_table.assert_called_once_with(
+        self.dao.create_snapshot_table.assert_called_once_with(
             self.resource_name, self.fake_snapshot_timestamp)
 
         # Assert that conn.commit() was called.
@@ -155,17 +155,17 @@ class ViolationDaoTest(ForsetiTestCase):
         Setup:
             * Create fake custom timestamp.
             * Create mocks:
-                * self.dao._create_snapshot_table
+                * self.dao.create_snapshot_table
                 * self.dao.get_latest_snapshot_timestamp
                 * self.dao.conn
 
         Expect:
             * Assert that get_latest_snapshot_timestamp() doesn't get called.
-            * Assert that _create_snapshot_table() gets called once.
+            * Assert that create_snapshot_table() gets called once.
         """
         fake_custom_timestamp = '11111'
         self.dao.conn = mock.MagicMock()
-        self.dao._create_snapshot_table = mock.MagicMock()
+        self.dao.create_snapshot_table = mock.MagicMock()
         self.dao.get_latest_snapshot_timestamp = mock.MagicMock()
         self.dao.insert_violations(
             self.fake_flattened_violations,
@@ -173,7 +173,7 @@ class ViolationDaoTest(ForsetiTestCase):
             fake_custom_timestamp)
 
         self.dao.get_latest_snapshot_timestamp.assert_not_called()
-        self.dao._create_snapshot_table.assert_called_once_with(
+        self.dao.create_snapshot_table.assert_called_once_with(
             self.resource_name, fake_custom_timestamp)
 
     def test_insert_violations_raises_error_on_create(self):
@@ -184,7 +184,7 @@ class ViolationDaoTest(ForsetiTestCase):
         """
         self.dao.get_latest_snapshot_timestamp = mock.MagicMock(
             return_value=self.fake_snapshot_timestamp)
-        self.dao._create_snapshot_table = mock.MagicMock(
+        self.dao.create_snapshot_table = mock.MagicMock(
             side_effect=MySQLdb.DataError)
 
         with self.assertRaises(errors.MySQLError):
@@ -197,7 +197,7 @@ class ViolationDaoTest(ForsetiTestCase):
             * Create mocks:
                 * self.dao.conn
                 * self.dao.get_latest_snapshot_timestamp
-                * self.dao._create_snapshot_table
+                * self.dao.create_snapshot_table
             * Create side effect for one violation to raise an error.
 
         Expect:
@@ -208,7 +208,7 @@ class ViolationDaoTest(ForsetiTestCase):
         resource_name = 'policy_violations'
         self.dao.get_latest_snapshot_timestamp = mock.MagicMock(
             return_value=self.fake_snapshot_timestamp)
-        self.dao._create_snapshot_table = mock.MagicMock(
+        self.dao.create_snapshot_table = mock.MagicMock(
             return_value=self.fake_table_name)
         violation_dao.LOGGER = mock.MagicMock()
 


### PR DESCRIPTION
Ensure all the tables are created, to support client usages & joins, which expect the tables to exist even if empty.