### PR TITLE
Test fix when port number is not released in time in case of SQLite

### DIFF
--- a/tests/iam/api_tests/api_tester.py
+++ b/tests/iam/api_tests/api_tester.py
@@ -17,15 +17,19 @@ from concurrent import futures
 from collections import defaultdict
 
 from google.cloud.forseti.services.client import ClientComposition
+from tests.unittest_utils import get_available_port
 
 
 class ApiTestRunner(object):
     """Test runner for end-to-end API testing."""
-    def __init__(self, service_config, service_factories, port=50058):
+    def __init__(self, service_config, service_factories, port=None):
         super(ApiTestRunner, self).__init__()
         self.service_config = service_config
         self.service_factories = service_factories
-        self.service_port = port
+        if port:
+            self.service_port = port
+        else:
+            self.service_port = get_available_port()
 
     def run(self, test_callback):
         """Test runner."""

--- a/tests/unittest_utils.py
+++ b/tests/unittest_utils.py
@@ -21,7 +21,16 @@ import logging
 import os
 import tempfile
 import unittest
+import socket
 
+def get_available_port():
+    """Get a port that is available to use"""
+    sckt = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sckt.bind(("",0))
+    sckt.listen(1)
+    port = sckt.getsockname()[1]
+    sckt.close()
+    return port
 
 @contextlib.contextmanager
 def create_temp_file(data):


### PR DESCRIPTION
Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [ ] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [ ] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [ ] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [ ] My PR has been functionally tested.
- [ ] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests) still pass.
- [ ] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/forseti-security/837)
<!-- Reviewable:end -->
