### PR TITLE
Fix resource ancestry lookup

### DIFF
--- a/google/cloud/security/common/data_access/org_resource_rel_dao.py
+++ b/google/cloud/security/common/data_access/org_resource_rel_dao.py
@@ -64,24 +64,42 @@ class OrgResourceRelDao(object):
         while curr_resource is not None:
             parent_resource = None
 
+            # If we don't have parent information for the current
+            # resource, try to look it up.
+            if not curr_resource.parent:
+                curr_resource = self._load_resource(
+                    curr_resource, snapshot_timestamp)
+
             if (curr_resource.parent and
                     curr_resource.parent.type and
                     curr_resource.parent.id):
-                resource_lookup = self._resource_db_lookup.get(
-                    curr_resource.parent.type, {})
-
-                # No dao object for the parent resource, so quit
-                if not resource_lookup.get('dao'):
-                    break
-
-                # Invoke the dao.get_*() method, to get the parent resource
-                parent_resource = getattr(
-                    resource_lookup.get('dao'),
-                    resource_lookup.get('get'))(
-                        curr_resource.parent.id, snapshot_timestamp)
+                parent_resource = self._load_resource(
+                    curr_resource.parent, snapshot_timestamp)
 
             if parent_resource:
                 ancestors.append(parent_resource)
             curr_resource = parent_resource
 
         return ancestors
+
+    def _load_resource(self, unloaded_resource, snapshot_timestamp):
+        """Load the resource from the database.
+
+        Args:
+            unloaded_resource (Resource): The Resource to load.
+            snapshot_timestamp (str): The timestamp to use for data lookup.
+
+        Returns:
+            Resource: The resource.
+        """
+        loaded_resource = unloaded_resource
+        if unloaded_resource:
+            resource_lookup = self._resource_db_lookup.get(
+                unloaded_resource.type, {})
+            # Invoke the dao.get_*() method, to get the resource
+            if resource_lookup.get('dao'):
+                loaded_resource = getattr(
+                    resource_lookup.get('dao'),
+                    resource_lookup.get('get'))(
+                        unloaded_resource.id, snapshot_timestamp)
+        return loaded_resource

--- a/google/cloud/security/common/data_access/org_resource_rel_dao.py
+++ b/google/cloud/security/common/data_access/org_resource_rel_dao.py
@@ -93,13 +93,15 @@ class OrgResourceRelDao(object):
             Resource: The resource.
         """
         loaded_resource = unloaded_resource
-        if unloaded_resource:
-            resource_lookup = self._resource_db_lookup.get(
-                unloaded_resource.type, {})
-            # Invoke the dao.get_*() method, to get the resource
-            if resource_lookup.get('dao'):
-                loaded_resource = getattr(
-                    resource_lookup.get('dao'),
-                    resource_lookup.get('get'))(
-                        unloaded_resource.id, snapshot_timestamp)
+        if not unloaded_resource:
+            return unloaded_resource
+
+        resource_lookup = self._resource_db_lookup.get(
+            unloaded_resource.type, {})
+        # Invoke the dao.get_*() method, to get the resource
+        if resource_lookup.get('dao'):
+            loaded_resource = getattr(
+                resource_lookup.get('dao'),
+                resource_lookup.get('get'))(
+                    unloaded_resource.id, snapshot_timestamp)
         return loaded_resource

--- a/google/cloud/security/scanner/scanner.py
+++ b/google/cloud/security/scanner/scanner.py
@@ -16,8 +16,7 @@
 Usage:
 
   Run scanner:
-  $ forseti_scanner \\
-      --forseti_config (optional)
+  $ forseti_scanner --forseti_config
 """
 import sys
 
@@ -105,9 +104,6 @@ def main(_):
     runnable_scanners = scanner_builder.ScannerBuilder(
         global_configs, scanner_configs, snapshot_timestamp).build()
 
-    # TODO: Make resilient by letting the batch continue to run even if one
-    # scanner errors out.
-    # TODO: fix the bare except
     # pylint: disable=bare-except
     for scanner in runnable_scanners:
         try:

--- a/google/cloud/security/scanner/scanners/fw_rules_scanner.py
+++ b/google/cloud/security/scanner/scanners/fw_rules_scanner.py
@@ -152,8 +152,7 @@ class FwPolicyScanner(base_scanner.BaseScanner):
         """Find violations in the policies.
 
         Args:
-            policies (list): The a list of resource and policy tuples to find
-              violations in.
+            policies (list): The list of policies to find violations in.
 
         Returns:
             list: A list of all violations

--- a/google/cloud/security/scanner/scanners/iam_rules_scanner.py
+++ b/google/cloud/security/scanner/scanners/iam_rules_scanner.py
@@ -150,7 +150,8 @@ class IamPolicyScanner(base_scanner.BaseScanner):
         """Find violations in the policies.
 
         Args:
-            policies (list): The list of policies to find violations in.
+            policies (list): The list of (resource, policy) tuples to
+                find violations in.
 
         Returns:
             list: A list of all violations

--- a/tests/scanner/audit/fw_rules_engine_test.py
+++ b/tests/scanner/audit/fw_rules_engine_test.py
@@ -19,8 +19,6 @@ import parameterized
 
 from tests.unittest_utils import ForsetiTestCase
 from google.cloud.security.common.gcp_type.firewall_rule import FirewallRule
-from google.cloud.security.common.gcp_type.organization import Organization
-from google.cloud.security.common.gcp_type.project import Project
 from google.cloud.security.scanner.audit.errors import InvalidRulesSchemaError
 from google.cloud.security.scanner.audit import fw_rules_engine as fre
 from google.cloud.security.scanner.audit import rules as scanner_rules


### PR DESCRIPTION
The previous code assumed that the resource to lookup ancestry for already "knew" whether it had a parent. This fix checks if the resource has a parent supplied and if not, performs a lookup (just in case we didn't preload the data).