### PR TITLE
Add pipeline to upload violations to GCS

### DIFF
--- a/configs/forseti_conf.yaml.in
+++ b/configs/forseti_conf.yaml.in
@@ -143,11 +143,17 @@ notifier:
         - resource: policy_violations
           should_notify: false
           pipelines:
+            # Email violations
             - name: email_violations_pipeline
               configuration:
                 sendgrid_api_key: {SENDGRID_API_KEY}
                 sender: {EMAIL_SENDER}
                 recipient: {EMAIL_RECIPIENT}
+            # Upload violations to GCS.
+            - name: gcs_violations_pipeline
+              configuration:
+                # gcs_path should begin with "gs://"
+                gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
             # Slack webhook pipeline.
             # Create an incoming webhook in your organization's Slack setting, located at:
             # https://[your_org].slack.com/apps/manage/custom-integrations

--- a/configs/forseti_conf.yaml.sample
+++ b/configs/forseti_conf.yaml.sample
@@ -137,12 +137,18 @@ notifier:
         - resource: policy_violations
           should_notify: false
           pipelines:
+            # Email violations
             - name: email_violations_pipeline
               configuration:
                 sendgrid_api_key: ''
                 sender: ''
                 # Multiple recipients can be specified as comma-separated text.
                 recipient: ''
+            # Upload violations to GCS.
+            - name: gcs_violations_pipeline
+              configuration:
+                # gcs_path should begin with "gs://"
+                gcs_path: ''
             # Slack webhook pipeline
             # Create an incoming webhook in your organization's Slack setting, located at:
             # https://[your_org].slack.com/apps/manage/custom-integrations

--- a/google/cloud/security/common/email_templates/inventory_snapshot_summary.jinja
+++ b/google/cloud/security/common/email_templates/inventory_snapshot_summary.jinja
@@ -1,5 +1,5 @@
 <!--
