### PR TITLE
Fix parsing of lists with no values in firewall_rule.py

### DIFF
--- a/google/cloud/security/common/data_access/csv_writer.py
+++ b/google/cloud/security/common/data_access/csv_writer.py
@@ -215,6 +215,7 @@ FIREWALL_RULES_FIELDNAMES = [
     'firewall_rule_destination_ranges',
     'firewall_rule_source_tags',
     'firewall_rule_target_tags',
+    'firewall_rule_source_service_accounts',
     'firewall_rule_target_service_accounts',
     'firewall_rule_allowed',
     'firewall_rule_denied',

--- a/google/cloud/security/common/data_access/sql_queries/create_tables.py
+++ b/google/cloud/security/common/data_access/sql_queries/create_tables.py
@@ -252,6 +252,7 @@ CREATE_FIREWALL_RULES_TABLE = """
         `firewall_rule_source_ranges` json DEFAULT NULL,
         `firewall_rule_destination_ranges` json DEFAULT NULL,
         `firewall_rule_source_tags` json DEFAULT NULL,
+        `firewall_rule_source_service_accounts` json DEFAULT NULL,
         `firewall_rule_target_service_accounts` json DEFAULT NULL,
         `firewall_rule_target_tags` json DEFAULT NULL,
         `firewall_rule_allowed` json DEFAULT NULL,

--- a/google/cloud/security/common/data_access/sql_queries/select_data.py
+++ b/google/cloud/security/common/data_access/sql_queries/select_data.py
@@ -100,6 +100,7 @@ FIREWALL_RULES = """
     firewall_rule_priority, firewall_rule_direction,
     firewall_rule_source_ranges, firewall_rule_destination_ranges,
     firewall_rule_source_tags, firewall_rule_target_tags,
+    firewall_rule_source_service_accounts, 
     firewall_rule_target_service_accounts, firewall_rule_allowed,
     firewall_rule_denied
     FROM firewall_rules_{0}

--- a/google/cloud/security/common/gcp_type/firewall_rule.py
+++ b/google/cloud/security/common/gcp_type/firewall_rule.py
@@ -47,13 +47,19 @@ class FirewallRule(object):
         self._priority = kwargs.get('firewall_rule_priority')
         self.direction = kwargs.get('firewall_rule_direction')
         self._source_ranges = frozenset(parser.json_unstringify(
-            kwargs.get('firewall_rule_source_ranges', '[]')))
+            kwargs.get('firewall_rule_source_ranges'), default=list()))
         self._destination_ranges = frozenset(parser.json_unstringify(
-            kwargs.get('firewall_rule_destination_ranges', '[]')))
+            kwargs.get('firewall_rule_destination_ranges'), default=list()))
         self._source_tags = frozenset(parser.json_unstringify(
-            kwargs.get('firewall_rule_source_tags', '[]')))
+            kwargs.get('firewall_rule_source_tags'), default=list()))
         self._target_tags = frozenset(parser.json_unstringify(
-            kwargs.get('firewall_rule_target_tags', '[]')))
+            kwargs.get('firewall_rule_target_tags'), default=list()))
+        self._source_service_accounts = frozenset(parser.json_unstringify(
+            kwargs.get('firewall_rule_source_service_accounts'),
+            default=list()))
+        self._target_service_accounts = frozenset(parser.json_unstringify(
+            kwargs.get('firewall_rule_target_service_accounts'),
+            default=list()))
         self.allowed = parser.json_unstringify(
             kwargs.get('firewall_rule_allowed'))
         self.denied = parser.json_unstringify(
@@ -99,6 +105,24 @@ class FirewallRule(object):
           list: Sorted target tags.
         """
         return sorted(self._target_tags)
+
+    @property
+    def source_service_accounts(self):
+        """The sorted source tags for this policy.
+
+        Returns:
+          list: Sorted source tags.
+        """
+        return sorted(self._source_service_accounts)
+
+    @property
+    def target_service_accounts(self):
+        """The sorted target tags for this policy.
+
+        Returns:
+          list: Sorted target tags.
+        """
+        return sorted(self._target_service_accounts)
 
     @property
     def priority(self):

--- a/google/cloud/security/common/util/parser.py
+++ b/google/cloud/security/common/util/parser.py
@@ -85,15 +85,16 @@ def json_stringify(obj_to_jsonify):
     return json_str
 
 
-def json_unstringify(json_to_objify):
+def json_unstringify(json_to_objify, default=None):
     """Convert a json string to a python object.
 
     Args:
         json_to_objify (str): The json string.
+        default (object): The default value if no json string is passed in.
 
     Returns:
         object: The un-stringified object.
     """
     if not json_to_objify:
-        return None
+        return default
     return json.loads(json_to_objify)

--- a/tests/common/gcp_type/firewall_rule_test.py
+++ b/tests/common/gcp_type/firewall_rule_test.py
@@ -52,6 +52,7 @@ class FirewallRuleTest(ForsetiTestCase):
         (
             {
                 'firewall_rule_source_ranges': json.dumps(['1.1.1.1']),
+                'firewall_rule_source_tags': None,
                 'firewall_rule_direction': 'ingress',
                 'firewall_rule_network': 'n1',
                 'firewall_rule_allowed': json.dumps(


### PR DESCRIPTION
* Fix parsing of lists with no values in firewall_rule.py
* Re-add target_service_account support that was dropped accidentally.
* Add source_service_account support.
* Allow parser.json_unstringify to set a default value other than None
for empty json strings.

Fixes issue #709.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
