### PR TITLE
Fix network interface scanner by making it agnostic to api versions.

### DIFF
--- a/google/cloud/security/scanner/audit/instance_network_interface_rules_engine.py
+++ b/google/cloud/security/scanner/audit/instance_network_interface_rules_engine.py
@@ -223,7 +223,7 @@ class Rule(object):
         """
         for instance_network_interface in instance_network_interface_list:
             network_and_project = re.search(
-                r'compute/v1/projects/([^/]*).*networks/([^/]*)',
+                r'compute/.*/projects/([^/]*).*networks/([^/]*)',
                 instance_network_interface.network)
             project = network_and_project.group(1)
             network = network_and_project.group(2)


### PR DESCRIPTION
This was caused from one of the api mix-in changes.

![image](https://user-images.githubusercontent.com/6977544/29949700-5af87202-8e6b-11e7-84bf-e2946fbc7085.png)
