### PR TITLE
Separate out the logic for required rules

### DIFF
--- a/google/cloud/security/common/email_templates/scanner_summary.jinja
+++ b/google/cloud/security/common/email_templates/scanner_summary.jinja
@@ -50,7 +50,7 @@ td {
 <body style="background-color: #eee;">
 <div style="background-color: #fff; margin-top: 40px; padding: 20px; margin-left: 20%; margin-right: 20%;">
   <div style="margin: 10px 10px 15px 10px; font-size: 14px;">
-    Forseti Security found some issues during the scan on {{ scan_date }}.
+    Forseti Security found some scanner rule violations on {{ scan_date }}.
   </div>
   <div style="margin: 10px 10px;">
     <div style="font-weight: bold; font-size: 16px; margin-bottom: 5px;">

--- a/google/cloud/security/common/gcp_type/iam_policy.py
+++ b/google/cloud/security/common/gcp_type/iam_policy.py
@@ -134,7 +134,7 @@ class IamPolicyBinding(object):
         if not role_name or not members:
             raise errors.InvalidIamPolicyBindingError(
                 ('Invalid IAM policy binding: '
-                 'role={}, members={}'.format(role_name, members)))
+                 'role_name={}, members={}'.format(role_name, members)))
         self.role_name = role_name
         self.members = _get_iam_members(members)
         self.role_pattern = re.compile(_escape_and_globify(role_name),
@@ -171,7 +171,7 @@ class IamPolicyBinding(object):
         Returns:
             str: The representation of IamPolicyBinding.
         """
-        return 'IamBinding: <role={}, members={}>'.format(
+        return 'IamBinding: <role_name={}, members={}>'.format(
             self.role_name, self.members)
 
     @classmethod

--- a/google/cloud/security/scanner/audit/iam_rules_engine.py
+++ b/google/cloud/security/scanner/audit/iam_rules_engine.py
@@ -149,7 +149,7 @@ class IamRulesEngine(bre.BaseRulesEngine):
                 violations,
                 self.rule_book.find_violations(resource, binding))
 
-        return set(violations)
+        return violations
 
     def add_rules(self, rules):
         """Add rules to the rule book.

--- a/google/cloud/security/scanner/audit/iam_rules_engine.py
+++ b/google/cloud/security/scanner/audit/iam_rules_engine.py
@@ -143,13 +143,12 @@ class IamRulesEngine(bre.BaseRulesEngine):
         if self.rule_book is None or force_rebuild:
             self.build_rule_book()
 
-        violations = itertools.chain()
-        for binding in policy.get('bindings', []):
-            violations = itertools.chain(
-                violations,
-                self.rule_book.find_violations(resource, binding))
+        policy_bindings = [
+            iam_policy.IamPolicyBinding.create_from(b)
+            for b in policy.get('bindings', [])]
+        violations = self.rule_book.find_violations(resource, policy_bindings)
 
-        return violations
+        return set(violations)
 
     def add_rules(self, rules):
         """Add rules to the rule book.
@@ -381,7 +380,7 @@ class IamRuleBook(bre.BaseRuleBook):
 
         return resource_rules
 
-    def find_violations(self, resource, policy_binding):
+    def find_violations(self, resource, policy_bindings):
         """Find policy binding violations in the rule book.
 
         Args:
@@ -390,7 +389,7 @@ class IamRuleBook(bre.BaseRuleBook):
                 This is where we start looking for rule violations and
                 we move up the resource hierarchy (if permitted by the
                 resource's "inherit_from_parents" property).
-            policy_binding (IamPolicyBinding): An IamPolicyBinding.
+            policy_bindings (list): A list of IamPolicyBindings.
 
         Returns:
             iterable: A generator of the rule violations.
@@ -420,7 +419,7 @@ class IamRuleBook(bre.BaseRuleBook):
 
                 violations = itertools.chain(
                     violations,
-                    resource_rule.find_mismatches(resource, policy_binding))
+                    resource_rule.find_mismatches(resource, policy_bindings))
 
                 inherit_from_parents = resource_rule.inherit_from_parents
 
@@ -536,72 +535,78 @@ class ResourceRules(object):
                     self.resource, self.rules, self.applies_to,
                     self.inherit_from_parents)
 
-    def find_mismatches(self, policy_resource, binding_to_match):
+    def find_mismatches(self, resource, policy_bindings):
         """Determine if the policy binding matches this rule's criteria.
 
         How the member matching operates:
 
         1. Whitelist: policy members match at least one rule member
         2. Blacklist: policy members must not match any rule members
-        3. Require: rule members must all match policy members
+        3. Require: rule members must all be found in policy members
 
         Args:
-            policy_resource (Resource): The resource that the policy belongs to.
-            binding_to_match (IamPolicyBinding): The IamPolicyBinding binding
+            resource (Resource): The resource that the policy belongs to.
+            policy_bindings (list): The list of IamPolicyBindings
                 to compare to this rule's bindings.
 
         Yields:
             iterable: A generator of RuleViolations.
         """
