### PR TITLE
Add a new utility for recording and replaying API requests.

### DIFF
--- a/google/cloud/forseti/common/util/replay.py
+++ b/google/cloud/forseti/common/util/replay.py
@@ -135,7 +135,6 @@ def replay(requests):
     Returns:
         function: Decorator function.
     """
-
     def decorate(f):
         """Replay GCP API call answers.
 

--- a/google/cloud/forseti/common/util/replay.py
+++ b/google/cloud/forseti/common/util/replay.py
@@ -1,0 +1,191 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wrapper functions used to record and replay API responses."""
+
+import collections
+import functools
+import os
+import pickle
+from googleapiclient import errors
+from google.cloud.forseti.common.util import log_util
+
+LOGGER = log_util.get_logger(__name__)
+RECORD_ENVIRONMENT_VAR = 'FORSETI_RECORD_FILE'
+REPLAY_ENVIRONMENT_VAR = 'FORSETI_REPLAY_FILE'
+
+
+def _key_from_request(request):
+    """Generate a unique key from a request.
+
+    Args:
+        request (HttpRequest): a googleapiclient HttpRequest object.
+
+    Returns:
+        str: A unique key from the request uri and body.
+    """
+    return '{}{}'.format(request.uri, request.body)
+
+
+def record(requests):
+    """Record and serialize GCP API call answers.
+
+    Args:
+        requests (dict): A dictionary to store a copy of all requests and
+            responses in, before pickling.
+
+    Returns:
+        function: Decorator function.
+    """
+    def decorate(f):
+        """Decorator function for the wrapper.
+
+        Args:
+            f(function): passes a function into the wrapper.
+
+        Returns:
+            function: Wrapped function.
+        """
+        @functools.wraps(f)
+        def record_wrapper(self, request, *args, **kwargs):
+            """Record and serialize GCP API call answers.
+
+            Args:
+                request (HttpRequest): The HttpRequest object to execute.
+                **args (list): Additional args to pass through to function.
+                **kwargs (dict): Additional key word args to pass through to
+                    function.
+
+            Returns:
+                object: The result from the wrapped function.
+
+            Raises:
+                HttpError: Raised by any fatal HTTP error when executing the
+                    HttpRequest.
+                Exception: Any exception raised by the wrapped function.
+            """
+            record_file = os.environ.get(RECORD_ENVIRONMENT_VAR, None)
+            if not record_file:
+                return f(self, request, *args, **kwargs)
+
+            with file(record_file, 'w') as outfile:
+                pickler = pickle.Pickler(outfile)
+                request_key = _key_from_request(request)
+                results = requests.setdefault(
+                    request_key, collections.deque())
+                try:
+                    result = f(self, request, *args, **kwargs)
+                    obj = {
+                        'exception_args': None,
+                        'raised': False,
+                        'request': request.to_json(),
+                        'result': result,
+                        'uri': request.uri}
+                    results.append(obj)
+                    return result
+                except errors.HttpError as e:
+                    # HttpError won't unpickle without all three arguments.
+                    obj = {
+                        'raised': True,
+                        'request': request.to_json(),
+                        'result': e.__class__,
+                        'uri': request.uri,
+                        'exception_args': (e.resp, e.content, e.uri)
+                    }
+                    results.append(obj)
+                    raise
+                except Exception as e:
+                    obj = {
+                        'raised': True,
+                        'request': request.to_json(),
+                        'result': e.__class__,
+                        'uri': request.uri,
+                        'exception_args': [str(e)]
+                    }
+                    results.append(obj)
+                    raise
+                finally:
+                    LOGGER.debug('Recording key %s', request_key)
+                    pickler.dump(requests)
+                    outfile.flush()
+
+        return record_wrapper
+
+    return decorate
+
+
+def replay(requests):
+    """Record and serialize GCP API call answers.
+
+    Args:
+        requests (dict): A dictionary to store a copy of all requests and
+            responses in, after unpickling.
+
+    Returns:
+        function: Decorator function.
+    """
+
+    def decorate(f):
+        """Replay GCP API call answers.
+
+        Args:
+            f (function): Function to decorate
+
+        Returns:
+            function: Wrapped function.
+        """
+        @functools.wraps(f)
+        def replay_wrapper(self, request, *args, **kwargs):
+            """Replay and deserialize GCP API call answers.
+
+            Args:
+                request (HttpRequest): The HttpRequest object to execute.
+                **args (list): Additional args to pass through to function.
+                **kwargs (dict): Additional key word args to pass through to
+                    function.
+
+            Returns:
+                object: The result object from the previous recording.
+
+            Raises:
+                Exception: Any exception raised during the previous recording.
+            """
+            replay_file = os.environ.get(REPLAY_ENVIRONMENT_VAR, None)
+            if not replay_file:
+                return f(self, request, *args, **kwargs)
+
+            if not requests:
+                LOGGER.info('Loading replay file %s.', replay_file)
+                with file(replay_file) as infile:
+                    unpickler = pickle.Unpickler(infile)
+                    requests.update(unpickler.load())
+
+            request_key = _key_from_request(request)
+            if request_key in requests:
+                results = requests[request_key]
+                # Pull the first result from the queue.
+                obj = results.popleft()
+                if obj['raised']:
+                    raise obj['result'](*obj['exception_args'])
+                return obj['result']
+            else:
+                LOGGER.warning(
+                    'Request URI %s with body %s not found in recorded '
+                    'requests, executing live http request instead.',
+                    request.uri, request.body)
+                return f(self, request, *args, **kwargs)
+
+        return replay_wrapper
+
+    return decorate

--- a/tests/common/util/replay_test.py
+++ b/tests/common/util/replay_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for google.cloud.forseti.common.util.replay."""
-import logging
 import os
 import tempfile
 import unittest
