### PR TITLE
Documentation Update for Forseti Quickstart

### DIFF
--- a/_docs/howto/deploy/change-gcp-deployment.md
+++ b/_docs/howto/deploy/change-gcp-deployment.md
@@ -6,7 +6,8 @@ order: 104
 
 This page describes how to change a Forseti Security deployment. Most changes
 to a deployment are usually to the deployment properties, such as the
-notification email address, instance type, or `src-path` when you want your deployment to run a certain version of Forseti Security. To update your deployment, follow the process below:
+instance type or `src-path` when you want your deployment to run a certain 
+version of Forseti Security. To update your deployment, follow the process below:
 
   1. Edit `deploy-forseti.yaml` and update the values you want to change.
   1. Run the following update command:

--- a/_docs/quickstarts/forseti-security/index.md
+++ b/_docs/quickstarts/forseti-security/index.md
@@ -78,7 +78,7 @@ Forseti Security is now set up in your GCP project but requires some extra steps
   - Set up [Inventory]({% link _docs/quickstarts/inventory/index.md %}). Forseti
     Scanner and Enforcer depend on Inventory data to perform their operations.
   - Once [Inventory]({% link _docs/quickstarts/inventory/index.md %}) setup is complete, proceed to set up [Scanner]({% link _docs/quickstarts/scanner/index.md %}) and [Enforcer]({% link _docs/quickstarts/enforcer/index.md %})
-  - Set up Forseti to send [email notifications]({% link _docs/howto/email-notification.md %}).
-  - Enable [GSuite Google Groups collection]({% link _docs/howto/gsuite-group-collection.md %})
+  - Set up Forseti to send [email notifications]({% link _docs/howto/configure/email-notification.md %}).
+  - Enable [GSuite Google Groups collection]({% link _docs/howto/configure/gsuite-group-collection.md %})
   for processing by Forseti.
-  - Learn how to [change a deployment]({% link _docs/howto/deploy/change-gcp-deployment.md %}).
+  - Learn how to [change a deployment]({% link _docs/howto/configure/deploy/change-gcp-deployment.md %}).

--- a/_docs/quickstarts/forseti-security/index.md
+++ b/_docs/quickstarts/forseti-security/index.md
@@ -40,12 +40,6 @@ It's best to use [Cloud Shell](https://cloud.google.com/shell/docs/quickstart) t
       ```bash
       git clone https://github.com/GoogleCloudPlatform/forseti-security
       ```
-      
-      To install the latest release:
-      
-      ```
-      git checkout master
-      ```
 
   1. Navigate to the setup wizard directory:
   
@@ -77,13 +71,14 @@ It's best to use [Cloud Shell](https://cloud.google.com/shell/docs/quickstart) t
   1. After the setup wizard successfully completes Forseti setup and deployment, 
      complete the steps to [enable G Suite Google Groups collection]({% link _docs/howto/configure/gsuite-group-collection.md %}). This is a **required** step if you also plan to deploy IAM Explain.
 
+Forseti Security is now set up in your GCP project but requires some extra steps (shown below) to run autonomously.
 
 ## What's next
 
-  - Configure [Inventory]({% link _docs/quickstarts/inventory/index.md %}),
-  [Scanner]({% link _docs/quickstarts/scanner/index.md %}),
-  and [Enforcer]({% link _docs/quickstarts/enforcer/index.md %}).
-  - Configure Forseti to send [email notifications]({% link _docs/howto/configure/email-notification.md %}).
-  - Enable [GSuite Google Groups collection]({% link _docs/howto/configure/gsuite-group-collection.md %})
+  - Set up [Inventory]({% link _docs/quickstarts/inventory/index.md %}). Forseti
+    Scanner and Enforcer depend on Inventory data to perform their operations.
+  - Once [Inventory]({% link _docs/quickstarts/inventory/index.md %}) setup is complete, proceed to set up [Scanner]({% link _docs/quickstarts/scanner/index.md %}) and [Enforcer]({% link _docs/quickstarts/enforcer/index.md %})
+  - Set up Forseti to send [email notifications]({% link _docs/howto/email-notification.md %}).
+  - Enable [GSuite Google Groups collection]({% link _docs/howto/gsuite-group-collection.md %})
   for processing by Forseti.
