### PR TITLE
Tweak docs styles

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -4,15 +4,19 @@ layout: default
 {% include site/layout/docs/tabs.html %}
 
 <div class="row">
-  <div class="col-md-3">
-    {% unless page.hide.left_sidebar %} 
-      {% include site/layout/docs/category_nav.html %}
-    {% endunless %}
-  </div>
+  {% unless page.hide.left_sidebar %} 
+    <div class="col-md-3">
+        {% include site/layout/docs/category_nav.html %}
+    </div>
 
-  <div id="documentation" class="col-md-7">
-    {{ content }}
-  </div>
+    <div id="documentation" class="col-md-7">
+      {{ content }}
+    </div>
+  {% else %}
+    <div id="documentation" class="col-md-10">
+      {{ content }}
+    </div>
+  {% endunless %}
 
   {% unless page.hide.right_sidebar %}
     <div id="toc" class="col-md-2 toc">

--- a/_sass/base/_override.scss
+++ b/_sass/base/_override.scss
@@ -61,3 +61,22 @@ pre.highlight {
     padding: 9.5px;
   }
 }
+
+// Body
+#documentation {
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+// Rouge inline highlight
+code.highlighter-rouge {
+  color: $grey-800;
+  background-color: $white-alpha-90;
+}
+
+// Left sidebar heading
+.left-sidebar > h4 > a,
+.left-sidebar > h4 > a:active,
+.left-sidebar > h4 > a:hover {
+  color: $grey-800;
+}


### PR DESCRIPTION
Made the following changes (see screenshots):

* On "Overview" page, hide the left sidebar space completely if the sidebar is set to "hide".
* Documentation font size changed to 16px.
* Inline code style changed to a dark grey with no background.
* Left sidebar header link style should match the list links.

![screen shot 2017-08-22 at 9 51 19 pm](https://user-images.githubusercontent.com/14340/29599476-bfccb5f0-8784-11e7-813a-4a114c2c820c.png)

![screen shot 2017-08-22 at 9 52 03 pm](https://user-images.githubusercontent.com/14340/29599479-c99b1360-8784-11e7-81d3-464533a8da0e.png)

![screen shot 2017-08-22 at 9 52 16 pm](https://user-images.githubusercontent.com/14340/29599481-ce47c32c-8784-11e7-87b4-5f25b7814fdd.png)

![screen shot 2017-08-22 at 9 51 52 pm](https://user-images.githubusercontent.com/14340/29599482-d2dde466-8784-11e7-832c-6e342e0d955d.png)
