### PR TITLE
Adding Get Global Operations call to Compute API

### DIFF
--- a/google/cloud/security/common/gcp_api/compute.py
+++ b/google/cloud/security/common/gcp_api/compute.py
@@ -678,7 +678,7 @@ class ComputeClient(object):
                                                        'forwardingRules')
         return results
 
-    def get_global_operations(self, project_id, operation_id):
+    def get_global_operation(self, project_id, operation_id):
         """Get the Operations Status
         Args:
             project_id (str): The project id.
@@ -689,7 +689,9 @@ class ComputeClient(object):
             https://cloud.google.com/compute/docs/reference/latest/globalOperations/get
 
         Raises:
-            apiError: Returns if the api is not enabled or executable.
+            ApiNotEnabledError: Returns if the api is not enabled.
+            ApiExecutionError: Returns if the api is not executable.
+
         """
         try:
             return self.repository.global_operations.get(

--- a/tests/common/gcp_api/compute_test.py
+++ b/tests/common/gcp_api/compute_test.py
@@ -117,12 +117,13 @@ class ComputeTest(unittest_utils.ForsetiTestCase):
         with self.assertRaises(expected_exception):
             list(self.gce_api_client.get_firewall_rules(self.project_id))
 
-
-    def test_get_global_operations(self):
+    @parameterized.parameterized.expand(ERROR_TEST_CASES)
+    def test_get_global_operation(self, name, response, status,
+                                  expected_exception):
         """Test get_global_operations"""
-        http_mocks.mock_http_response(fake_compute.GLOBAL_OPERATIONS_RESPONSE)
-        results = self.gce_api_client.get_global_operations(
-            self.project_id, operation_id='operation-1234')
+        http_mocks.mock_http_response(fake_compute.GLOBAL_OPERATION_RESPONSE)
+        results = self.gce_api_client.get_global_operation(
+            self.project_id, operation_id=fake_compute.FAKE_OPERATION_ID)
 
     def test_get_quota(self):
         """Test get quota."""

--- a/tests/common/gcp_api/compute_test.py
+++ b/tests/common/gcp_api/compute_test.py
@@ -117,13 +117,20 @@ class ComputeTest(unittest_utils.ForsetiTestCase):
         with self.assertRaises(expected_exception):
             list(self.gce_api_client.get_firewall_rules(self.project_id))
 
-    @parameterized.parameterized.expand(ERROR_TEST_CASES)
-    def test_get_global_operation(self, name, response, status,
-                                  expected_exception):
+    def test_get_global_operation(self):
         """Test get_global_operations"""
         http_mocks.mock_http_response(fake_compute.GLOBAL_OPERATION_RESPONSE)
         results = self.gce_api_client.get_global_operation(
             self.project_id, operation_id=fake_compute.FAKE_OPERATION_ID)
+
+    @parameterized.parameterized.expand(ERROR_TEST_CASES)
+    def test_get_global_operation_errors(self, name, response, status,
+                                       expected_exception):
+        """Verify error conditions for get global operation."""
+        http_mocks.mock_http_response(response, status)
+        with self.assertRaises(expected_exception):
+            list(self.gce_api_client.get_global_operation(
+                self.project_id, operation_id=fake_compute.FAKE_OPERATION_ID))
 
     def test_get_quota(self):
         """Test get quota."""

--- a/tests/common/gcp_api/compute_test.py
+++ b/tests/common/gcp_api/compute_test.py
@@ -117,6 +117,13 @@ class ComputeTest(unittest_utils.ForsetiTestCase):
         with self.assertRaises(expected_exception):
             list(self.gce_api_client.get_firewall_rules(self.project_id))
 
+
+    def test_get_global_operations(self):
+        """Test get_global_operations"""
+        http_mocks.mock_http_response(fake_compute.GLOBAL_OPERATIONS_RESPONSE)
+        results = self.gce_api_client.get_global_operations(
+            self.project_id, operation_id='operation-1234')
+
     def test_get_quota(self):
         """Test get quota."""
         http_mocks.mock_http_response(fake_compute.GET_PROJECT_RESPONSE)

--- a/tests/common/gcp_api/test_data/fake_compute_responses.py
+++ b/tests/common/gcp_api/test_data/fake_compute_responses.py
@@ -1543,7 +1543,7 @@ EXPECTED_SUBNETWORKS_LIST_SELFLINKS = frozenset([
     "{}/regions/us-central1/subnetworks/default2".format(BASE_URL)
 ])
 
-GLOBAL_OPERATIONS_RESPONSE = """
+GLOBAL_OPERATION_RESPONSE = """
     {
       "kind": "compute#operation",
       "id": "1234",
@@ -1558,3 +1558,5 @@ GLOBAL_OPERATIONS_RESPONSE = """
       "selfLink": "https://www.googleapis.com/compute/beta/projects/project1/global/operations/operation-1234"
 }
 """
+
+FAKE_OPERATION_ID = "operation-1234"

--- a/tests/common/gcp_api/test_data/fake_compute_responses.py
+++ b/tests/common/gcp_api/test_data/fake_compute_responses.py
@@ -1542,3 +1542,19 @@ EXPECTED_SUBNETWORKS_LIST_SELFLINKS = frozenset([
     "{}/regions/us-central1/subnetworks/default1".format(BASE_URL),
     "{}/regions/us-central1/subnetworks/default2".format(BASE_URL)
 ])
+
+GLOBAL_OPERATIONS_RESPONSE = """
+    {
+      "kind": "compute#operation",
+      "id": "1234",
+      "name": "operation-1234",
+      "operationType": "delete",
+      "targetLink": "https://www.googleapis.com/compute/v1/projects/project1/global/firewalls/test-1234",
+      "targetId": "123456",
+      "status": "PENDING",
+      "user": "mock_data@example.com",
+      "progress": 0,
+      "insertTime": "2017-08-08T10:37:55.413-07:00",
+      "selfLink": "https://www.googleapis.com/compute/beta/projects/project1/global/operations/operation-1234"
+}
+"""

--- a/tests/common/gcp_api/test_data/fake_compute_responses.py
+++ b/tests/common/gcp_api/test_data/fake_compute_responses.py
@@ -1556,6 +1556,7 @@ GLOBAL_OPERATION_RESPONSE = """
       "progress": 0,
       "insertTime": "2017-08-08T10:37:55.413-07:00",
       "selfLink": "https://www.googleapis.com/compute/beta/projects/project1/global/operations/operation-1234"
+ }
 """
 
 FAKE_OPERATION_ID = "operation-1234"


### PR DESCRIPTION
Adding the get global operations to the compute api
for additional migration of functionality.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