-Copyright 2017 Google Inc.
+Copyright 2017 The Forseti Security Authors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/google/cloud/security/common/email_templates/notification_summary.jinja
+++ b/google/cloud/security/common/email_templates/notification_summary.jinja
@@ -54,7 +54,7 @@ td {
   </div>
   <div style="margin: 10px 10px;">
     <div style="font-weight: bold; font-size: 16px; margin-bottom: 5px;">
-      Totale Resource Violations: {{ violation_errors|length }}
+      Total Resource Violations: {{ violation_errors|length }}
     </div>
     <div style="font-style: italic; font-size: 14px; margin-bottom: 5px;">
       See attached JSON for details.

--- a/google/cloud/security/notifier/pipelines/base_email_notification_pipeline.py
+++ b/google/cloud/security/notifier/pipelines/base_email_notification_pipeline.py
@@ -1,0 +1,48 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Base email pipeline to perform notifications"""
+
+import abc
+
+from google.cloud.security.notifier.pipelines import (
+    base_notification_pipeline as bnp)
+from google.cloud.security.common.util import log_util
+
+
+LOGGER = log_util.get_logger(__name__)
+
+
+class BaseEmailNotificationPipeline(bnp.BaseNotificationPipeline):
+    """Base email pipeline."""
+
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def _send(self, **kwargs):
+        """Send notifications.
+
+        Args:
+            **kwargs: Arbitrary keyword arguments.
+        """
+        pass
+
+    @abc.abstractmethod
+    def _compose(self, **kwargs):
+        """Compose notifications.
+
+        Args:
+            **kwargs: Arbitrary keyword arguments.
+        """
+        pass

--- a/google/cloud/security/notifier/pipelines/base_notification_pipeline.py
+++ b/google/cloud/security/notifier/pipelines/base_notification_pipeline.py
@@ -52,12 +52,42 @@ class BaseNotificationPipeline(object):
         # self.api_client = api_client
 
         # Initializing DAOs
-        self.dao = dao.Dao(global_configs)
-        self.project_dao = project_dao.ProjectDao(global_configs)
-        self.violation_dao = violation_dao.ViolationDao(global_configs)
+        self.dao = None
+        self.project_dao = None
+        self.violation_dao = None
 
         # Get violations
         self.violations = violations
+
+    def _get_dao(self):
+        """Init or get dao.
+
+        Returns:
+            dao: Dao instance
+        """
+        if not self.dao:
+            self.dao = dao.Dao(self.global_configs)
+        return self.dao
+
+    def _get_project_dao(self):
+        """Init or get project_dao.
+
+        Returns:
+            project_dao: ProjectDao instance
+        """
+        if not self.project_dao:
+            self.project_dao = project_dao.ProjectDao(self.global_configs)
+        return self.project_dao
+
+    def _get_violation_dao(self):
+        """Init or get violation dao.
+
+        Returns:
+            violation_dao: ViolationDao instance
+        """
+        if not self.violation_dao:
+            self.violation_dao = violation_dao.ViolationDao(self.global_configs)
+        return self.violation_dao
 
     def _get_violations(self, timestamp):
         """Get all violtions.
@@ -68,32 +98,15 @@ class BaseNotificationPipeline(object):
         Returns:
             dict: Violations organized per resource type.
         """
+        vdao = self._get_violation_dao()
         violations = {
-            'violations': self.violation_dao.get_all_violations(
+            'violations': vdao.get_all_violations(
                 timestamp, 'violations'),
-            'bucket_acl_violations': self.violation_dao.get_all_violations(
+            'bucket_acl_violations': vdao.get_all_violations(
                 timestamp, 'buckets_acl_violations')
         }
 
         return violations
-
-    @abc.abstractmethod
-    def _send(self, **kwargs):
-        """Send notifications.
-
-        Args:
-            **kwargs: Arbitrary keyword arguments.
-        """
-        pass
-
-    @abc.abstractmethod
-    def _compose(self, **kwargs):
-        """Compose notifications.
-
-        Args:
-            **kwargs: Arbitrary keyword arguments.
-        """
-        pass
 
     @abc.abstractmethod
     def run(self):

--- a/google/cloud/security/notifier/pipelines/email_inventory_snapshot_summary_pipeline.py
+++ b/google/cloud/security/notifier/pipelines/email_inventory_snapshot_summary_pipeline.py
@@ -18,7 +18,7 @@
 from google.cloud.security.common.util import errors as util_errors
 from google.cloud.security.common.util import log_util
 from google.cloud.security.common.util.email_util import EmailUtil
-from google.cloud.security.notifier.pipelines import base_notification_pipeline as bnp
+from google.cloud.security.notifier.pipelines import base_email_notification_pipeline as bnp
 # pylint: enable=line-too-long
 
 
@@ -27,7 +27,7 @@ LOGGER = log_util.get_logger(__name__)
 
 # pylint: disable=arguments-differ
 
-class EmailInventorySnapshotSummaryPipeline(bnp.BaseNotificationPipeline):
+class EmailInventorySnapshotSummaryPipeline(bnp.BaseEmailNotificationPipeline):
     """Email pipeline for inventory snapshot summary."""
 
     # TODO: See if the base pipline init() can be reused.

--- a/google/cloud/security/notifier/pipelines/email_scanner_summary_pipeline.py
+++ b/google/cloud/security/notifier/pipelines/email_scanner_summary_pipeline.py
@@ -19,13 +19,13 @@ import collections
 from google.cloud.security.common.util import log_util
 from google.cloud.security.common.util.email_util import EmailUtil
 from google.cloud.security.common.gcp_type import resource_util
-from google.cloud.security.notifier.pipelines import base_notification_pipeline as bnp
+from google.cloud.security.notifier.pipelines import base_email_notification_pipeline as bnp
 # pylint: enable=line-too-long
 
 LOGGER = log_util.get_logger(__name__)
 
 
-class EmailScannerSummaryPipeline(bnp.BaseNotificationPipeline):
+class EmailScannerSummaryPipeline(bnp.BaseEmailNotificationPipeline):
     """Email pipeline for scanner summary."""
 
     # TODO: See if the base pipline init() can be reused.

--- a/google/cloud/security/notifier/pipelines/email_violations_pipeline.py
+++ b/google/cloud/security/notifier/pipelines/email_violations_pipeline.py
@@ -131,6 +131,8 @@ class EmailViolationsPipeline(bnp.BaseNotificationPipeline):
         Returns:
             dict: A map of the email with subject, content, attachemnt
         """
+        del kwargs
+
         email_map = {}
 
         attachment = self._make_attachment()

--- a/google/cloud/security/notifier/pipelines/gcs_violations_pipeline.py
+++ b/google/cloud/security/notifier/pipelines/gcs_violations_pipeline.py
@@ -1,0 +1,64 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Upload violations to GCS."""
+
+import tempfile
+
+from datetime import datetime
+
+# pylint: disable=line-too-long
+from google.cloud.security.common.gcp_api import storage
+from google.cloud.security.common.util import log_util
+from google.cloud.security.common.util import parser
+from google.cloud.security.notifier.pipelines import base_notification_pipeline as bnp
+# pylint: enable=line-too-long
+
+
+LOGGER = log_util.get_logger(__name__)
+
+VIOLATIONS_JSON_FMT = 'violations.{}.{}.{}.json'
+OUTPUT_TIMESTAMP_FMT = '%Y%m%dT%H%M%SZ'
+
+
+class GcsViolationsPipeline(bnp.BaseNotificationPipeline):
+    """Upload violations to GCS."""
+
+    def _get_output_filename(self):
+        """Create the output filename.
+
+        Returns:
+            str: The output filename for the violations json.
+        """
+        now_utc = datetime.utcnow()
+        output_timestamp = now_utc.strftime(OUTPUT_TIMESTAMP_FMT)
+        output_filename = VIOLATIONS_JSON_FMT.format(self.resource,
+                                                     self.cycle_timestamp,
+                                                     output_timestamp)
+        return output_filename
+
+    def run(self):
+        """Generate the temporary json file and upload to GCS."""
+        with tempfile.NamedTemporaryFile() as tmp_violations:
+            output_filename = self._get_output_filename()
+            tmp_violations.write(parser.json_stringify(self.violations))
+
+            gcs_upload_path = '{}/{}'.format(
+                self.pipeline_config['gcs_path'],
+                output_filename)
+
+            if gcs_upload_path.startswith('gs://'):
+                storage_client = storage.StorageClient()
+                storage_client.put_text_file(
+                    tmp_violations.name, gcs_upload_path)

--- a/google/cloud/security/notifier/pipelines/slack_webhook_pipeline.py
+++ b/google/cloud/security/notifier/pipelines/slack_webhook_pipeline.py
@@ -86,6 +86,10 @@ class SlackWebhookPipeline(bnp.BaseNotificationPipeline):
 
     def run(self):
         """Run the slack webhook pipeline"""
+        if not self.pipeline_config.get('webhook_url'):
+            LOGGER.warn('No url found, not running Slack pipeline.')
+            return
+
         for violation in self.violations:
             webhook_payload = self._compose(violation=violation)
             self._send(payload=webhook_payload)

--- a/google/cloud/security/scanner/scanners/scanners_map.py
+++ b/google/cloud/security/scanner/scanners/scanners_map.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Map for mapping rules engine to scanner class"""
+"""Map for mapping violations."""
 
 RESOURCE_MAP = {
     'bigquery_acl_violations': 'violations',

--- a/tests/notifier/pipelines/base_notification_pipeline_test.py
+++ b/tests/notifier/pipelines/base_notification_pipeline_test.py
@@ -1,0 +1,84 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests BaseNotificationPipeline."""
+
+import mock
+import tempfile
+import unittest
+
+from datetime import datetime
+
+import MySQLdb
+
+from google.cloud.security.notifier.pipelines import base_notification_pipeline as bnp
+from tests.unittest_utils import ForsetiTestCase
+
+class FakePipeline(bnp.BaseNotificationPipeline):
+    def run():
+        pass
+
+
+class BaseNotificationPipelineTest(ForsetiTestCase):
+    """Tests for base_notification_pipeline."""
+
+    @mock.patch(
+        'google.cloud.security.common.data_access._db_connector.DbConnector',
+        autospec=True)
+    def setUp(self, mock_conn):
+        """Setup."""
+        fake_global_conf = {
+            'db_host': 'x',
+            'db_name': 'y',
+            'db_user': 'z',
+        }
+        fake_pipeline_conf = {
+            'gcs_path': 'gs://blah'
+        }
+
+        self.fake_pipeline = FakePipeline(
+            'abc', '123', None, fake_global_conf, {}, fake_pipeline_conf)
+
+    @mock.patch(
+        'google.cloud.security.common.data_access.violation_dao.ViolationDao',
+        autospec=True)
+    def test_get_violation_dao(self, mock_violation_dao):
+        """Test _get_violation_dao()."""
+        self.fake_pipeline._get_violation_dao()
+        mock_violation_dao.assert_called_once_with(self.fake_pipeline.global_configs)
+
+    @mock.patch.object(bnp.BaseNotificationPipeline, '_get_violation_dao')
+    def test_get_violations(self, mock_violation_dao):
+        """Test _get_violations()."""
+        fake_timestamp = '1111'
+
+        got_violations = ['a', 'b', 'c']
+        got_bucket_acl_violations = ['x', 'y', 'z']
+
+        mock_get_all_violations = mock.MagicMock(
+            side_effect=[got_violations, got_bucket_acl_violations])
+
+        mock_violation_dao.return_value.get_all_violations = mock_get_all_violations
+
+        expected = {
+            'violations': got_violations,
+            'bucket_acl_violations': got_bucket_acl_violations
+        }
+        actual = self.fake_pipeline._get_violations(fake_timestamp)
+        self.assertEquals(expected, actual)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/notifier/pipelines/email_inventory_snapshot_summary_pipeline_test.py
+++ b/tests/notifier/pipelines/email_inventory_snapshot_summary_pipeline_test.py
@@ -60,7 +60,8 @@ class EmailInventorySnapshotSummaryPipelineTest(ForsetiTestCase):
         expected_subject = ('Inventory Snapshot Complete: '
                             '20001225T010000Z SUCCESS')
         expected_content = (
-            u'<!--\nCopyright 2017 Google Inc.\n\nLicensed under the Apache '
+            u'<!--\nCopyright 2017 The Forseti Security Authors. '
+            'All rights reserved.\n\nLicensed under the Apache '
             'License, Version 2.0 (the \"License\");\nyou may not use this '
             'file except in compliance with the License.\nYou may obtain a '
             'copy of the License at\n\n    '

--- a/tests/notifier/pipelines/gcs_violations_pipeline_test.py
+++ b/tests/notifier/pipelines/gcs_violations_pipeline_test.py
@@ -1,0 +1,98 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests the GCS Violations upload pipeline."""
+
+import mock
+import tempfile
+import unittest
+
+from datetime import datetime
+
+from google.cloud.security.notifier.pipelines import gcs_violations_pipeline
+from tests.unittest_utils import ForsetiTestCase
+
+
+class GcsViolationsPipelineTest(ForsetiTestCase):
+    """Tests for gcs_violations_pipeline."""
+
+    def setUp(self):
+        """Setup."""
+        self.fake_utcnow = datetime(
+            year=1900, month=1, day=1, hour=0, minute=0, second=0,
+            microsecond=0)
+
+        fake_global_conf = {
+            'db_host': 'x',
+            'db_name': 'y',
+            'db_user': 'z',
+        }
+
+        fake_pipeline_conf = {
+            'gcs_path': 'gs://blah'
+        }
+
+        self.gvp = gcs_violations_pipeline.GcsViolationsPipeline(
+            'abcd',
+            '11111',
+            [],
+            fake_global_conf,
+            {},
+            fake_pipeline_conf)
+
+    @mock.patch(
+        'google.cloud.security.notifier.pipelines.gcs_violations_pipeline.datetime',
+        autospec=True)
+    def test_get_output_filename(self, mock_datetime):
+        """Test _get_output_filename()."""
+        mock_datetime.utcnow = mock.MagicMock()
+        mock_datetime.utcnow.return_value = self.fake_utcnow
+        output_timestamp = mock_datetime.utcnow().strftime(
+            gcs_violations_pipeline.OUTPUT_TIMESTAMP_FMT)
+
+        actual_filename = self.gvp._get_output_filename()
+        self.assertEquals(
+            gcs_violations_pipeline.VIOLATIONS_JSON_FMT.format(
+                self.gvp.resource, self.gvp.cycle_timestamp, output_timestamp),
+            actual_filename)
+
+    @mock.patch(
+        'google.cloud.security.common.gcp_api.storage.StorageClient',
+        autospec=True)
+    @mock.patch('tempfile.NamedTemporaryFile')
+    def test_run(self, mock_tempfile, mock_storage):
+        """Test run()."""
+        fake_tmpname = 'tmp_name'
+        fake_output_name = 'abc'
+
+        self.gvp._get_output_filename = mock.MagicMock(
+            return_value=fake_output_name)
+        gcs_path = '{}/{}'.format(
+            self.gvp.pipeline_config['gcs_path'],
+            fake_output_name)
+
+        mock_tmp_json = mock.MagicMock()
+        mock_tempfile.return_value.__enter__.return_value = mock_tmp_json
+        mock_tmp_json.name = fake_tmpname
+        mock_tmp_json.write = mock.MagicMock()
+
+        self.gvp.run()
+
+        mock_tmp_json.write.assert_called()
+        mock_storage.return_value.put_text_file.assert_called_once_with(
+            fake_tmpname, gcs_path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/notifier/pipelines/slack_webhook_pipeline_test.py
+++ b/tests/notifier/pipelines/slack_webhook_pipeline_test.py
@@ -48,6 +48,16 @@ class SlackWebhookPipelineTest(ForsetiTestCase):
 
             self.assertEqual(expected_output.strip(), actual_output.strip())
 
+    def test_no_url_no_run_pipeline(self):
+        """Test that no url for Slack pipeline will skip running."""
+        with mock.patch.object(slack_webhook_pipeline.SlackWebhookPipeline, '__init__', lambda x: None):
+            slack_pipeline = slack_webhook_pipeline.SlackWebhookPipeline()
+            slack_pipeline.pipeline_config = {}
+            slack_pipeline._compose = mock.MagicMock()
+            slack_pipeline.run()
+
+            slack_pipeline._compose.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
New pipeline to upload violations.json to GCS.

Also doing a bunch of cleanup and adding tests.
* Don't init the daos in the `__init__`, instead create `_get_*_dao()` methods
* Create a base_email_notification_pipeline so that non-email pipelines don't have to implement _send() and _compose()
* If Slack webhook_url is not configured, don't try to post the Slack notifications.

resolves #704 