### PR TITLE
GCS Bucket and Object ACLs are returned with the resource.

### DIFF
--- a/google/cloud/forseti/services/inventory/base/gcp.py
+++ b/google/cloud/forseti/services/inventory/base/gcp.py
@@ -558,15 +558,6 @@ class ApiClientImpl(ApiClient):
         return self.iam.get_service_account_iam_policy(name)
 
     @create_lazy('storage', _create_storage)
-    def get_bucket_gcs_policy(self, bucketid):
-        """Bucket GCS policy from gcp API call
-
-        Returns:
-            dict: Bucket GCS policy
-        """
-        return self.storage.get_bucket_acls(bucketid)
-
-    @create_lazy('storage', _create_storage)
     def get_bucket_iam_policy(self, bucketid):
         """Bucket IAM policy Iterator from gcp API call
 
@@ -574,15 +565,6 @@ class ApiClientImpl(ApiClient):
             dict: Bucket IAM policy
         """
         return self.storage.get_bucket_iam_policy(bucketid)
-
-    @create_lazy('storage', _create_storage)
-    def get_object_gcs_policy(self, bucket_name, object_name):
-        """Object GCS policy for an object from gcp API call
-
-        Returns:
-            dict: Object GCS policy
-        """
-        return self.storage.get_object_acls(bucket_name, object_name)
 
     @create_lazy('storage', _create_storage)
     def get_object_iam_policy(self, bucket_name, object_name):

--- a/google/cloud/forseti/services/inventory/base/resources.py
+++ b/google/cloud/forseti/services/inventory/base/resources.py
@@ -242,9 +242,12 @@ class GcsBucket(Resource):
     def getIamPolicy(self, client=None):
         return client.get_bucket_iam_policy(self.key())
 
-    @cached('gcs_policy')
     def getGCSPolicy(self, client=None):
-        return client.get_bucket_gcs_policy(self.key())
+        # Full projection returns GCS policy with the resource.
+        try:
+            return self['acl']
+        except KeyError:
+            return []
 
     def type(self):
         return 'bucket'
@@ -259,10 +262,12 @@ class GcsObject(Resource):
         return client.get_object_iam_policy(self.parent()['name'],
                                             self['name'])
 
-    @cached('gcs_policy')
     def getGCSPolicy(self, client=None):
-        return client.get_object_gcs_policy(self.parent()['name'],
-                                            self['name'])
+        # Full projection returns GCS policy with the resource.
+        try:
+            return self['acl']
+        except KeyError:
+            return []
 
     def type(self):
         return 'storage_object'

--- a/scripts/iam_auto_deployment.sh
+++ b/scripts/iam_auto_deployment.sh
@@ -329,7 +329,6 @@ echo "        - 'roles/appengine.appViewer',"
 echo "        - 'roles/servicemanagement.quotaViewer',"
 echo "        - 'roles/cloudsql.viewer',"
 echo "        - 'roles/compute.securityAdmin',"
-echo "        - 'roles/storage.admin',"
 echo "    - Project level:"
 echo "        - 'roles/storage.admin'"
 echo "        - 'roles/cloudsql.client'"
@@ -365,10 +364,6 @@ then
 	$CmdPrefix add-iam-policy-binding $ROOTID \
 	 --member=serviceAccount:$SCRAPINGSA \
 	 --role=roles/compute.securityAdmin
-
-	$CmdPrefix add-iam-policy-binding $ROOTID \
-	 --member=serviceAccount:$SCRAPINGSA \
-	 --role=roles/storage.admin
 
 	gcloud projects add-iam-policy-binding $PROJECT_ID \
 	 --member=serviceAccount:$SCRAPINGSA \