-        policy_binding = iam_policy.IamPolicyBinding.create_from(
-            binding_to_match)
-
         for rule in self.rules:
-            found_role = False
-            for binding in rule.bindings:
-                policy_role_name = policy_binding.role_name
-                if not policy_binding.role_name.startswith('roles'):
-                    policy_role_name = 'roles/{}'.format(
-                        policy_binding.role_name)
+            if rule.mode == scanner_rules.RuleMode.REQUIRED:
+                found_role = False
+                violating_bindings = {}
+                # If the rule's binding role is found in the policy, check the policy members
+                # to see if all rule binding members are found.
+                # Any outstanding rule bindings (role => members) should be reported.
+                for rule_binding in rule.bindings:
+                    for policy_binding in policy_bindings:
+                        if rule_binding.role_pattern.match(policy_binding.role_name):
+                            found_role = True
+                            violating_members = (self._dispatch_rule_mode_check(
+                                mode=rule.mode,
+                                rule_members=rule_binding.members,
+                                policy_members=policy_binding.members))
+                            if violating_members:
+                                violating_bindings[rule_binding.role_name] = violating_members
 
-                # If the rule's role pattern matches the policy binding's role
-                # pattern, then check the members to see whether they match,
-                # according to the rule mode.
-                if binding.role_pattern.match(policy_role_name):
-                    if rule.mode == scanner_rules.RuleMode.REQUIRED:
-                        role_name = binding.role_name
-                    else:
-                        role_name = policy_role_name
-                    found_role = True
-                    violating_members = (self._dispatch_rule_mode_check(
-                        mode=rule.mode,
-                        rule_members=binding.members,
-                        policy_members=policy_binding.members))
-                    if violating_members:
+                if not found_role:
+                    violating_bindings = {b.role_name: b.members for b in rule.bindings}
+
+                if violating_bindings:
+                    for (role_name, members) in violating_bindings.iteritems():
                         yield scanner_rules.RuleViolation(
-                            resource_type=policy_resource.type,
-                            resource_id=policy_resource.id,
+                            resource_type=resource.type,
+                            resource_id=resource.id,
                             rule_name=rule.rule_name,
                             rule_index=rule.rule_index,
                             violation_type=scanner_rules.VIOLATION_TYPE.get(
                                 rule.mode,
                                 scanner_rules.VIOLATION_TYPE['UNSPECIFIED']),
                             role=role_name,
-                            members=tuple(violating_members))
-
-            # Extra check if the role did not match in the REQUIRED case.
-            if not found_role and rule.mode == scanner_rules.RuleMode.REQUIRED:
-                for binding in rule.bindings:
-                    yield scanner_rules.RuleViolation(
-                        resource_type=policy_resource.type,
-                        resource_id=policy_resource.id,
-                        rule_name=rule.rule_name,
-                        rule_index=rule.rule_index,
-                        violation_type=scanner_rules.VIOLATION_TYPE.get(
-                            rule.mode,
-                            scanner_rules.VIOLATION_TYPE['UNSPECIFIED']),
-                        role=binding.role_name,
-                        members=tuple(binding.members))
+                            members=tuple(members))
+            else:
+                for policy_binding in policy_bindings:
+                    for rule_binding in rule.bindings:
+                        # If the rule's role pattern matches the policy binding's role
+                        # pattern, then check the members to see whether they match,
+                        # according to the rule mode.
+                        if rule_binding.role_pattern.match(policy_binding.role_name):
+                            violating_members = (self._dispatch_rule_mode_check(
+                                mode=rule.mode,
+                                rule_members=rule_binding.members,
+                                policy_members=policy_binding.members))
+                            if violating_members:
+                                yield scanner_rules.RuleViolation(
+                                    resource_type=resource.type,
+                                    resource_id=resource.id,
+                                    rule_name=rule.rule_name,
+                                    rule_index=rule.rule_index,
+                                    violation_type=scanner_rules.VIOLATION_TYPE.get(
+                                        rule.mode,
+                                        scanner_rules.VIOLATION_TYPE['UNSPECIFIED']),
+                                    role=policy_binding.role_name,
+                                    members=tuple(violating_members))
 
     def _dispatch_rule_mode_check(self, mode, rule_members=None,
                                   policy_members=None):

--- a/google/cloud/security/scanner/audit/iam_rules_engine.py
+++ b/google/cloud/security/scanner/audit/iam_rules_engine.py
@@ -149,7 +149,7 @@ class IamRulesEngine(bre.BaseRulesEngine):
                 violations,
                 self.rule_book.find_violations(resource, binding))
 
