### PR TITLE
Fix json breakage in slack notifiiction.

### DIFF
--- a/google/cloud/security/notifier/pipelines/slack_webhook_pipeline.py
+++ b/google/cloud/security/notifier/pipelines/slack_webhook_pipeline.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Slack webhook pipeline to perform notifications."""
-import json
+
 import requests
 
 # TODO: Investigate improving so we can avoid the pylint disable.
@@ -67,7 +67,7 @@ class SlackWebhookPipeline(bnp.BaseNotificationPipeline):
 
         payload = {
             'type': self.resource,
-            'details': json.loads(violation.get('violation_data'))
+            'details': violation.get('violation_data')
         }
 
         return self._dump_slack_output(payload)

--- a/tests/common/data_access/violation_dao_test.py
+++ b/tests/common/data_access/violation_dao_test.py
@@ -293,6 +293,12 @@ class ViolationDaoTest(ForsetiTestCase):
         self.assertEqual(
             fake_data.EXPECTED_MAP_BY_RESOURCE_1, actual)
 
+        violation_data = (
+            actual.get('policy_violations')[0].get('violation_data'))
+        self.assertTrue(
+            type(violation_data) is dict,
+            'violation_data must be dict type to be compatible with slack')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/notifier/pipelines/slack_webhook_pipeline_test.py
+++ b/tests/notifier/pipelines/slack_webhook_pipeline_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests the email scanner summary pipeline."""
 
+import json
 import mock
 import unittest
 
@@ -35,9 +36,12 @@ class SlackWebhookPipelineTest(ForsetiTestCase):
             }
         """
 
-        violation = {'violation_data': violation_data, 'resource_id': '123',
-                     'rule_name': 'Public buckets (allUsers)', 'rule_index': 0L,
-                     'violation_type': 'BUCKET_VIOLATION', 'id': 1L, 'resource_type': 'bucket'}
+        violation = {'violation_data': json.loads(violation_data),
+                     'resource_id': '123',
+                     'rule_name': 'Public buckets (allUsers)',
+                     'rule_index': 0L,
+                     'violation_type': 'BUCKET_VIOLATION',
+                     'id': 1L, 'resource_type': 'bucket'}
 
         with mock.patch.object(slack_webhook_pipeline.SlackWebhookPipeline, '__init__', lambda x: None):
             slack_pipeline = slack_webhook_pipeline.SlackWebhookPipeline()


### PR DESCRIPTION
The issue is that [json.loads() is called upstream] (https://github.com/GoogleCloudPlatform/forseti-security/pull/762/files#diff-35e1e2967889bcc1d9049e770706aee7R164), which then causes a problem when json.loads() is called here again.

Best way to make sure this doesn't regress in the future is to test this functionally, when we have an in-memory database.  Will open an issue for this.