### PR TITLE
Integrate Inventory2 Data with Forseti Storage

### DIFF
--- a/google/cloud/security/iam/explain/importer/importer.py
+++ b/google/cloud/security/iam/explain/importer/importer.py
@@ -312,38 +312,39 @@ class InventoryImporter(object):
             item_counter = 0
             last_res_type = None
 
-            with Inventory(self.session, self.inventory_id, True) as inventory:
-
-                for resource in inventory.iter(['organization']):
-                    self.found_root = True
-                if not self.found_root:
-                    raise Exception(
-                        'Cannot import inventory without organization root')
-
-                for resource in inventory.iter(gcp_type_list):
-                    item_counter += 1
-                    last_res_type = self._store_resource(resource,
-                                                         last_res_type)
-                self._store_resource(None, last_res_type)
-                self.session.flush()
-
-                for resource in inventory.iter(gsuite_type_list):
-                    self._store_gsuite_principal(resource)
-                self.session.flush()
-
-                self._store_gsuite_membership_pre()
-                for child, parent in inventory.iter(member_type_list,
-                                                    with_parent=True):
-                    self._store_gsuite_membership(parent, child)
-                self._store_gsuite_membership_post()
-
-                self.dao.denorm_group_in_group(self.session)
-
-                self._store_iam_policy_pre()
-                for policy in inventory.iter(gcp_type_list,
-                                             fetch_iam_policy=True):
-                    self._store_iam_policy(policy)
-                self._store_iam_policy_post()
+            with self.service_config.forseti_scoped_session() as forseti_session:
+                with Inventory(forseti_session, self.inventory_id, True) as inventory:
+                
+                    for resource in inventory.iter(['organization']):
+                        self.found_root = True
+                    if not self.found_root:
+                        raise Exception(
+                            'Cannot import inventory without organization root')
+        
+                    for resource in inventory.iter(gcp_type_list):
+                        item_counter += 1
+                        last_res_type = self._store_resource(resource,
+                                                             last_res_type)
+                    self._store_resource(None, last_res_type)
+                    self.session.flush()
+        
+                    for resource in inventory.iter(gsuite_type_list):
+                        self._store_gsuite_principal(resource)
+                    self.session.flush()
+        
+                    self._store_gsuite_membership_pre()
+                    for child, parent in inventory.iter(member_type_list,
+                                                        with_parent=True):
+                        self._store_gsuite_membership(parent, child)
+                    self._store_gsuite_membership_post()
+        
+                    self.dao.denorm_group_in_group(self.session)
+        
+                    self._store_iam_policy_pre()
+                    for policy in inventory.iter(gcp_type_list,
+                                                 fetch_iam_policy=True):
+                        self._store_iam_policy(policy)
+                    self._store_iam_policy_post()
 
         except Exception:  # pylint: disable=broad-except
             buf = StringIO()

--- a/google/cloud/security/iam/explain/importer/importer.py
+++ b/google/cloud/security/iam/explain/importer/importer.py
@@ -311,6 +311,7 @@ class InventoryImporter(object):
             self.session.autoflush = False
             item_counter = 0
             last_res_type = None
+
             with Inventory(self.session, self.inventory_id, True) as inventory:
 
                 for resource in inventory.iter(['organization']):
@@ -975,7 +976,11 @@ class InventoryImporter(object):
 
 
 class ForsetiImporter(object):
