### PR TITLE
Tweak the iam rule naming to be consistent.

### DIFF
--- a/rules/iam_rules.yaml
+++ b/rules/iam_rules.yaml
@@ -29,7 +29,7 @@ rules:
           - group:*@YOURDOMAIN
 
   # custom rules
-  - name: Allow service accounts to have access
+  - name: Only allow service accounts to have access
     mode: whitelist
     resource:
       - type: organization

--- a/rules/iam_rules.yaml
+++ b/rules/iam_rules.yaml
@@ -14,7 +14,7 @@
 
 rules:
   # default rules
-  - name: Allow only IAM members in my domain to be an OrgAdmin
+  - name: Only allow only IAM members in my domain to be an OrgAdmin
     mode: whitelist
     resource:
       - type: organization

--- a/rules/iam_rules.yaml
+++ b/rules/iam_rules.yaml
@@ -14,7 +14,7 @@
 
 rules:
   # default rules
-  - name: Only allow only IAM members in my domain to be an OrgAdmin
+  - name: Allow only IAM members in my domain to be an OrgAdmin
     mode: whitelist
     resource:
       - type: organization
@@ -29,7 +29,7 @@ rules:
           - group:*@YOURDOMAIN
 
   # custom rules
-  - name: Only allow service accounts to have access
+  - name: Allow only service accounts to have access
     mode: whitelist
     resource:
       - type: organization


### PR DESCRIPTION
This makes the ```Allow only service accounts to have access``` rule naming to be consistent with the ```Allow only IAM members in my domain to be an OrgAdmin``` rule naming.