### PR TITLE
Fix firewall rule sort

### DIFF
--- a/google/cloud/security/common/gcp_type/firewall_rule.py
+++ b/google/cloud/security/common/gcp_type/firewall_rule.py
@@ -811,9 +811,14 @@ def sort_rules(rules):
         return rules
     for rule in sorted(rules, key=lambda k: k.get('IPProtocol', '')):
         if 'ports' in rule:
-            # Sort ports numerically handle ranges through sorting by start port
-            rule['ports'] = sorted(rule['ports'],
-                                   key=lambda k: int(k.split('-')[0]))
+            # If the ports contains 'all', don't care about the other ports
+            # or sorting. Otherwise, sort ports numerically, and handle ranges
+            # through sorting by start port.
+            if 'all' in rule['ports']:
+                rule['ports'] = 'all'
+            else:
+                rule['ports'] = sorted(rule['ports'],
+                                       key=lambda k: int(k.split('-')[0]))
         sorted_rules.append(rule)
     return sorted_rules
 

--- a/google/cloud/security/scanner/scanners/fw_rules_scanner.py
+++ b/google/cloud/security/scanner/scanners/fw_rules_scanner.py
@@ -128,7 +128,7 @@ class FwPolicyScanner(base_scanner.BaseScanner):
                 # from the saved copy.
                 if self.global_configs.get('email_recipient') is not None:
                     payload = {
-                        'email_description': 'Policy Scan',
+                        'email_description': 'Firewall Rules Scan',
                         'email_sender':
                             self.global_configs.get('email_sender'),
                         'email_recipient':

--- a/tests/scanner/scanners/fw_rules_scanner_test.py
+++ b/tests/scanner/scanners/fw_rules_scanner_test.py
@@ -279,7 +279,7 @@ class FwRulesScannerTest(unittest_utils.ForsetiTestCase):
         expected_message = {
             'status': 'scanner_done',
             'payload': {
-                'email_description': 'Policy Scan',
+                'email_description': 'Firewall Rules Scan',
                 'email_sender':
                 self.scanner.global_configs.get('email_sender'),
                 'email_recipient':


### PR DESCRIPTION
If the firewall rule ports contains "all" ports, then don't bother sorting and just set the ports to "all". Otherwise, apply the sort function, which sorts the ports numerically.

resolves #759 