### PR TITLE
Handle unicode when writing to csv.

### DIFF
--- a/google/cloud/security/common/data_access/csv_writer.py
+++ b/google/cloud/security/common/data_access/csv_writer.py
@@ -14,9 +14,10 @@
 
 """Writes the csv files for upload to Cloud SQL."""
 from contextlib import contextmanager
-import csv
 import os
 import tempfile
+
+import unicodecsv as csv
 
 from google.cloud.security.common.data_access.errors import CSVFileError
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ INSTALL_REQUIRES = [
     'sendgrid==3.6.3',
     'SQLAlchemy==1.1.9',
     'pygraph>=0.2.1',
+    'unicodecsv==0.14.1',
 ]
 
 SETUP_REQUIRES = [


### PR DESCRIPTION
Python 2’s csv module doesn’t handle unicode strings.  So, opting to change to a serializer that handles unicode natively.  I believe this is much better since we don't have to do this ourselves, or handle complex nested dictionaries.

Here is a screenshot that this is written correctly to the database.
![image](https://user-images.githubusercontent.com/6977544/30413700-762910ae-98d4-11e7-8b2d-e011357b0dc4.png)

https://pypi.python.org/pypi/unicodecsv/0.14.1