### PR TITLE
Hide nav firstlink

### DIFF
--- a/_includes/site/layout/docs/category_nav.html
+++ b/_includes/site/layout/docs/category_nav.html
@@ -45,9 +45,11 @@
         </li>
       {% endif %}
 
+      {% if forloop.index != 1 %}
       <li {% if page.url == doc.url %}class="active"{% endif %}>
         <a href="{{ doc.url | remove:"index.html" | remove:".html" }}">{{ doc.title }}</a>
       </li>
+      {% endif %}
     {% endfor %}
   </ul>
 </div>


### PR DESCRIPTION
Hide the landing page link from the left navbar links, because it's just redundant.

Current: 
![screen shot 2017-08-14 at 10 36 55 pm](https://user-images.githubusercontent.com/14340/29303364-1f0f326c-8141-11e7-976a-6b56f8fc6ace.png)

After fix:
![screen shot 2017-08-14 at 10 37 01 pm](https://user-images.githubusercontent.com/14340/29303365-1f132598-8141-11e7-8ce9-ebaa45efd72c.png)

