### PR TITLE
Move allAuthenticatedUsers to special_group attribute in rule file

### DIFF
--- a/rules/bigquery_rules.yaml
+++ b/rules/bigquery_rules.yaml
@@ -16,11 +16,11 @@
 rules:
   - name: sample BigQuery rule to search for public datasets
     dataset_id: '*'
-    special_group: '*'
+    special_group: 'allAuthenticatedUsers'
     user_email: '*'
     domain: '*'
     group_email: '*'
-    role: 'allAuthenticatedUsers'
+    role: '*'
     resource:
       - type: organization
         resource_ids:


### PR DESCRIPTION
allAuthenticatedUsers is an attribute of special group, not role.

https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets

![image](https://user-images.githubusercontent.com/6977544/31729218-3f5d478c-b3e3-11e7-87b3-713654475076.png)
