### PR TITLE
Notifier violations

### DIFF
--- a/configs/forseti_conf.yaml.in
+++ b/configs/forseti_conf.yaml.in
@@ -145,7 +145,7 @@ notifier:
     # to send alerts for every violation found
     resources:
         - resource: policy_violations
-          should_notify: true
+          should_notify: false
           pipelines:
             # Email violations
             - name: email_violations_pipeline
@@ -165,3 +165,57 @@ notifier:
             - name: slack_webhook_pipeline
               configuration:
                 webhook_url: ''
+
+        - resource: bigquery_acl_violations
+          should_notify: true
+          pipelines:
+            # Upload violations to GCS.
+            - name: gcs_violations_pipeline
+              configuration:
+                # gcs_path should begin with "gs://"
+                gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
+
+        - resource: buckets_acl_violations
+          should_notify: true
+          pipelines:
+            # Upload violations to GCS.
+            - name: gcs_violations_pipeline
+              configuration:
+                # gcs_path should begin with "gs://"
+                gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
+
+        - resource: cloudsql_acl_violations
+          should_notify: true
+          pipelines:
+            # Upload violations to GCS.
+            - name: gcs_violations_pipeline
+              configuration:
+                # gcs_path should begin with "gs://"
+                gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
+
+        - resource: forwarding_rule_violations
+          should_notify: true
+          pipelines:
+            # Upload violations to GCS.
+            - name: gcs_violations_pipeline
+              configuration:
+                # gcs_path should begin with "gs://"
+                gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
+
+        - resource: groups_violations
+          should_notify: true
+          pipelines:
+            # Upload violations to GCS.
+            - name: gcs_violations_pipeline
+              configuration:
+                # gcs_path should begin with "gs://"
+                gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
+
+        - resource: instance_network_interface_violations
+          should_notify: true
+          pipelines:
+            # Upload violations to GCS.
+            - name: gcs_violations_pipeline
+              configuration:
+                # gcs_path should begin with "gs://"
+                gcs_path: gs://{SCANNER_BUCKET}/scanner_violations

--- a/google/cloud/security/notifier/pipelines/gcs_violations_pipeline.py
+++ b/google/cloud/security/notifier/pipelines/gcs_violations_pipeline.py
@@ -51,12 +51,12 @@ class GcsViolationsPipeline(bnp.BaseNotificationPipeline):
     def run(self):
         """Generate the temporary json file and upload to GCS."""
         with tempfile.NamedTemporaryFile() as tmp_violations:
-            output_filename = self._get_output_filename()
             tmp_violations.write(parser.json_stringify(self.violations))
+            tmp_violations.flush()
 
             gcs_upload_path = '{}/{}'.format(
                 self.pipeline_config['gcs_path'],
-                output_filename)
+                self._get_output_filename())
 
             if gcs_upload_path.startswith('gs://'):
                 storage_client = storage.StorageClient()


### PR DESCRIPTION
Tweak the setup wizard default conf to upload violations to GCS for the violations that are not in (IAM, firewall, IAP).

Also call flush() on the temp file before uploading to GCS. For very small files (don't know the exact size, but anything under 1KB seemed to be fair game), we were uploading 0B files because the data hadn't been flushed. [StackOverflow link](https://stackoverflow.com/questions/9422478/why-does-tempfile-namedtemporaryfile-truncate-my-data)