### PR TITLE
Update storage client to handle retries and explicit credentials.

### DIFF
--- a/google/cloud/security/common/gcp_api/storage.py
+++ b/google/cloud/security/common/gcp_api/storage.py
@@ -63,6 +63,7 @@ class StorageRepositoryClient(_base_repository.BaseRepositoryClient):
     """Storage API Respository."""
 
     def __init__(self,
+                 credentials=None,
                  quota_max_calls=None,
                  quota_period=1.0,
                  use_rate_limiter=True):
@@ -74,6 +75,8 @@ class StorageRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_period (float): The time period to limit the requests within.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
+            credentials (GoogleCredentials): An optional GoogleCredentials
+                object to use.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -83,6 +86,7 @@ class StorageRepositoryClient(_base_repository.BaseRepositoryClient):
 
         super(StorageRepositoryClient, self).__init__(
             'storage', versions=['v1'],
+            credentials=credentials,
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
             use_rate_limiter=use_rate_limiter)
@@ -209,7 +213,7 @@ class _StorageObjectsRepository(
             downloader = http.MediaIoBaseDownload(out_stream, media_request)
             done = False
             while not done:
-                _, done = downloader.next_chunk()
+                _, done = downloader.next_chunk(num_retries=self._num_retries)
             file_content = out_stream.getvalue()
         finally:
             out_stream.close()
@@ -251,9 +255,10 @@ class StorageClient(object):
                 the StorageClient.
             **kwargs (dict): The kwargs.
         """
-        del args, kwargs
+        del args
         # Storage API has unlimited rate.
         self.repository = StorageRepositoryClient(
+            credentials=kwargs.get('credentials'),
             quota_max_calls=0,
             use_rate_limiter=False)
 

--- a/google/cloud/security/common/gcp_api/storage.py
+++ b/google/cloud/security/common/gcp_api/storage.py
@@ -70,13 +70,13 @@ class StorageRepositoryClient(_base_repository.BaseRepositoryClient):
         """Constructor.
 
         Args:
+            credentials (GoogleCredentials): An optional GoogleCredentials
+                object to use.
             quota_max_calls (int): Allowed requests per <quota_period> for the
                 API.
             quota_period (float): The time period to limit the requests within.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
-            credentials (GoogleCredentials): An optional GoogleCredentials
-                object to use.
         """
         if not quota_max_calls:
             use_rate_limiter = False

--- a/google/cloud/security/common/util/file_loader.py
+++ b/google/cloud/security/common/util/file_loader.py
@@ -86,8 +86,8 @@ def _read_file_from_gcs(file_path):
         dict: The parsed dict from the loaded file.
     """
     # Pass credential in explicitly so that cached credentials are not used.
-    credential = client.GoogleCredentials.get_application_default()
-    storage_client = storage.StorageClient(credential=credential)
+    credentials = client.GoogleCredentials.get_application_default()
+    storage_client = storage.StorageClient(credentials=credentials)
 
     file_content = storage_client.get_text_file(full_bucket_path=file_path)
 

--- a/google/cloud/security/common/util/file_loader.py
+++ b/google/cloud/security/common/util/file_loader.py
@@ -17,6 +17,7 @@
 import json
 import os
 import yaml
+from oauth2client import client
 
 from google.cloud.security.common.gcp_api import storage
 from google.cloud.security.common.util import errors as util_errors
@@ -84,7 +85,9 @@ def _read_file_from_gcs(file_path):
     Returns:
         dict: The parsed dict from the loaded file.
     """
-    storage_client = storage.StorageClient()
+    # Pass credential in explicitly so that cached credentials are not used.
+    credential = client.GoogleCredentials.get_application_default()
+    storage_client = storage.StorageClient(credential=credential)
 
     file_content = storage_client.get_text_file(full_bucket_path=file_path)
 

--- a/google/cloud/security/common/util/file_loader.py
+++ b/google/cloud/security/common/util/file_loader.py
@@ -27,7 +27,6 @@ from google.cloud.security.common.util import log_util
 LOGGER = log_util.get_logger(__name__)
 
 
-# pylint: disable=bad-indentation
 def read_and_parse_file(file_path):
     """Parse a json or yaml formatted file from a local path or GCS.
 

--- a/google/cloud/security/common/util/file_loader.py
+++ b/google/cloud/security/common/util/file_loader.py
@@ -169,7 +169,12 @@ def _parse_yaml(data):
 
 
 def _get_storage_client():
-    """Returns a new storage API client with explicit credentials."""
+    """Returns a new storage API client with explicit credentials.
+
+    Returns:
+        storage.StorageClient: A new Storage API client with explicit
+            credentials.
+    """
     # Pass credential in explicitly so that cached credentials are not used.
     credentials = client.GoogleCredentials.get_application_default()
     storage_client = storage.StorageClient(credentials=credentials)

--- a/google/cloud/security/common/util/file_loader.py
+++ b/google/cloud/security/common/util/file_loader.py
@@ -16,8 +16,8 @@
 
 import json
 import os
-import yaml
 from oauth2client import client
+import yaml
 
 from google.cloud.security.common.gcp_api import storage
 from google.cloud.security.common.util import errors as util_errors
@@ -27,6 +27,7 @@ from google.cloud.security.common.util import log_util
 LOGGER = log_util.get_logger(__name__)
 
 
+# pylint: disable=bad-indentation
 def read_and_parse_file(file_path):
     """Parse a json or yaml formatted file from a local path or GCS.
 
@@ -42,6 +43,7 @@ def read_and_parse_file(file_path):
         return _read_file_from_gcs(file_path)
 
     return _read_file_from_local(file_path)
+
 
 def _get_filetype_parser(file_path, parser_type):
     """Return a parser function for parsing the file.
@@ -76,29 +78,32 @@ def _get_filetype_parser(file_path, parser_type):
 
     return filetype_handlers[file_ext][parser_type]
 
-def _read_file_from_gcs(file_path):
+
+def _read_file_from_gcs(file_path, storage_client=None):
     """Load file from GCS.
 
     Args:
         file_path (str): The GCS path to the file.
+        storage_client (storage.StorageClient): The Storage API Client to use
+            for downloading the file using the API.
 
     Returns:
         dict: The parsed dict from the loaded file.
     """
-    # Pass credential in explicitly so that cached credentials are not used.
-    credentials = client.GoogleCredentials.get_application_default()
-    storage_client = storage.StorageClient(credentials=credentials)
+    if not storage_client:
+        storage_client = _get_storage_client()
 
     file_content = storage_client.get_text_file(full_bucket_path=file_path)
 
     parser = _get_filetype_parser(file_path, 'string')
     return parser(file_content)
 
+
 def _read_file_from_local(file_path):
     """Load rules file from local path.
 
     Args:
-        file_path (str): The path to the file.
+      file_path (str): The path to the file.
 
     Returns:
         dict: The parsed dict from the loaded file.
@@ -106,6 +111,7 @@ def _read_file_from_local(file_path):
     with open(os.path.abspath(file_path), 'r') as rules_file:
         parser = _get_filetype_parser(file_path, 'file')
         return parser(rules_file)
+
 
 def _parse_json_string(data):
     """Parse the data from a string of json.
@@ -143,6 +149,7 @@ def _parse_json_file(data):
     except ValueError as json_error:
         raise json_error
 
+
 def _parse_yaml(data):
     """Parse yaml data.
 
@@ -160,3 +167,11 @@ def _parse_yaml(data):
     except yaml.YAMLError as yaml_error:
         LOGGER.error(yaml_error)
         raise yaml_error
+
+
+def _get_storage_client():
+    """Returns a new storage API client with explicit credentials."""
+    # Pass credential in explicitly so that cached credentials are not used.
+    credentials = client.GoogleCredentials.get_application_default()
+    storage_client = storage.StorageClient(credentials=credentials)
+    return storage_client

--- a/tests/common/util/file_loader_test.py
+++ b/tests/common/util/file_loader_test.py
@@ -27,6 +27,14 @@ from google.cloud.security.common.util import file_loader
 class FileLoaderTest(ForsetiTestCase):
     """Test the file loader utility."""
 
+    @classmethod
+    @mock.patch.object(client.GoogleCredentials, 'get_application_default')
+    def setUpClass(cls, mock_google_credential):
+        """Set up."""
+        cls.storage_client = file_loader._get_storage_client()
+        # Enable cached HTTP for mock HTTP response object.
+        cls.storage_client.repository._use_cached_http = True
+
     def test_get_filetype_parser_works(self):
         """Test get_filetype_parser() works."""
         self.assertIsNotNone(
@@ -48,29 +56,29 @@ class FileLoaderTest(ForsetiTestCase):
         with self.assertRaises(errors.InvalidParserTypeError):
             file_loader._get_filetype_parser('path/to/file.yaml', 'asdf')
 
-    @mock.patch.object(client.GoogleCredentials, 'get_application_default')
-    def test_read_file_from_gcs_json(self, mock_default_credential):
+    def test_read_file_from_gcs_json(self):
         """Test read_file_from_gcs for json."""
         mock_responses = [
             ({'status': '200',
               'content-range': '0-10/11'}, b'{"test": 1}')
         ]
         http_mocks.mock_http_response_sequence(mock_responses)
-        expected_dict = {"test": 1}
-        return_dict = file_loader._read_file_from_gcs('gs://fake/file.json')
+        expected_dict = {'test': 1}
+        return_dict = file_loader._read_file_from_gcs(
+            'gs://fake/file.json', storage_client=self.storage_client)
 
         self.assertEqual(expected_dict, return_dict)
 
-    @mock.patch.object(client.GoogleCredentials, 'get_application_default')
-    def test_read_file_from_gcs_yaml(self, mock_default_credential):
+    def test_read_file_from_gcs_yaml(self):
         """Test read_file_from_gcs for yaml."""
         mock_responses = [
             ({'status': '200',
               'content-range': '0-6/7'}, b'test: 1')
         ]
         http_mocks.mock_http_response_sequence(mock_responses)
-        expected_dict = {"test": 1}
-        return_dict = file_loader._read_file_from_gcs('gs://fake/file.yaml')
+        expected_dict = {'test': 1}
+        return_dict = file_loader._read_file_from_gcs(
+            'gs://fake/file.yaml', storage_client=self.storage_client)
 
         self.assertEqual(expected_dict, return_dict)
 
@@ -82,4 +90,3 @@ class FileLoaderTest(ForsetiTestCase):
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
* Set file_loader util to use an explicit credential object so that
per thread http object caching is not used for loading and saving files
to a GCS bucket.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