-    """Imports data from Forseti."""
+    """Imports data from Forseti.
+
+    TODO: Delete this class when the forseti inventory pipelines are no longer
+    supported.
+    """
 
     def __init__(self, session, model, dao, service_config, *args, **kwargs):
         """Create a ForsetiImporter which creates a model from the Forseti DB.

--- a/google/cloud/security/iam/explain/importer/importer.py
+++ b/google/cloud/security/iam/explain/importer/importer.py
@@ -312,34 +312,36 @@ class InventoryImporter(object):
             item_counter = 0
             last_res_type = None
 
-            with self.service_config.forseti_scoped_session() as forseti_session:
-                with Inventory(forseti_session, self.inventory_id, True) as inventory:
-                
+            with self.service_config.forseti_scoped_session() as \
+                forseti_session:
+                with Inventory(
+                    forseti_session, self.inventory_id, True) as inventory:
+
                     for resource in inventory.iter(['organization']):
                         self.found_root = True
                     if not self.found_root:
                         raise Exception(
                             'Cannot import inventory without organization root')
-        
+
                     for resource in inventory.iter(gcp_type_list):
                         item_counter += 1
                         last_res_type = self._store_resource(resource,
                                                              last_res_type)
                     self._store_resource(None, last_res_type)
                     self.session.flush()
-        
+
                     for resource in inventory.iter(gsuite_type_list):
                         self._store_gsuite_principal(resource)
                     self.session.flush()
-        
+
                     self._store_gsuite_membership_pre()
                     for child, parent in inventory.iter(member_type_list,
                                                         with_parent=True):
                         self._store_gsuite_membership(parent, child)
                     self._store_gsuite_membership_post()
-        
+
                     self.dao.denorm_group_in_group(self.session)
-        
+
                     self._store_iam_policy_pre()
                     for policy in inventory.iter(gcp_type_list,
                                                  fetch_iam_policy=True):
@@ -977,7 +979,7 @@ class InventoryImporter(object):
 
 
 class ForsetiImporter(object):
-    """Imports data from Forseti.
+    """Imports data from Forseti data pipelines.
 
     TODO: Delete this class when the forseti inventory pipelines are no longer
     supported.

--- a/google/cloud/security/iam/server.py
+++ b/google/cloud/security/iam/server.py
@@ -235,11 +235,13 @@ class ServiceConfig(AbstractServiceConfig):
         super(ServiceConfig, self).__init__()
         self.thread_pool = ThreadPool()
         self.engine = create_engine(explain_connect_string, pool_recycle=3600)
-        self.forseti_engine = create_engine(forseti_connect_string, pool_recycle=3600)
-        self.model_manager = ModelManager(self.forseti_engine)
+        self.forseti_engine = create_engine(forseti_connect_string,
+                                            pool_recycle=3600)
+        self.model_manager = ModelManager(self.engine)
         self.forseti_connect_string = forseti_connect_string
         self.sessionmaker = db.create_scoped_sessionmaker(self.engine)
-        self.forseti_sessionmaker = db.create_scoped_sessionmaker(self.forseti_engine)
+        self.forseti_sessionmaker = db.create_scoped_sessionmaker(
+            self.forseti_engine)
         self.endpoint = endpoint
 
         self.inventory_config = inventory_config

--- a/google/cloud/security/iam/server.py
+++ b/google/cloud/security/iam/server.py
@@ -235,9 +235,11 @@ class ServiceConfig(AbstractServiceConfig):
         super(ServiceConfig, self).__init__()
         self.thread_pool = ThreadPool()
         self.engine = create_engine(explain_connect_string, pool_recycle=3600)
-        self.model_manager = ModelManager(self.engine)
+        self.forseti_engine = create_engine(forseti_connect_string, pool_recycle=3600)
+        self.model_manager = ModelManager(self.forseti_engine)
         self.forseti_connect_string = forseti_connect_string
         self.sessionmaker = db.create_scoped_sessionmaker(self.engine)
+        self.forseti_sessionmaker = db.create_scoped_sessionmaker(self.forseti_engine)
         self.endpoint = endpoint
 
         self.inventory_config = inventory_config
@@ -261,6 +263,15 @@ class ServiceConfig(AbstractServiceConfig):
 
         return self.engine
 
+    def get_forseti_engine(self):
+        """Get the forseti database engine.
+
+        Returns:
+            object: Database engine object.
+        """
+
+        return self.forseti_engine
+
     def scoped_session(self):
         """Get a scoped session.
 
@@ -269,6 +280,15 @@ class ServiceConfig(AbstractServiceConfig):
         """
 
         return self.sessionmaker()
+
+    def forseti_scoped_session(self):
+        """Get a forseti scoped session.
+
+        Returns:
+            object: A scoped session.
+        """
+
+        return self.forseti_sessionmaker()
 
     def client(self):
         """Get an API client.

--- a/google/cloud/security/iam/server.py
+++ b/google/cloud/security/iam/server.py
@@ -223,6 +223,7 @@ class InventoryConfig(AbstractInventoryConfig):
         return self.record_file
 
 
+# pylint: disable=too-many-instance-attributes
 class ServiceConfig(AbstractServiceConfig):
     """Implements composed dependency injection to IAM Explain services."""
 
@@ -314,6 +315,7 @@ class ServiceConfig(AbstractServiceConfig):
         """
 
         return Storage
+# pylint: enable=too-many-instance-attributes
 
 
 def serve(endpoint, services,

--- a/google/cloud/security/inventory/inventory.py
+++ b/google/cloud/security/inventory/inventory.py
@@ -171,7 +171,7 @@ class Inventory(object):
 
     def __init__(self, config):
         self.config = config
-        init_storage(self.config.get_engine())
+        init_storage(self.config.get_forseti_engine())
 
     def Create(self, background, model_name):
         """Create a new inventory,
@@ -193,7 +193,7 @@ class Inventory(object):
         def do_inventory():
             """Run the inventory."""
 
-            with self.config.scoped_session() as session:
+            with self.config.forseti_scoped_session() as session:
                 try:
                     result = run_inventory(
                         self.config,
@@ -232,7 +232,7 @@ class Inventory(object):
             object: Inventory metadata
         """
 
-        with self.config.scoped_session() as session:
+        with self.config.forseti_scoped_session() as session:
             for item in DataAccess.list(session):
                 yield item
 
@@ -246,7 +246,7 @@ class Inventory(object):
             object: Inventory metadata
         """
 
-        with self.config.scoped_session() as session:
+        with self.config.forseti_scoped_session() as session:
             result = DataAccess.get(session, inventory_id)
             return result
 
@@ -260,6 +260,6 @@ class Inventory(object):
             object: Inventory object that was deleted
         """
 
-        with self.config.scoped_session() as session:
+        with self.config.forseti_scoped_session() as session:
             result = DataAccess.delete(session, inventory_id)
             return result


### PR DESCRIPTION
This PR follows-up on PR #731:
- Inventory2 data will be saved to Forseti DB
- Importer will pull Inventory2 data from Forseti DB to build the models
- models data will be saved to Explain DB.

I am still getting up to speed on sqlalchemy sessions and how to best manage them.  So, I'm all open to any suggestions for the work in this PR.