-        return violations
+        return set(violations)
 
     def add_rules(self, rules):
         """Add rules to the rule book.

--- a/rules/iam_rules.yaml
+++ b/rules/iam_rules.yaml
@@ -29,15 +29,28 @@ rules:
           - group:*@YOURDOMAIN
 
   # custom rules
-  - name: sample whitelist
+  - name: Allow service accounts to have access
     mode: whitelist
     resource:
       - type: organization
         applies_to: self_and_children
         resource_ids:
-          - YOUR_ORG_ID
+          - '*'
     inherit_from_parents: true
     bindings:
       - role: roles/*
         members:
           - serviceAccount:*@*.gserviceaccount.com
+
+  - name: All projects must have owner from my domain
+    mode: required
+    resource:
+      - type: project
+        applies_to: self
+        resource_ids:
+          - '*'
+    inherit_from_parents: true
+    bindings:
+      - role: roles/owner
+        members:
+          - user:*@YOURDOMAIN

--- a/tests/scanner/audit/data/test_rules.py
+++ b/tests/scanner/audit/data/test_rules.py
@@ -392,3 +392,22 @@ RULES9 = {
         },
     ]
 }
+
+RULES10 = {
+    'rules': [
+        {
+            'name': 'project required',
+            'mode': 'required',
+            'resource': [{
+                    'type': 'project',
+                    'applies_to': 'self',
+                    'resource_ids': ['*']
+                }],
+            'inherit_from_parents': False,
+            'bindings': [{
+                    'role': 'roles/owner',
+                    'members': ['user:*@company.com']
+                }]
+        },
+    ]
+}

--- a/tests/scanner/audit/data/test_rules.py
+++ b/tests/scanner/audit/data/test_rules.py
@@ -403,7 +403,7 @@ RULES10 = {
                     'applies_to': 'self',
                     'resource_ids': ['*']
                 }],
-            'inherit_from_parents': False,
+            'inherit_from_parents': True, # this is kinda broken, keep it for now
             'bindings': [{
                     'role': 'roles/owner',
                     'members': ['user:*@company.com']

--- a/tests/scanner/audit/iam_rules_engine_test.py
+++ b/tests/scanner/audit/iam_rules_engine_test.py
@@ -168,7 +168,7 @@ class IamRulesEngineTest(ForsetiTestCase):
         Expected results:
             All policy binding members are in the whitelist.
         """