-  - Learn how to [change a deployment]({% link _docs/howto/deploy/change-gcp-deployment.md %}).
+  - Learn how to [change a deployment]({% link _docs/howto/change-gcp-deployment.md %}).

--- a/_docs/quickstarts/forseti-security/index.md
+++ b/_docs/quickstarts/forseti-security/index.md
@@ -38,7 +38,8 @@ It's best to use [Cloud Shell](https://cloud.google.com/shell/docs/quickstart) t
   1. Once you've started Cloud Shell, download Forseti. The setup wizard is included:
   
       ```bash
-      git clone https://github.com/GoogleCloudPlatform/forseti-security
+      git clone -b master --single-branch https://github.com/GoogleCloudPlatform/forseti-security
+
       ```
 
   1. Navigate to the setup wizard directory:
@@ -75,10 +76,10 @@ Forseti Security is now set up in your GCP project but requires some extra steps
 
 ## What's next
 
-  - Set up [Inventory]({% link _docs/quickstarts/inventory/index.md %}). Forseti
-    Scanner and Enforcer depend on Inventory data to perform their operations.
-  - Once [Inventory]({% link _docs/quickstarts/inventory/index.md %}) setup is complete, proceed to set up [Scanner]({% link _docs/quickstarts/scanner/index.md %}) and [Enforcer]({% link _docs/quickstarts/enforcer/index.md %})
-  - Set up Forseti to send [email notifications]({% link _docs/howto/configure/email-notification.md %}).
+  - Configure [Inventory]({% link _docs/quickstarts/inventory/index.md %}),
+  [Scanner]({% link _docs/quickstarts/scanner/index.md %}),
+  and [Enforcer]({% link _docs/quickstarts/enforcer/index.md %}).
+  - Configure Forseti to send [email notifications]({% link _docs/howto/configure/email-notification.md %}).
   - Enable [GSuite Google Groups collection]({% link _docs/howto/configure/gsuite-group-collection.md %})
   for processing by Forseti.
   - Learn how to [change a deployment]({% link _docs/howto/deploy/change-gcp-deployment.md %}).

--- a/_docs/quickstarts/forseti-security/index.md
+++ b/_docs/quickstarts/forseti-security/index.md
@@ -81,4 +81,4 @@ Forseti Security is now set up in your GCP project but requires some extra steps
   - Set up Forseti to send [email notifications]({% link _docs/howto/email-notification.md %}).
   - Enable [GSuite Google Groups collection]({% link _docs/howto/gsuite-group-collection.md %})
   for processing by Forseti.
-  - Learn how to [change a deployment]({% link _docs/howto/change-gcp-deployment.md %}).
+  - Learn how to [change a deployment]({% link _docs/howto/deploy/change-gcp-deployment.md %}).

--- a/_docs/quickstarts/forseti-security/index.md
+++ b/_docs/quickstarts/forseti-security/index.md
@@ -81,4 +81,4 @@ Forseti Security is now set up in your GCP project but requires some extra steps
   - Set up Forseti to send [email notifications]({% link _docs/howto/configure/email-notification.md %}).
   - Enable [GSuite Google Groups collection]({% link _docs/howto/configure/gsuite-group-collection.md %})
   for processing by Forseti.
-  - Learn how to [change a deployment]({% link _docs/howto/configure/deploy/change-gcp-deployment.md %}).
+  - Learn how to [change a deployment]({% link _docs/howto/deploy/change-gcp-deployment.md %}).

--- a/_docs/quickstarts/forseti-security/index.md
+++ b/_docs/quickstarts/forseti-security/index.md
@@ -72,8 +72,6 @@ It's best to use [Cloud Shell](https://cloud.google.com/shell/docs/quickstart) t
   1. After the setup wizard successfully completes Forseti setup and deployment, 
      complete the steps to [enable G Suite Google Groups collection]({% link _docs/howto/configure/gsuite-group-collection.md %}). This is a **required** step if you also plan to deploy IAM Explain.
 
-Forseti Security is now set up in your GCP project but requires some extra steps (shown below) to run autonomously.
-
 ## What's next
 
   - Configure [Inventory]({% link _docs/quickstarts/inventory/index.md %}),


### PR DESCRIPTION
I removed the "git checkout master" line in order to cut down on the steps for quickstart. The master branch is the default branch when users run the git clone so it felt redundant for a quickstart.

Also added some clarity around needing to run inventory setup first before the scanner and enforcer