### PR TITLE
Add targetServiceAccount to firewall rules inventory

### DIFF
--- a/google/cloud/security/inventory/pipelines/load_firewall_rules_pipeline.py
+++ b/google/cloud/security/inventory/pipelines/load_firewall_rules_pipeline.py
@@ -70,6 +70,9 @@ class LoadFirewallRulesPipeline(base_pipeline.BasePipeline):
                        'firewall_rule_target_tags':
                            parser.json_stringify(
                                firewall_rule.get('targetTags')),
+                       'firewall_rule_target_service_accounts':
+                            parser.json_stringify(
+                                firewall_rule.get('targetServiceAccounts')),
                        'firewall_rule_allowed':
                            parser.json_stringify(
                                firewall_rule.get('allowed')),


### PR DESCRIPTION
I've made a small addition to the firewall rules inventory pipeline: the `targetServiceAccount` field, which is not collected except than in the `raw_firewall_rule` data.