-        test_binding = {
+        test_binding = [{
             'role': 'roles/owner',
             'members': [
                 'user:foo@company.com',
@@ -176,7 +176,7 @@ class IamRulesEngineTest(ForsetiTestCase):
                 'group:some-group@googlegroups.com',
                 'serviceAccount:12345@iam.gserviceaccount.com',
             ]
-        }
+        }]
         rule_bindings = [
             {
                 'role': 'roles/owner',
@@ -209,12 +209,12 @@ class IamRulesEngineTest(ForsetiTestCase):
         Expected results:
             No policy bindings found in the blacklist.
         """
-        test_binding = {
+        test_binding = [{
             'role': 'roles/owner',
             'members': [
                 'user:someone@notcompany.com',
             ]
-        }
+        }]
         rule_bindings = [
             {
                 'role': 'roles/owner',
@@ -247,7 +247,7 @@ class IamRulesEngineTest(ForsetiTestCase):
         Expected results:
             All required members are found in the policy.
         """
-        test_binding = {
+        test_binding = [{
             'role': 'roles/owner',
             'members': [
                 'user:foo@company.com',
@@ -255,7 +255,7 @@ class IamRulesEngineTest(ForsetiTestCase):
                 'group:some-group@googlegroups.com',
                 'serviceAccount:12345@iam.gserviceaccount.com',
             ]
-        }
+        }]
         rule_bindings = [
             {
                 'role': 'roles/owner',
@@ -286,14 +286,14 @@ class IamRulesEngineTest(ForsetiTestCase):
         Expected results:
             All required members are found in the policy.
         """
-        test_binding = {
+        test_binding = [{
             'role': 'roles/owner',
             'members': [
                 'user:foo@company.com.abc',
                 'group:some-group@googlegroups.com',
                 'serviceAccount:12345@iam.gserviceaccount.com',
             ]
-        }
+        }]
         rule_bindings = [
             {
                 'role': 'roles/owner',
@@ -1337,6 +1337,71 @@ class IamRulesEngineTest(ForsetiTestCase):
                 violation_type='ADDED',
                 role=project_policy['bindings'][0]['role'],
                 members=tuple(expected_outstanding['roles/editor'])),
+        ])
+        self.assertItemsEqual(expected_violations, actual_violations)
+
+    def test_project_required_dedupe(self):
+        """Test that violations are deduped."""
+        rules_local_path = get_datafile_path(__file__, 'test_rules_1.yaml')
+        rules_engine = ire.IamRulesEngine(rules_local_path)
+        rules_engine.rule_book = ire.IamRuleBook(
+            {}, test_rules.RULES10, self.fake_timestamp)
+        rules_engine.rule_book.org_res_rel_dao = mock.MagicMock()
+        find_ancestor_mock = mock.MagicMock()
+        rules_engine.rule_book.org_res_rel_dao.find_ancestors = \
+            find_ancestor_mock
+
+        project1_policy = {
+            'bindings': [
+                {
+                    'role': 'roles/owner',
+                    'members': [
+                        'user:someone@company.com',
+                    ]
+                },
+                {
+                    'role': 'roles/viewer',
+                    'members': [
+                        'user:someone2@company.com',
+                    ]
+                },
+            ]
+        }
+        project2_policy = {
+            'bindings': [
+                {
+                    'role': 'roles/editor',
+                    'members': [
+                        'user:someone1@company.com',
+                    ]
+                }
+            ]
+        }
+
+        actual_violations = set(itertools.chain(
+                rules_engine.find_policy_violations(
+                    self.project1, project1_policy),
+                rules_engine.find_policy_violations(
+                    self.project2, project2_policy)
+            )
+        )
+
+        # expected
+        expected_outstanding = {
+            'roles/owner': [
+                IamPolicyMember.create_from('user:*@company.com')
+            ]
+        }
+
+        expected_violations = set([
+            scanner_rules.RuleViolation(
+                rule_index=0,
+                rule_name='project required',
+                resource_id=self.project2.id,
+                resource_type=self.project2.type,
+                violation_type='REMOVED',
+                role='roles/owner',
+                members=tuple(expected_outstanding['roles/owner'])),
         ])
         self.assertItemsEqual(expected_violations, actual_violations)
 

--- a/tests/scanner/audit/iam_rules_engine_test.py
+++ b/tests/scanner/audit/iam_rules_engine_test.py
@@ -168,7 +168,7 @@ class IamRulesEngineTest(ForsetiTestCase):
         Expected results:
             All policy binding members are in the whitelist.
         """
-        test_binding = [{
+        test_binding = [IamPolicyBinding.create_from({
             'role': 'roles/owner',
             'members': [
                 'user:foo@company.com',
@@ -176,7 +176,7 @@ class IamRulesEngineTest(ForsetiTestCase):
                 'group:some-group@googlegroups.com',
                 'serviceAccount:12345@iam.gserviceaccount.com',
             ]
-        }]
+        })]
         rule_bindings = [
             {
                 'role': 'roles/owner',
@@ -209,12 +209,12 @@ class IamRulesEngineTest(ForsetiTestCase):
         Expected results:
             No policy bindings found in the blacklist.
         """
-        test_binding = [{
+        test_binding = [IamPolicyBinding.create_from({
             'role': 'roles/owner',
             'members': [
                 'user:someone@notcompany.com',
             ]
-        }]
+        })]
         rule_bindings = [
             {
                 'role': 'roles/owner',
@@ -247,7 +247,7 @@ class IamRulesEngineTest(ForsetiTestCase):
         Expected results:
             All required members are found in the policy.
         """
-        test_binding = [{
+        test_binding = [IamPolicyBinding.create_from({
             'role': 'roles/owner',
             'members': [
                 'user:foo@company.com',
@@ -255,7 +255,7 @@ class IamRulesEngineTest(ForsetiTestCase):
                 'group:some-group@googlegroups.com',
                 'serviceAccount:12345@iam.gserviceaccount.com',
             ]
-        }]
+        })]
         rule_bindings = [
             {
                 'role': 'roles/owner',
@@ -286,14 +286,14 @@ class IamRulesEngineTest(ForsetiTestCase):
         Expected results:
             All required members are found in the policy.
         """
-        test_binding = [{
+        test_binding = [IamPolicyBinding.create_from({
             'role': 'roles/owner',
             'members': [
                 'user:foo@company.com.abc',
                 'group:some-group@googlegroups.com',
                 'serviceAccount:12345@iam.gserviceaccount.com',
             ]
-        }]
+        })]
         rule_bindings = [
             {
                 'role': 'roles/owner',
@@ -1340,8 +1340,8 @@ class IamRulesEngineTest(ForsetiTestCase):
         ])
         self.assertItemsEqual(expected_violations, actual_violations)
 
-    def test_project_required_dedupe(self):
-        """Test that violations are deduped."""
+    def test_project_required(self):
+        """Test required rule."""
         rules_local_path = get_datafile_path(__file__, 'test_rules_1.yaml')
         rules_engine = ire.IamRulesEngine(rules_local_path)
         rules_engine.rule_book = ire.IamRuleBook(


### PR DESCRIPTION
Required rules need to be evaluated on the entire policy (and all the policy bindings), not just one binding at a time.

Also tweaking the email summary wording.

resolves #711 
resolves #617 