### PR TITLE
Give forseti service account visibility to bigquery datasets.

### DIFF
--- a/scripts/gcp_setup/environment/gcloud_env.py
+++ b/scripts/gcp_setup/environment/gcloud_env.py
@@ -43,6 +43,7 @@ ORG_IAM_ROLES = [
     'roles/compute.networkViewer',
     'roles/iam.securityReviewer',
     'roles/appengine.appViewer',
+    'roles/bigquery.dataViewer',
     'roles/servicemanagement.quotaViewer',
     'roles/cloudsql.viewer',
     'roles/compute.securityAdmin',


### PR DESCRIPTION
Antoine reported that his bigquery datasets are not inventory, despite having a lot of datasets.  After testing, it turns out that the forseti-gcp-reader service account needs to have ```roles/bigquery.dataViewer``` in the org IAM.