### PR TITLE
Changes and improvements to the auto-deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,11 @@ services:
   - docker
 
 before_install:
+  # Update docker.
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y install docker-ce
   # Build the Forseti base image containing all the dependencies.
   - docker build -t forseti/base -f scripts/docker/base .
   # Build the Forseti image containing the dependencies and code.

--- a/deployment-templates/compute-engine/explain-instance.py
+++ b/deployment-templates/compute-engine/explain-instance.py
@@ -135,8 +135,7 @@ if [ -z "$FLUENTD" ]; then
 fi
 
 # Check whether Cloud SQL proxy is installed
-CLOUD_SQL_PROXY=$(ls $USER_HOME/cloud_sql_proxy)
-if [ -z "$CLOUD_SQL_PROXY" ]; then
+if ! [[ -x /usr/bin/cloud_sql_proxy ]]; then
     cd $USER_HOME
     wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 \
             -O /tmp/cloud_sql_proxy

--- a/deployment-templates/compute-engine/explain-instance.py
+++ b/deployment-templates/compute-engine/explain-instance.py
@@ -14,6 +14,8 @@
 
 """Creates a GCE instance template for Forseti Security."""
 
+SQL_PORT = '3306'
+
 def GenerateConfig(context):
     """Generate configuration."""
 
@@ -51,6 +53,19 @@ def GenerateConfig(context):
     ROOT_RESOURCE_ID = context.properties['root-resource-id']
 
     resources = []
+
+    EXPORT_INITIALIZE_VARS = (
+        'export SQL_PORT={0}\n'
+        'export CLOUDSQL_INSTANCE_ID="{1}"\n'
+        'export FORSETI_DB_NAME="{2}"\n'
+        'export EXPLAIN_DB_NAME="{3}"\n'
+        'export GSUITE_ADMIN_EMAIL="{4}"\n'
+        'export GSUITE_ADMIN_CREDENTIAL_PATH="{5}"\n'
+        'export ROOT_RESOURCE_ID="{6}"\n')
+    EXPORT_INITIALIZE_VARS = EXPORT_INITIALIZE_VARS.format(
+        SQL_PORT, SQL_INSTANCE_CONN_STRING, FORSETI_DB_NAME, EXPLAIN_DB_NAME,
+        GSUITE_ADMIN_EMAIL, GSUITE_SERVICE_ACCOUNT_PATH, ROOT_RESOURCE_ID)
+
 
     resources.append({
         'name': '{}-explain-vm'.format(context.env['deployment']),
@@ -114,18 +129,19 @@ USER_HOME=/home/ubuntu
 # Install fluentd if necessary
 FLUENTD=$(ls /usr/sbin/google-fluentd)
 if [ -z "$FLUENTD" ]; then
-      cd $USER_HOME
-      curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh
-      bash install-logging-agent.sh
+    cd $USER_HOME
+    curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh
+    bash install-logging-agent.sh
 fi
 
 # Check whether Cloud SQL proxy is installed
 CLOUD_SQL_PROXY=$(ls $USER_HOME/cloud_sql_proxy)
 if [ -z "$CLOUD_SQL_PROXY" ]; then
-        cd $USER_HOME
-        wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64
-        mv cloud_sql_proxy.linux.amd64 cloud_sql_proxy
-        chmod +x cloud_sql_proxy
+    cd $USER_HOME
+    wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 \
+            -O /tmp/cloud_sql_proxy
+    chmod 755 /tmp/cloud_sql_proxy
+    sudo mv /tmp/cloud_sql_proxy /usr/bin/cloud_sql_proxy
 fi
 
 # Install Forseti Security
@@ -138,57 +154,26 @@ pip install google-apputils grpcio grpcio-tools protobuf
 cd $USER_HOME
 
 # Download Forseti src; see DOWNLOAD_FORSETI
-{}
+{download_forseti_bash}
 python setup.py install
 
+# Export variables required by initialize_explain_services.sh.
+{export_initialize_vars}
 
-# Create upstart script for API server
-read -d '' API_SERVER << EOF
-[Unit]
-Description=Explain API Server
-[Service]
-Restart=always
-RestartSec=3
-ExecStart=/usr/local/bin/forseti_api '[::]:50051' 'mysql://root@127.0.0.1:3306/{}' 'mysql://root@127.0.0.1:3306/{}' '{}' '{}' '{}' playground explain inventory
-[Install]
-WantedBy=multi-user.target
-Wants=cloudsqlproxy.service
-EOF
-echo "$API_SERVER" > /lib/systemd/system/forseti.service
+# Start explain service depends on vars defined above.
+bash ./scripts/gcp_setup/bash_scripts/initialize_explain_services.sh
 
-read -d '' SQL_PROXY << EOF
-[Unit]
-Description=Explain Cloud SQL Proxy
-[Service]
-Restart=always
-RestartSec=3
-ExecStart=/home/ubuntu/cloud_sql_proxy -instances={}=tcp:3306
-[Install]
-WantedBy=forseti.service
-EOF
-echo "$SQL_PROXY" > /lib/systemd/system/cloudsqlproxy.service
-
+echo "Starting services."
 systemctl start cloudsqlproxy
-sleep 1
+sleep 5
 systemctl start forseti
+echo "Success! The Forseti API server has been started."
 
 
-""".format(
-
-    # install forseti
-    DOWNLOAD_FORSETI,
-    FORSETI_DB_NAME,
-    EXPLAIN_DB_NAME,
-    GSUITE_SERVICE_ACCOUNT_PATH,
-    GSUITE_ADMIN_EMAIL,
-    ROOT_RESOURCE_ID,
-
-    # cloud_sql_proxy
-    SQL_INSTANCE_CONN_STRING,
-)
+""".format(download_forseti_bash=DOWNLOAD_FORSETI,
+           export_initialize_vars=EXPORT_INITIALIZE_VARS)
                 }]
             }
         }
     })