@@ -25,13 +24,6 @@ from tests.common.gcp_api.test_data import http_mocks
 from google.cloud.forseti.common.gcp_api import compute
 from google.cloud.forseti.common.gcp_api import errors as api_errors
 from google.cloud.forseti.common.util import replay
-
-ERROR_TEST_CASES = [
-    ('api_not_enabled', fake_compute.API_NOT_ENABLED, '403',
-     api_errors.ApiNotEnabledError),
-    ('access_denied', fake_compute.ACCESS_DENIED, '403',
-     api_errors.ApiExecutionError),
-]
 
 
 class ReplayTest(unittest_utils.ForsetiTestCase):

--- a/tests/common/util/replay_test.py
+++ b/tests/common/util/replay_test.py
@@ -1,0 +1,93 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for google.cloud.forseti.common.util.replay."""
+import logging
+import os
+import tempfile
+import unittest
+import mock
+from oauth2client import client
+
+from tests import unittest_utils
+from tests.common.gcp_api.test_data import fake_compute_responses as fake_compute
+from tests.common.gcp_api.test_data import http_mocks
+from google.cloud.forseti.common.gcp_api import compute
+from google.cloud.forseti.common.gcp_api import errors as api_errors
+from google.cloud.forseti.common.util import replay
+
+ERROR_TEST_CASES = [
+    ('api_not_enabled', fake_compute.API_NOT_ENABLED, '403',
+     api_errors.ApiNotEnabledError),
+    ('access_denied', fake_compute.ACCESS_DENIED, '403',
+     api_errors.ApiExecutionError),
+]
+
+
+class ReplayTest(unittest_utils.ForsetiTestCase):
+    """Tests for the Record and Replay wrappers."""
+
+    def setUp(self):
+        """Set up."""
+        self.fake_global_configs = {'max_compute_api_calls_per_second': 2000}
+        self.project_id = fake_compute.FAKE_PROJECT_ID
+        self.record_file = tempfile.NamedTemporaryFile(delete=False).name
+        self.maxDiff = None
+
+    def tearDown(self):
+        """Clean up."""
+        os.unlink(self.record_file)
+
+    def run_api_tests(self, record=False):
+        """Run several API calls."""
+        if record:
+            os.environ[replay.RECORD_ENVIRONMENT_VAR] = self.record_file
+            os.environ[replay.REPLAY_ENVIRONMENT_VAR] = ''
+
+            mock_responses = []
+            mock_responses.append(({'status': '200'},
+                                   fake_compute.GET_PROJECT_RESPONSE))
+            for page in fake_compute.LIST_NETWORKS_RESPONSES:
+                mock_responses.append(({'status': '200'}, page))
+            mock_responses.append((
+                {'status': '403', 'content-type': 'application/json'},
+                fake_compute.ACCESS_DENIED))
+            http_mocks.mock_http_response_sequence(mock_responses)
+        else:
+            os.environ[replay.RECORD_ENVIRONMENT_VAR] = ''
+            os.environ[replay.REPLAY_ENVIRONMENT_VAR] = self.record_file
+
+        gce_api_client = None
+        with mock.patch.object(client, 'GoogleCredentials', spec=True):
+            gce_api_client = compute.ComputeClient(
+                global_configs=self.fake_global_configs)
+
+        responses = []
+        responses.append(gce_api_client.get_project(self.project_id))
+        responses.append(gce_api_client.get_networks(self.project_id))
+        try:
+            gce_api_client.get_instances(self.project_id)
+        except api_errors.ApiExecutionError as e:
+            responses.append(str(e))
+
+        return responses
+
+    def test_record_and_replay(self):
+        """Verify record and replay functionality."""
+        expected_results = self.run_api_tests(record=True)
+        results = self.run_api_tests(record=False)
+        self.assertEqual(expected_results, results)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change migrates functionality from gcp_api2/_base_client into
gcp_api.

The record and replay functionality is extended to use a global
dictionary to store the responses so it works across all API
repositories. This allows a developer to record all output from a live
environment and then use the data in testing local on their system.

The environment variables FORSETI_RECORD_FILE and FORSETI_REPLAY_FILE
are introduced to enable the recording to or replaying from a file.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