--- a/tests/services/inventory/crawling_test.py
+++ b/tests/services/inventory/crawling_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Unit Tests: Inventory crawler for IAM Explain."""
 
+import logging
 import unittest
 from tests.services.inventory import gcp_api_mocks
 from tests.unittest_utils import ForsetiTestCase
@@ -38,6 +39,7 @@ class NullProgresser(Progresser):
         self.warnings += 1
 
     def on_error(self, error):
+        logging.error("Progressor Error: %s", error)
         self.errors += 1
 
     def get_summary(self):

--- a/tests/services/inventory/gcp_api_mocks.py
+++ b/tests/services/inventory/gcp_api_mocks.py
@@ -270,17 +270,8 @@ def _mock_gcs():
             return results.GCS_GET_OBJECTS[bucket_name]
         return []
 
-    def _mock_gcs_get_bucket_acls(bucketid):
-        return results.GCS_GET_BUCKET_ACLS[bucketid]
-
     def _mock_gcs_get_bucket_iam(bucketid):
         return results.GCS_GET_BUCKET_IAM[bucketid]
-
-    def _mock_gcs_get_object_acls(bucket_name, object_name):
-        if (bucket_name in results.GCS_GET_OBJECT_ACLS and
-                object_name in results.GCS_GET_OBJECT_ACLS[bucket_name]):
-            return results.GCS_GET_OBJECT_ACLS[bucket_name][object_name]
-        return []
 
     def _mock_gcs_get_object_iam(bucket_name, object_name):
         if (bucket_name in results.GCS_GET_OBJECT_IAM and
@@ -293,9 +284,7 @@ def _mock_gcs():
     mock_gcs = gcs_patcher.start().return_value
     mock_gcs.get_buckets.side_effect = _mock_gcs_get_buckets
     mock_gcs.get_objects.side_effect = _mock_gcs_get_objects
-    mock_gcs.get_bucket_acls.side_effect = _mock_gcs_get_bucket_acls
     mock_gcs.get_bucket_iam_policy.side_effect = _mock_gcs_get_bucket_iam
-    mock_gcs.get_object_acls.side_effect = _mock_gcs_get_object_acls
     mock_gcs.get_object_iam_policy.side_effect = _mock_gcs_get_object_iam
 
     return gcs_patcher

--- a/tests/services/inventory/test_data/mock_gcp_results.py
+++ b/tests/services/inventory/test_data/mock_gcp_results.py
@@ -1376,64 +1376,6 @@ GCS_GET_BUCKETS = {
 
 GCS_GET_OBJECTS = {}
 
-# Fields: name, num
-BUCKET_ACLS_TEMPLATE = """
-[
-  {{
-   "kind": "storage#bucketAccessControl",
-   "id": "{name}/project-owners-{num}",
-   "selfLink": "https://www.googleapis.com/storage/v1/b/{name}/acl/project-owners-{num}",
-   "bucket": "{name}",
-   "entity": "project-owners-{num}",
-   "role": "OWNER",
-   "projectTeam": {{
-    "projectNumber": "{num}",
-    "team": "owners"
-   }},
-   "etag": "CAE="
-  }},
-  {{
-   "kind": "storage#bucketAccessControl",
-   "id": "{name}/project-editors-{num}",
-   "selfLink": "https://www.googleapis.com/storage/v1/b/{name}/acl/project-editors-{num}",
-   "bucket": "{name}",
-   "entity": "project-editors-{num}",
-   "role": "OWNER",
-   "projectTeam": {{
-    "projectNumber": "{num}",
-    "team": "editors"
-   }},
-   "etag": "CAE="
-  }},
-  {{
-   "kind": "storage#bucketAccessControl",
-   "id": "{name}/project-viewers-{num}",
-   "selfLink": "https://www.googleapis.com/storage/v1/b/{name}/acl/project-viewers-{num}",
-   "bucket": "{name}",
-   "entity": "project-viewers-{num}",
-   "role": "READER",
-   "projectTeam": {{
-    "projectNumber": "{num}",
-    "team": "viewers"
-   }},
-   "etag": "CAE="
-  }}
-]
-"""
-
-GCS_GET_BUCKET_ACLS = {
-    "bucket1": [
-        json.loads(
-            BUCKET_ACLS_TEMPLATE.format(
-                name="bucket1", num=PROJECT_ID_PREFIX + "3")),
-    ],
-    "bucket2": [
-        json.loads(
-            BUCKET_ACLS_TEMPLATE.format(
-                name="bucket2", num=PROJECT_ID_PREFIX + "4")),
-    ]
-}
-
 BUCKET_IAM_TEMPLATE = """
 {{
  "kind": "storage#policy",
@@ -1465,8 +1407,6 @@ GCS_GET_BUCKET_IAM = {
         json.loads(
             BUCKET_IAM_TEMPLATE.format(name="bucket2", project="project4"))
 }
-
-GCS_GET_OBJECT_ACLS = {}
 
 GCS_GET_OBJECT_IAM = {}
 


### PR DESCRIPTION
There is no need to re-fetch GCS ACLs from the API as they are returned with the resource object when projection='full', so the storage.admin permission is not needed on the organization.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