-
     return {'resources': resources}

--- a/deployment-templates/compute-engine/explain-instance.py
+++ b/deployment-templates/compute-engine/explain-instance.py
@@ -56,7 +56,7 @@ def GenerateConfig(context):
 
     EXPORT_INITIALIZE_VARS = (
         'export SQL_PORT={0}\n'
-        'export CLOUDSQL_INSTANCE_ID="{1}"\n'
+        'export SQL_INSTANCE_CONN_STRING="{1}"\n'
         'export FORSETI_DB_NAME="{2}"\n'
         'export EXPLAIN_DB_NAME="{3}"\n'
         'export GSUITE_ADMIN_EMAIL="{4}"\n'

--- a/scripts/docker/cloudbuild.yaml
+++ b/scripts/docker/cloudbuild.yaml
@@ -1,0 +1,40 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This defines the build steps of Forseti docker images. The google container
+# builder must be invoked against the root of the git directory.
+#
+# Example invocation:
+#   gcloud container builds submit --config scripts/docker/cloudbuild.yaml ./
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--file=scripts/docker/base'
+  - '--tag=gcr.io/$PROJECT_ID/forseti-base'
+  - '.'
+  waitFor: ['-']
+  id: base
+
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--file=scripts/docker/forseti'
+  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/forseti-base'
+  - '--tag=gcr.io/$PROJECT_ID/forseti'
+  - '.'
+  waitFor: ['base']
+  id: forseti
+
+images: ['gcr.io/$PROJECT_ID/forseti-base', 'gcr.io/$PROJECT_ID/forseti']

--- a/scripts/docker/forseti
+++ b/scripts/docker/forseti
@@ -16,7 +16,8 @@
 # You still need to do all the other prereq GCP setup (e.g.
 # setting up service accounts, GCP infrastructure).
 
-FROM forseti/base
+ARG BASE_IMAGE=forseti/base
+FROM ${BASE_IMAGE}
 
 ADD . /forseti-security/
 WORKDIR /forseti-security/

--- a/scripts/gcp_setup/bash_scripts/initialize_explain_services.sh
+++ b/scripts/gcp_setup/bash_scripts/initialize_explain_services.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Try to guess if a user has invoked this unexpectedly, and print info.
+if [[ -z "${GSUITE_ADMIN_CREDENTIAL_PATH}" ]]; then
+    echo "This script is a piece of the IAM deployment infrastructure."
+    echo "It will be run during an automated deployment invoked during"
+    echo "a deployment started by iam_auto_deploy.sh. This script expects"
+    echo "to have root or unauthenticated sudo privileges on the target VM."
+fi
+
+set -o errexit
+set -o nounset
+
+# Reference all required bash varibles prior to running. Due to 'nounset', if
+# a caller fails to export the following expected environmental variables, this
+# script will fail immediately rather than partially succeeding.
+echo "CloudSQL Instance ID: ${CLOUDSQL_INSTANCE_ID}"
+echo "Local SQL port is: ${SQL_PORT}"
+echo "Forseti DB name: ${FORSETI_DB_NAME}"
+echo "Explain DB name: ${EXPLAIN_DB_NAME}"
+echo "GSuite admin email: ${GSUITE_ADMIN_EMAIL}"
+echo "Root resource ID: ${ROOT_RESOURCE_ID}"
+if ! [[ -f $GSUITE_ADMIN_CREDENTIAL_PATH ]]; then
+    echo "Could not find gsuite admin credentials." >&2
+    exit 1
+fi
+
+
+SQL_SERVER_LOCAL_ADDRESS="mysql://root@127.0.0.1:${SQL_PORT}"
+
+
+FORSETI_COMMAND="$(which forseti_api) '[::]:50051'"
+FORSETI_COMMAND+=" ${SQL_SERVER_LOCAL_ADDRESS}/${FORSETI_DB_NAME}"
+FORSETI_COMMAND+=" ${SQL_SERVER_LOCAL_ADDRESS}/${EXPLAIN_DB_NAME}"
+FORSETI_COMMAND+=" ${GSUITE_ADMIN_CREDENTIAL_PATH}"
+FORSETI_COMMAND+=" ${GSUITE_ADMIN_EMAIL}"
+FORSETI_COMMAND+=" ${ROOT_RESOURCE_ID}"
+FORSETI_COMMAND+=" playground explain inventory"
+
+
+SQL_PROXY_COMMAND="$(which cloud_sql_proxy)"
+SQL_PROXY_COMMAND+=" -instances=${CLOUDSQL_INSTANCE_ID}=tcp:${SQL_PORT}"
+
+
+# Cannot use "read -d" since it returns a nonzero exit status.
+API_SERVICE="$(cat << EOF
+[Unit]
+Description=Explain API Server
+[Service]
+Restart=always
+RestartSec=3
+ExecStart=$FORSETI_COMMAND
+[Install]
+WantedBy=multi-user.target
+Wants=cloudsqlproxy.service
+EOF
+)"
+echo "$API_SERVICE" > /tmp/forseti.service
+sudo mv /tmp/forseti.service /lib/systemd/system/forseti.service
+
+
+SQL_PROXY_SERVICE="$(cat << EOF
+[Unit]
+Description=Explain Cloud SQL Proxy
+[Service]
+Restart=always
+RestartSec=3
+ExecStart=$SQL_PROXY_COMMAND
+[Install]
+WantedBy=forseti.service
+EOF
+)"
+echo "$SQL_PROXY_SERVICE" > /tmp/cloudsqlproxy.service
+sudo mv /tmp/cloudsqlproxy.service /lib/systemd/system/cloudsqlproxy.service
+
+
+# Define a foreground runner. This runner will start the CloudSQL
+# proxy and block on the forseti API server.
+FOREGROUND_RUNNER="$(cat << EOF
+$SQL_PROXY_COMMAND &&
+$FORSETI_COMMAND
+EOF
+)"
+echo "$FOREGROUND_RUNNER" > /tmp/iamexplain-foreground.sh
+chmod 755 /tmp/iamexplain-foreground.sh
+sudo mv /tmp/iamexplain-foreground.sh /usr/bin/iamexplain-foreground.sh
+
+echo "Explain services are now registered with systemd. Services can be started"
+echo "immediately by running the following:"
+echo "    systemctl start cloudsqlproxy"
+echo "    systemctl start forseti"
+echo ""
+echo "Additionally, the IAM Explain server can be run in the foreground by using"
+echo "the foreground runner script: /usr/bin/iamexplain-foreground.sh"

