### PR TITLE
Add Org Policy support for cloud resource manager API.

### DIFF
--- a/google/cloud/forseti/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/forseti/common/gcp_api/cloud_resource_manager.py
@@ -180,7 +180,6 @@ class _ResourceManagerFoldersRepository(
         repository_mixins.GetQueryMixin,
         repository_mixins.GetIamPolicyQueryMixin,
         repository_mixins.ListQueryMixin,
-        repository_mixins.OrgPolicyQueryMixin,
         repository_mixins.SearchQueryMixin,
         _base_repository.GCPRepository):
     """Implementation of Cloud Resource Manager Folders repository."""

--- a/google/cloud/forseti/common/gcp_api/repository_mixins.py
+++ b/google/cloud/forseti/common/gcp_api/repository_mixins.py
@@ -162,6 +162,104 @@ class GetIamPolicyQueryMixin(object):
         )
 
 
+class OrgPolicyQueryMixin(object):
+    """Mixin that implements getOrgPolicy and listOrgPolicies query."""
+
+    def get_effective_org_policy(self, resource, constraint, fields=None,
+                                 verb='getEffectiveOrgPolicy', **kwargs):
+        """Get Effective Org Policy for a constraint on a resource.
+
+        Args:
+            self (GCPRespository): An instance of a GCPRespository class.
+            resource (str): The id of the resource to fetch.
+            constraint (str): The constraint name to fetch the policy for.
+            fields (str): Fields to include in the response - partial response.
+            verb (str): The method to call on the API.
+            **kwargs (dict): Optional additional arguments to pass to the query.
+
+        Returns:
+            dict: Response from the API.
+
+        Raises:
+            errors.HttpError: When attempting to get a non-existent entity.
+                ex: HttpError 404 when requesting ... returned
+                    "The resource '...' was not found"
+        """
+        arguments = {'resource': resource,
+                     'fields': fields}
+        arguments['body'] = {'constraint': constraint}
+        if kwargs:
+            arguments.update(kwargs)
+        return self.execute_query(
+            verb=verb,
+            verb_arguments=arguments,
+        )
+
+    def get_org_policy(self, resource, constraint, fields=None,
+                       verb='getOrgPolicy', **kwargs):
+        """Get Org Policy for a constraint on a resource.
+
+        Args:
+            self (GCPRespository): An instance of a GCPRespository class.
+            resource (str): The id of the resource to fetch.
+            constraint (str): The constraint name to fetch the policy for.
+            fields (str): Fields to include in the response - partial response.
+            verb (str): The method to call on the API.
+            **kwargs (dict): Optional additional arguments to pass to the query.
+
+        Returns:
+            dict: Response from the API.
+
+        Raises:
+            errors.HttpError: When attempting to get a non-existent entity.
+                ex: HttpError 404 when requesting ... returned
+                    "The resource '...' was not found"
+        """
+        arguments = {'resource': resource,
+                     'fields': fields}
+        arguments['body'] = {'constraint': constraint}
+        if kwargs:
+            arguments.update(kwargs)
+        return self.execute_query(
+            verb=verb,
+            verb_arguments=arguments,
+        )
+
+    def list_org_policies(self, resource, fields=None, max_results=None,
+                          verb='listOrgPolicies', **kwargs):
+        """List Org Policies applied to the resource.
+
+        Args:
+            self (GCPRespository): An instance of a GCPRespository class.
+            resource (str): The id of the resource to query.
+            fields (str): Fields to include in the response - partial response.
+            max_results (int): Number of entries to include per page.
+            verb (str): The method to call on the API.
+            **kwargs (dict): Optional additional arguments to pass to the query.
+
+        Yields:
+            dict: An API response containing one page of results.
+
+        Raises:
+            errors.HttpError: When attempting to get a non-existent entity.
+                ex: HttpError 404 when requesting ... returned
+                    "The resource '...' was not found"
+        """
+        arguments = {'resource': resource,
+                     'fields': fields}
+        arguments['body'] = {}
+        if max_results:
+            arguments['body']['pageSize'] = max_results
+
+        if kwargs:
+            arguments.update(kwargs)
+
+        for resp in self.execute_search_query(
+                verb=verb,
+                verb_arguments=arguments):
+            yield resp
+
+
 class SearchQueryMixin(object):
     """Mixin that implements a paged Search query."""
 

--- a/tests/common/gcp_api/test_data/fake_crm_responses.py
+++ b/tests/common/gcp_api/test_data/fake_crm_responses.py
@@ -58,7 +58,7 @@ GET_PROJECT_ANCESTRY_RESPONSE = """
 }
 """
 
-EXPECTED_PROJECT_ANCESTRY_IDs = ["forseti-system-test", "3333333", "2222222"]
+EXPECTED_PROJECT_ANCESTRY_IDS = ["forseti-system-test", "3333333", "2222222"]
 
 GET_IAM_POLICY = """
 {
@@ -143,6 +143,37 @@ GET_FOLDER = """
  "createTime": "2017-02-09T22:02:07.769Z"
 }
 """
+
+GET_ORG_POLICY_NO_POLICY = """
+{
+  "constraint": "constraints/compute.disableSerialPortAccess",
+  "etag": "BwVUSr8Q7Ng="
+}
+"""
+
+GET_EFFECTIVE_ORG_POLICY = """
+{
+  "constraint": "constraints/compute.disableSerialPortAccess",
+  "booleanPolicy": {
+   "enforced": true
+  }
+}
+"""
+
+LIST_ORG_POLICIES = """
+{
+ "policies": [
+  {
+    "constraint": "constraints/compute.disableSerialPortAccess",
+    "booleanPolicy": {
+     "enforced": true
+    }
+  }
+ ]
+}
+"""
+
+TEST_ORG_POLICY_CONSTRAINT = "constraints/compute.disableSerialPortAccess"
 
 # Errors
 


### PR DESCRIPTION
Ensure gcp_api2 cloud resource manager and gcp_api cloud resource manager libraries are compatible. This adds support for the get_org_org_policies method and extends it to support all resource types.

* List all org policies on folders, organizations or project resources.
* Get set or effective org policy for a given constraint on any resource.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
