### PR TITLE
Force grpcio and grpcio-tools to version 1.4.0.

### DIFF
--- a/scripts/docker/base
+++ b/scripts/docker/base
@@ -34,8 +34,8 @@ RUN pip install -q --upgrade \
     coverage \
     codecov \
     google-apputils \
-    grpcio \
-    grpcio-tools \
+    grpcio==1.4.0 \
+    grpcio-tools==1.4.0 \
     mock \
     parameterized \
     pylint

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,8 @@ INSTALL_REQUIRES = [
 SETUP_REQUIRES = [
     'google-apputils==0.4.2',
     'python-gflags==3.1.1',
-    'grpcio>=1.2.1',
-    'grpcio-tools>=1.2.1',
+    'grpcio==1.4.0',
+    'grpcio-tools==1.4.0',
     'protobuf>=3.2.0',
 ]
 


### PR DESCRIPTION
Version 1.6.0 fails tests.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