--- a/scripts/gcp_setup/bash_scripts/initialize_explain_services.sh
+++ b/scripts/gcp_setup/bash_scripts/initialize_explain_services.sh
@@ -28,7 +28,7 @@ set -o nounset
 # Reference all required bash varibles prior to running. Due to 'nounset', if
 # a caller fails to export the following expected environmental variables, this
 # script will fail immediately rather than partially succeeding.
-echo "CloudSQL Instance ID: ${CLOUDSQL_INSTANCE_ID}"
+echo "CloudSQL Instance connection string: ${SQL_INSTANCE_CONN_STRING}"
 echo "Local SQL port is: ${SQL_PORT}"
 echo "Forseti DB name: ${FORSETI_DB_NAME}"
 echo "Explain DB name: ${EXPLAIN_DB_NAME}"
@@ -53,7 +53,7 @@ FORSETI_COMMAND+=" playground explain inventory"
 
 
 SQL_PROXY_COMMAND="$(which cloud_sql_proxy)"
-SQL_PROXY_COMMAND+=" -instances=${CLOUDSQL_INSTANCE_ID}=tcp:${SQL_PORT}"
+SQL_PROXY_COMMAND+=" -instances=${SQL_INSTANCE_CONN_STRING}=tcp:${SQL_PORT}"
 
 
 # Cannot use "read -d" since it returns a nonzero exit status.

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -15,8 +15,6 @@
 
 # A git pre-commit hook to perform linter checks to catch errors locally
 
