### PR TITLE
Setup wizard can deploy Forseti to a shared VPC

### DIFF
--- a/deployment-templates/compute-engine/explain-instance.py
+++ b/deployment-templates/compute-engine/explain-instance.py
@@ -69,7 +69,7 @@ def GenerateConfig(context):
                     'https://www.googleapis.com/compute/v1/'
                     'projects/{}/global/networks/{}'.format(
                         context.properties['host-project'],
-                        context.properties['xpn-name'])),
+                        context.properties['vpc-name'])),
                 'accessConfigs': [{
                     'name': 'External NAT',
                     'type': 'ONE_TO_ONE_NAT'

--- a/deployment-templates/compute-engine/explain-instance.py
+++ b/deployment-templates/compute-engine/explain-instance.py
@@ -67,12 +67,19 @@ def GenerateConfig(context):
             'networkInterfaces': [{
                 'network': (
                     'https://www.googleapis.com/compute/v1/'
-                    'projects/{}/global/networks/default'.format(
-                    context.env['project'])),
+                    'projects/{}/global/networks/{}'.format(
+                        context.properties['host-project'],
+                        context.properties['xpn-name'])),
                 'accessConfigs': [{
                     'name': 'External NAT',
                     'type': 'ONE_TO_ONE_NAT'
-                }]
+                }],
+                'subnetwork': (
+                    'https://www.googleapis.com/compute/v1/'
+                    'projects/{}/regions/{}/subnetworks/{}'.format(
+                        context.properties['host-project'],
+                        context.properties['region'],
+                        context.properties['subnetwork']))
             }],
             'serviceAccounts': [{
                 'email': context.properties['service-account'],

--- a/deployment-templates/compute-engine/forseti-instance.py
+++ b/deployment-templates/compute-engine/forseti-instance.py
@@ -100,12 +100,19 @@ python build_protos.py --clean
             'networkInterfaces': [{
                 'network': (
                     'https://www.googleapis.com/compute/v1/'
-                    'projects/{}/global/networks/default'.format(
-                    context.env['project'])),
+                    'projects/{}/global/networks/{}'.format(
+                        context.properties['network-host-project'],
+                        context.properties['xpn-name'])),
                 'accessConfigs': [{
                     'name': 'External NAT',
                     'type': 'ONE_TO_ONE_NAT'
-                }]
+                }],
+                'subnetwork': (
+                    'https://www.googleapis.com/compute/v1/'
+                    'projects/{}/regions/{}/subnetworks/{}'.format(
+                        context.properties['network-host-project'],
+                        context.properties['region'],
+                        context.properties['subnetwork']))
             }],
             'serviceAccounts': [{
                 'email': context.properties['service-account'],

--- a/deployment-templates/compute-engine/forseti-instance.py
+++ b/deployment-templates/compute-engine/forseti-instance.py
@@ -102,7 +102,7 @@ python build_protos.py --clean
                     'https://www.googleapis.com/compute/v1/'
                     'projects/{}/global/networks/{}'.format(
                         context.properties['network-host-project'],
-                        context.properties['xpn-name'])),
+                        context.properties['vpc-name'])),
                 'accessConfigs': [{
                     'name': 'External NAT',
                     'type': 'ONE_TO_ONE_NAT'

--- a/deployment-templates/compute-engine/forseti-instance.py.schema
+++ b/deployment-templates/compute-engine/forseti-instance.py.schema
@@ -80,3 +80,15 @@ properties:
     type: integer
     default: 3306
     description: The port for the database.
+
+  network-host-project:
+    type: string
+    description: the id of the shared network host project
+
+  xpn-name:
+    type: string
+    description: the name of the shared network
+
+  subnetwork:
+    type: string
+    description: the name of the subnet

--- a/deployment-templates/compute-engine/forseti-instance.py.schema
+++ b/deployment-templates/compute-engine/forseti-instance.py.schema
@@ -85,7 +85,7 @@ properties:
     type: string
     description: the id of the shared network host project
 
-  xpn-name:
+  vpc-name:
     type: string
     description: the name of the shared network
 

--- a/deployment-templates/deploy-forseti.yaml.in
+++ b/deployment-templates/deploy-forseti.yaml.in
@@ -53,6 +53,7 @@ resources:
     image-project: ubuntu-os-cloud
     image-family: ubuntu-1604-lts
     instance-type: n1-standard-2
+    region: $(ref.cloudsql-instance.region)
     zone: $(ref.cloudsql-instance.region)-c
 
     service-account: $(ref.forseti-gcp-reader.email)
@@ -60,6 +61,9 @@ resources:
       - https://www.googleapis.com/auth/cloud-platform
     scanner-bucket: {SCANNER_BUCKET}
     database-name: forseti_security
+    network-host-project: {HOST_PROJECT}
+    xpn-name: {XPN_NAME}
+    subnetwork: {SUBNETWORK}
 
     # --- Forseti version
     # Use either branch-name or release-version, but NOT both.

--- a/deployment-templates/deploy-forseti.yaml.in
+++ b/deployment-templates/deploy-forseti.yaml.in
@@ -62,7 +62,7 @@ resources:
     scanner-bucket: {SCANNER_BUCKET}
     database-name: forseti_security
     network-host-project: {HOST_PROJECT}
-    xpn-name: {XPN_NAME}
+    vpc-name: {XPN_NAME}
     subnetwork: {SUBNETWORK}
 
     # --- Forseti version

--- a/scripts/gcp_setup/environment/gcloud_env.py
+++ b/scripts/gcp_setup/environment/gcloud_env.py
@@ -146,9 +146,8 @@ class ForsetiGcpSetup(object):
         self.notification_recipient_email = (
             kwargs.get('notification_recipient_email'))
         self.gsuite_superadmin_email = kwargs.get('gsuite_superadmin_email')
-
         self.host_project_id = kwargs.get('host_project', self.project_id)
-        self.xpn_name = kwargs.get('vpc') or 'default'
+        self.vpc_name = kwargs.get('vpc') or 'default'
         self.subnetwork = kwargs.get('subnet') or 'default'
 
     def run_setup(self):
@@ -163,6 +162,7 @@ class ForsetiGcpSetup(object):
         self.get_organization()
         self.check_billing_enabled()
         self.has_permissions()
+        self.get_host_project()
 
         self.enable_apis()
 
@@ -351,6 +351,13 @@ class ForsetiGcpSetup(object):
             print('You need to have an active project! Exiting.')
             sys.exit(1)
         print('Project id: %s' % self.project_id)
+
+    def get_host_project(self):
+        """Get the host project."""
+        if not self.host_project_id:
+            self.get_project()
+            self.host_project_id = self.project_id
+        print('VPC Host Project %s' % self.host_project_id)
 
     def check_billing_enabled(self):
         """Check if billing is enabled."""
@@ -669,7 +676,7 @@ class ForsetiGcpSetup(object):
             'SERVICE_ACCT_GSUITE_READER': self.gsuite_service_account,
             'BRANCH_OR_RELEASE': 'branch-name: "{}"'.format(self.branch),
             'HOST_PROJECT': self.host_project_id,
-            'XPN_NAME': self.xpn_name,
+            'XPN_NAME': self.vpc_name,
             'SUBNETWORK': self.subnetwork
         }
 

--- a/scripts/gcp_setup/environment/gcloud_env.py
+++ b/scripts/gcp_setup/environment/gcloud_env.py
@@ -147,6 +147,10 @@ class ForsetiGcpSetup(object):
             kwargs.get('notification_recipient_email'))
         self.gsuite_superadmin_email = kwargs.get('gsuite_superadmin_email')
 
