### PR TITLE
hide the main page landing page from sidebar nav

### DIFF
--- a/_includes/site/layout/docs/category_nav.html
+++ b/_includes/site/layout/docs/category_nav.html
@@ -45,9 +45,11 @@
         </li>
       {% endif %}
 
+      {% if forloop.index != 1 %}
       <li {% if page.url == doc.url %}class="active"{% endif %}>
         <a href="{{ doc.url | remove:"index.html" | remove:".html" }}">{{ doc.title }}</a>
       </li>
+      {% endif %}
     {% endfor %}
   </ul>
 </div>

--- a/_includes/site/layout/docs/category_nav.html
+++ b/_includes/site/layout/docs/category_nav.html
@@ -1,5 +1,10 @@
 <div class="left-sidebar">
-  <h4>{{ page.category }}</h4>
+  {% include site/get_docs_for_category.liquid category=page.category %}
+
+  {% assign ordered_docs = category_docs | sort:"order" %}
+  {% assign category_root_url = ordered_docs[0].url | remove:"index.html" %}
+
+  <h4><a href="{{ category_root_url }}">{{ page.category }}</a></h4>
 
   {% comment %}
     Assume that nested subcategories are ordered continguously. with index files
@@ -16,10 +21,6 @@
     children in the second level... even though that's not how the files exist
     on disk.
   {% endcomment %}
-
-  {% include site/get_docs_for_category.liquid category=page.category %}
- 
-  {% assign ordered_docs = category_docs | sort:"order" %}
 
   <ul class="links">
     {% assign last_level = 3 %}
@@ -46,9 +47,9 @@
       {% endif %}
 
       {% if forloop.index != 1 %}
-      <li {% if page.url == doc.url %}class="active"{% endif %}>
-        <a href="{{ doc.url | remove:"index.html" | remove:".html" }}">{{ doc.title }}</a>
-      </li>
+        <li {% if page.url == doc.url %}class="active"{% endif %}>
+          <a href="{{ doc.url | remove:"index.html" | remove:".html" }}">{{ doc.title }}</a>
+        </li>
       {% endif %}
     {% endfor %}
   </ul>


### PR DESCRIPTION
Hide the landing page link from the left navbar links, because it's just redundant.

Example:

Current: 
![screen shot 2017-08-14 at 10 36 55 pm](https://user-images.githubusercontent.com/14340/29303364-1f0f326c-8141-11e7-976a-6b56f8fc6ace.png)

After fix:
![screen shot 2017-08-14 at 10 37 01 pm](https://user-images.githubusercontent.com/14340/29303365-1f132598-8141-11e7-8ce9-ebaa45efd72c.png)