-# TODO:
-
 # Check if the user is in a virtual environment
 echo -n "Checking for a virtual env..."
 if [ -z $VIRTUAL_ENV ]; then
@@ -37,17 +35,17 @@ fi
 echo " ok."
 
 # Check for TODOs
-echo -n "Checking for TODOs..."
-for FILE in `git diff --name-only --cached`; do
-    if [ -a FILE ]; then
-      egrep -i '# TODO: ' $FILE 2>&1 >/dev/null
-      if [ $? -eq 0 ]; then
-          let TODO_MATCH=1
-          echo $FILE ' contains a TODO'
+TODO_MATCH=false
+echo "Checking for TODOs..."
+for FILE in $(git diff --name-only --cached); do
+    if [ -a "$FILE" ]; then
+      if grep -qEi "'#\s*TODO(\([a-z0-9_-]+\))?\:'" "$FILE"; then
+          TODO_MATCH=true
+          echo "${FILE} contains a TODO"
       fi
     fi
 done
-if [ -z $TODO_MATCH ]; then
+if $TODO_MATCH; then
     echo " Oops, there are some TODOs to fix. If you really must you can
     pass in --no-verify."
     exit 1

--- a/scripts/iam_auto_deployment.sh
+++ b/scripts/iam_auto_deployment.sh
@@ -13,11 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o errexit
+
 # Preparation
 TRED='\e[91m'
 TYELLOW='\e[93m'
 TGREEN='\e[92m'
 TNC='\033[0m'
+LABEL_SAFE_TIMESTAMP=$(date --utc +%Ft%Tz | sed -e 's/:/-/g')
 # Set the toplevel forseti folder.
 if command -v git > /dev/null; then
 	repodir="$(git rev-parse --show-toplevel 2> /dev/null || echo "/home/$USER/forseti-security")"
@@ -25,7 +28,42 @@ else
 	repodir="/home/$USER/forseti-security"
 fi
 
+# Config variables: the following variables are set during config and
+# are used to prepare, conifgure, or execute deployment. They are
+# pre-set here in order to document document the variables and to ensure
+# that they are in the shells global namespace.
+ROOTTYPE=""
+ROOTID=""
+SCRAPINGSA=""
+GSUITE_ADMINISTRATOR=""
+BRANCHNAME=""
+SQLINSTANCE=""
+PROJECT_ID=""
+DEPLOYMENTNAME=""
+
+# WARNING: THESE VALUES ARE NOT CONFIGURABLE!
+# These defaults match values contained in the example deployment YAMLs.
+# These should not be considered to be configurable but they are placed
+# here to avoid repetition.
+FORSETI_DB_NAME="forseti_security"
+EXPLAIN_DB_NAME="explain_security"
+COMPUTE_REGION="us-central1"
+COMPUTE_ZONE="us-central1-c"
+
+
 echo -e "${TGREEN}Welcome to IAM Explain${TNC}"
+
+# Get project information
+echo -e "${TYELLOW}Getting Project ID from your Cloud SDK config${TNC}"
+
+PROJECT_ID="$(gcloud config get-value project)"
+echo "Using '${PROJECT_ID}', would you like to continue?"
+read -p "Shall we proceed? (Y/n)" -n 1 -r
+echo
+if [[ "${REPLY:-y}" =~ ^[Nn]$ ]]; then
+	echo "Project not confirmed. Set with 'gcloud config set project YOUR-PROJECT-ID'"
+	exit 1
+fi
 
 # Set Organization ID
 echo -e "${TYELLOW}Setting up organization ID${TNC}"
@@ -148,12 +186,6 @@ then
 	done
 fi
 
-# Get project information
-echo "Fetching deployment project ID from your Cloud SDK config"
-
-PROJECT_ID="$(gcloud config get-value project)"
-echo "Found: ${PROJECT_ID}"
-
 # Checking user authority
 echo -e "${TYELLOW}Please make sure you have adequate permissions on GCP and GSuite in order to deploy IAM Explain ${TNC}"
 read -p "Press any key to proceed" -n 1 -r
