### PR TITLE
Update admin sdk quota limits to use the 100sec bucket

### DIFF
--- a/configs/forseti_conf.yaml.in
+++ b/configs/forseti_conf.yaml.in
@@ -38,7 +38,7 @@ global:
 
     # quota
     # The pre-populated values are the defaults from GCP.
-    max_admin_api_calls_per_day: 150000
+    max_admin_api_calls_per_100_seconds: 1500
     max_appengine_api_calls_per_second: 20
     max_bigquery_api_calls_per_100_seconds: 17000
     max_compute_api_calls_per_second: 20

--- a/configs/forseti_conf.yaml.sample
+++ b/configs/forseti_conf.yaml.sample
@@ -33,7 +33,7 @@ global:
 
     # quota
     # The pre-populated values are the defaults from GCP.
-    max_admin_api_calls_per_day: 1500
+    max_admin_api_calls_per_100_seconds: 1500
     max_appengine_api_calls_per_second: 20
     max_bigquery_api_calls_per_100_seconds: 17000
     max_compute_api_calls_per_second: 20

--- a/configs/forseti_conf.yaml.sample
+++ b/configs/forseti_conf.yaml.sample
@@ -33,7 +33,7 @@ global:
 
     # quota
     # The pre-populated values are the defaults from GCP.
-    max_admin_api_calls_per_day: 150000
+    max_admin_api_calls_per_day: 1500
     max_appengine_api_calls_per_second: 20
     max_bigquery_api_calls_per_100_seconds: 17000
     max_compute_api_calls_per_second: 20

--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -42,7 +42,7 @@ class AdminDirectoryClient(_base_client.BaseClient):
             api_name=self.API_NAME)
 
         self.rate_limiter = RateLimiter(
-            self.global_configs.get('max_admin_api_calls_per_day'),
+            self.global_configs.get('max_admin_api_calls_per_100_secs'),
             self.DEFAULT_QUOTA_TIMESPAN_PER_SECONDS)
 
     def _build_credentials(self, global_configs):

--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -42,7 +42,7 @@ class AdminDirectoryClient(_base_client.BaseClient):
             api_name=self.API_NAME)
 
         self.rate_limiter = RateLimiter(
-            self.global_configs.get('max_admin_api_calls_per_100_secs'),
+            self.global_configs.get('max_admin_api_calls_per_100_seconds'),
             self.DEFAULT_QUOTA_TIMESPAN_PER_SECONDS)
 
     def _build_credentials(self, global_configs):

--- a/google/cloud/security/common/gcp_api/admin_directory.py
+++ b/google/cloud/security/common/gcp_api/admin_directory.py
@@ -25,7 +25,7 @@ class AdminDirectoryClient(_base_client.BaseClient):
     """GSuite Admin Directory API Client."""
 
     API_NAME = 'admin'
-    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 86400 # pylint: disable=invalid-name
+    DEFAULT_QUOTA_TIMESPAN_PER_SECONDS = 100 # pylint: disable=invalid-name
     REQUIRED_SCOPES = frozenset([
         'https://www.googleapis.com/auth/admin.directory.group.readonly'
     ])


### PR DESCRIPTION
Switching the admin directory API to use the lower of the two buckets.