+        self.host_project_id = kwargs.get('host_project', self.project_id)
+        self.xpn_name = kwargs.get('vpc') or 'default'
+        self.subnetwork = kwargs.get('subnet') or 'default'
+
     def run_setup(self):
         """Run the setup steps."""
         # Pre-flight checks.
@@ -664,6 +668,9 @@ class ForsetiGcpSetup(object):
             'SERVICE_ACCT_GCP_READER': self.gcp_service_account,
             'SERVICE_ACCT_GSUITE_READER': self.gsuite_service_account,
             'BRANCH_OR_RELEASE': 'branch-name: "{}"'.format(self.branch),
+            'HOST_PROJECT': self.host_project_id,
+            'XPN_NAME': self.xpn_name,
+            'SUBNETWORK': self.subnetwork
         }
 
         # Create Deployment template with values filled in.

--- a/scripts/gcp_setup/setup_forseti.py
+++ b/scripts/gcp_setup/setup_forseti.py
@@ -40,6 +40,14 @@ def run():
     group.add_argument('--cloudsql-region',
                        help='The Cloud SQL region')
 
+    network = parser.add_argument_group(title='network')
+    network.add_argument('--host-project',
+                         help='The host project id')
+    network.add_argument('--vpc',
+                         help='The VPC name where Forseti VM will run')
+    network.add_argument('--subnet',
+                         help='The subnetwork name where Forseti VM will run')
+
     email_params = parser.add_argument_group(title='email')
     email_params.add_argument('--sendgrid-api-key',
                               help='Sendgrid API key')


### PR DESCRIPTION
This PR is designed to allow users who wish to run the Forseti Compute VM in a shared VPC to use the setup wizard. The user must specify the host project id, shared vpc name, and subnetwork name as arguments.

The generated compute instance template section networkInterfaces.network will now contain a host-project and vpc-name. The host-project can either be the host project id supplied by the user or the current project id as discovered by the script. The vpc-name can either be the vpc name supplied by the user or the name string 'default'.

The generated compute instance template section networkInterfaces.subnetwork is new. It will contain a host-project defined the same as above, region defined as it was previously, and subnetwork supplied by the user or the name string 'default'.