@@ -208,7 +240,10 @@ echo "    Cloud SQL Admin API: sqladmin.googleapis.com"
 echo "    Cloud SQL API: sql-component.googleapis.com"
 echo "    Compute Engine API: compute.googleapis.com"
 echo "    Deployment Manager API: deploymentmanager.googleapis.com"
+echo "    Google Cloud Container Builder API: cloudbuild.googleapis.com"
 echo "    Google Identity and Access Management (IAM) API: iam.googleapis.com"
+echo "    Google BigQuery API: bigquery-json.googleapis.com"
+echo "    Google Cloud Storage API: storage.googleapis.com"
 read -p "Do you want to use the script to enable them? (y/n)" -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
@@ -220,8 +255,10 @@ then
 	gcloud beta service-management enable sql-component.googleapis.com
 	gcloud beta service-management enable compute.googleapis.com
 	gcloud beta service-management enable deploymentmanager.googleapis.com
+	gcloud beta service-management enable cloudbuild.googleapis.com
 	gcloud beta service-management enable iam.googleapis.com
 	gcloud beta service-management enable bigquery-json.googleapis.com
+	gcloud beta service-management enable storage.googleapis.com
 else
 	echo "API Enabling skipped, if you haven't enable them, you can do so in cloud console."
 fi
@@ -331,24 +368,17 @@ then
 	$CmdPrefix add-iam-policy-binding $ROOTID \
 	 --member=serviceAccount:$SCRAPINGSA \
 	 --role=roles/storage.admin
-	
+
+	gcloud projects add-iam-policy-binding $PROJECT_ID \
+	 --member=serviceAccount:$SCRAPINGSA \
+	 --role=roles/storage.admin
+
 	gcloud projects add-iam-policy-binding $PROJECT_ID \
 	 --member=serviceAccount:$SCRAPINGSA \
 	 --role=roles/cloudsql.client
 else
 	echo "Roles assigning skipped, if you haven't done it, you can do so in cloud console."
 fi
-
-# Prepare the deployment template yaml file
-echo "Customizing deployment template..."
-cp $repodir/deployment-templates/deploy-explain.yaml.sample \
-$repodir/deployment-templates/deploy-explain.yaml
-sed -i -e 's/ROOT_RESOURCE_ID/'$ROOTTYPE$"\/"$ROOTID'/g' \
-$repodir/deployment-templates/deploy-explain.yaml
-sed -i -e 's/YOUR_SERVICE_ACCOUNT/'$SCRAPINGSA'/g' \
-$repodir/deployment-templates/deploy-explain.yaml
-sed -i -e 's/GSUITE_ADMINISTRATOR/'$GSUITE_ADMINISTRATOR'/g' \
-$repodir/deployment-templates/deploy-explain.yaml
 
 #Choose deployment branch
 echo -e "${TYELLOW}Choosing Github Branch${TNC}"
@@ -375,13 +405,10 @@ then
 else
 	BRANCHNAME="master"
 fi
-sed -i -e 's/BRANCHNAME/'$BRANCHNAME'/g' \
-$repodir/deployment-templates/deploy-explain.yaml
 
 # sql instance name
 echo -e "${TYELLOW}Choosing SQL Instance name${TNC}"
-timestamp=$(date --utc +%Ft%Tz | sed -e 's/:/-/g')
-SQLINSTANCE="iam-explain-no-external-"$timestamp
+SQLINSTANCE="iam-explain-no-external-"$LABEL_SAFE_TIMESTAMP
 echo "Do you want to use the generated sql instance name:"
 echo "    $SQLINSTANCE"
 read -p "for this deployment? (y/n)" -n 1 -r
@@ -394,24 +421,44 @@ then
 		"sql instance can still occupy the name space, even though they are not shown above:"
 	read SQLINSTANCE
 fi
-sed -i -e 's/ iam-explain-sql-instance/ '$SQLINSTANCE'/g' \
-$repodir/deployment-templates/deploy-explain.yaml
+
+# Taking as an argument a basename, this generates a default deployment
+# name and directs a user to accept this name or provide their own.
+function read_deployment_name() {
+	# Deployment name
+	local DEFAULT_BASENAME="${1}"
+	echo -e "\n${TYELLOW}Choosing deployment name${TNC}"
+	DEPLOYMENTNAME="${DEFAULT_BASENAME}-${LABEL_SAFE_TIMESTAMP}"
+	echo "Do you want to use the generated deployment name:"
+	echo "    $DEPLOYMENTNAME"
+	read -p "for this deployment? (y/n)" -n 1 -r
+	echo
+	if [[ ! $REPLY =~ ^[Yy]$ ]]
+	then
+		echo "Here are existing deployments in this project:"
+		gcloud deployment-manager deployments list
+		echo "Choose a deployment name that is not used above"
+		read DEPLOYMENTNAME
+	fi
+}
 
 # Deployment name
