### PR TITLE
Updated BigQuery rules and IAM deployment prerequisite

### DIFF
--- a/_docs/quickstarts/scanner/rules.md
+++ b/_docs/quickstarts/scanner/rules.md
@@ -131,11 +131,11 @@ BigQuery scanner rules serve as blacklists.
 rules:
   - name: sample BigQuery rule to search for public datasets
     dataset_id: '*'
-    special_group: '*'
+    special_group: 'allAuthenticatedUsers'
     user_email: '*'
     domain: '*'
     group_email: '*'
-    role: 'allAuthenticatedUsers'
+    role: '*'
     resource:
       - type: organization
         resource_ids:

--- a/_includes/docs/howto/deployment_prerequisites.md
+++ b/_includes/docs/howto/deployment_prerequisites.md
@@ -127,6 +127,11 @@ $ gcloud organizations add-iam-policy-binding ORGANIZATION_ID \
 --member=MEMBER_TYPE:MEMBER_NAME \
 --role=roles/compute.securityAdmin
 ```
+```bash
+$ gcloud organizations add-iam-policy-binding ORGANIZATION_ID \
+--member=MEMBER_TYPE:MEMBER_NAME \
+--role=roles/bigquery.dataViewer
+```
 
 _Project Cloud IAM roles_
 


### PR DESCRIPTION
Few small updates to documentation:
* Updated Scanner rule example to match the one in the main branch [dev/rules/bigquery_rules.yaml](https://github.com/GoogleCloudPlatform/forseti-security/blob/dev/rules/bigquery_rules.yaml) 
* BigQuery dataset ACL scanner/inventory requires bigquery.dataViewer roles, because other IAM roles doesn't contain bigquery.datasets.get permission.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [ ] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [ ] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [ ] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [ ] My PR has been functionally tested.
- [ ] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests) still pass.
- [ ] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