-echo -e "${TYELLOW}Choosing deployment name${TNC}"
-DEPLOYMENTNAME="iam-explain-"$timestamp
-echo "Do you want to use the generated deployment name:"
-echo "    $DEPLOYMENTNAME"
-read -p "for this deployment? (y/n)" -n 1 -r
-echo
-if [[ ! $REPLY =~ ^[Yy]$ ]]
-then
-	echo "Here are existing deployments in this project:"
-	gcloud deployment-manager deployments list
-	echo "Choose a deployment name that is not used above"
-	read DEPLOYMENTNAME
-fi
+read_deployment_name "iam-explain"
 
+# Prepare the deployment template yaml file
+echo "Customizing deployment template..."
+cp $repodir/deployment-templates/deploy-explain.yaml.sample \
+$repodir/deployment-templates/deploy-explain.yaml
+sed -i -e 's/ROOT_RESOURCE_ID/'$ROOTTYPE$"\/"$ROOTID'/g' \
+$repodir/deployment-templates/deploy-explain.yaml
+sed -i -e 's/YOUR_SERVICE_ACCOUNT/'$SCRAPINGSA'/g' \
+$repodir/deployment-templates/deploy-explain.yaml
+sed -i -e 's/GSUITE_ADMINISTRATOR/'$GSUITE_ADMINISTRATOR'/g' \
+$repodir/deployment-templates/deploy-explain.yaml
+sed -i -e 's/ iam-explain-sql-instance/ '$SQLINSTANCE'/g' \
+$repodir/deployment-templates/deploy-explain.yaml
+sed -i -e 's/BRANCHNAME/'$BRANCHNAME'/g' \
+$repodir/deployment-templates/deploy-explain.yaml
 
 # Deploy the IAM Explain
 echo -e "${TYELLOW}Start to deploy${TNC}"
@@ -424,7 +471,7 @@ VMNAME=$(echo "$response" | grep " compute." | sed -e 's/ .*//g')
 echo -e "${TYELLOW}Generate and copy the gsuite service account key file${TNC}"
 # Creating gsuite service account key
 gcloud iam service-accounts keys create \
-    ~/gsuite.json \
+    "${HOME}/gsuite.json" \
     --iam-account $GSUITESA
 
 for (( TRIAL=1; TRIAL<=5; TRIAL++ ))
@@ -440,9 +487,9 @@ do
 	for (( trial=1; trial<=10; trial++ ))
 	do
 		sleep 2
-		gcloud compute scp ~/gsuite.json \
+		gcloud compute scp "${HOME}/gsuite.json" \
 			ubuntu@$VMNAME:/home/ubuntu/gsuite.json \
-			--zone=us-central1-c &&
+			--zone=$COMPUTE_ZONE &&
 		{
 			cpResponse="SUCCESS"
 			break
@@ -453,8 +500,8 @@ do
 	fi
 done
 echo "Destroying the gsuite service account key..."
-shred -vzn 3 gsuite.json
-rm -f gsuite.json
+shred -vzn 3 "${HOME}/gsuite.json"
+rm -f "${HOME}/gsuite.json"
 
 if [[ $cpResponse != "SUCCESS" ]]; then
 	echo "Service account key copy failed."


### PR DESCRIPTION
Hey - I'm trying a different route of deploying the IAM Explain inventory crawler. The following changes substantially reduce the work of keeping my changes synced. On top of that I think there's some general improvements available here, among them:

Improvements:
  1) iam_auto_deployment.sh 
     * Fixed the script's failure to delete the service account key.
     * Improved readability by making the config variables more explicit.
     * Enabled strict bash syntax.
  2) I added a cloud builder YAML for the dockerfiles.
  
Refactoring:
  I factored the service creation step out of the explain-instance deployment
  template. This simplifies reuse of that step in other deployment schemes. For
  example; Initializing in docker would be far easier with this step factored out.

PR checklist:
- [NA] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [yes] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [NA] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [NA] My PR has been functionally tested.
- [yes] All of the unit-tests still pass.
- [yes] Running `pylint --rcfile=pylintrc` passes.