### PR TITLE
Scanner tweaks

### DIFF
--- a/google/cloud/forseti/scanner/scanner.py
+++ b/google/cloud/forseti/scanner/scanner.py
@@ -92,14 +92,14 @@ def run(forseti_config, model_name=None, service_config=None):
 
     if forseti_config is None:
         LOGGER.error('Path to Forseti Security config needs to be specified.')
-        sys.exit()
+        return 1
 
     try:
         configs = file_loader.read_and_parse_file(forseti_config)
     except IOError:
         LOGGER.error('Unable to open Forseti Security config file. '
                      'Please check your path and filename and try again.')
-        sys.exit()
+        return 1
     global_configs = configs.get('global')
     scanner_configs = configs.get('scanner')
 
@@ -107,10 +107,10 @@ def run(forseti_config, model_name=None, service_config=None):
 
     # TODO: Figure out if we still need to get the latest model here,
     # or should it be set in the server context before calling the scanner.
-    snapshot_timestamp = _get_timestamp(global_configs)
-    if not snapshot_timestamp:
-        LOGGER.warn('No snapshot timestamp found. Exiting.')
-        sys.exit()
+    #snapshot_timestamp = _get_timestamp(global_configs)
+    #if not snapshot_timestamp:
+    #    LOGGER.warn('No snapshot timestamp found. Exiting.')
+    #    sys.exit()
 
     violation_access = scanner_dao.define_violation(
         model_name, service_config.engine)
@@ -118,7 +118,7 @@ def run(forseti_config, model_name=None, service_config=None):
 
     runnable_scanners = scanner_builder.ScannerBuilder(
         global_configs, scanner_configs, service_config, model_name,
-        snapshot_timestamp).build()
+        model_name).build()
 
     # pylint: disable=bare-except
     for scanner in runnable_scanners:

--- a/google/cloud/forseti/scanner/scanner.py
+++ b/google/cloud/forseti/scanner/scanner.py
@@ -117,7 +117,7 @@ def run(forseti_config, model_name=None, service_config=None):
 
     runnable_scanners = scanner_builder.ScannerBuilder(
         global_configs, scanner_configs, service_config, model_name,
-        model_name).build()
+        None).build()
 
     # pylint: disable=bare-except
     for scanner in runnable_scanners:

--- a/google/cloud/forseti/scanner/scanner.py
+++ b/google/cloud/forseti/scanner/scanner.py
@@ -18,7 +18,6 @@ Usage:
   Run scanner:
   $ forseti_scanner --forseti_config
 """
-import sys
 
 import gflags as flags
 

--- a/google/cloud/forseti/scanner/scanner_builder.py
+++ b/google/cloud/forseti/scanner/scanner_builder.py
@@ -35,13 +35,13 @@ class ScannerBuilder(object):
         Args:
             global_configs (dict): Global configurations.
             scanner_configs (dict): Scanner configurations.
-            service_config (ServiceConfig): Forseti 2.0 service configs
+            service_config (ServiceConfig): Service configuration.
             model_name (str): name of the data model
             snapshot_timestamp (str): The snapshot timestamp
         """
         self.global_configs = global_configs
         self.scanner_configs = scanner_configs
-        self.service_config = service_config,
+        self.service_config = service_config
         self.model_name = model_name
         self.snapshot_timestamp = snapshot_timestamp
 

--- a/google/cloud/forseti/scanner/scanners/base_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/base_scanner.py
@@ -39,7 +39,7 @@ class BaseScanner(object):
         Args:
             global_configs (dict): Global configurations.
             scanner_configs (dict): Scanner configurations.
-            service_config (ServiceConfig): Forseti 2.0 service configs
+            service_config (ServiceConfig): Service configuration.
             model_name (str): name of the data model
             snapshot_timestamp (str): Timestamp, formatted as YYYYMMDDTHHMMSSZ.
             rules (str): Fully-qualified path and filename of the rules file.
@@ -69,8 +69,8 @@ class BaseScanner(object):
         # Add a unit test for the errors.
         (inserted_row_count, violation_errors) = (0, [])
 
-        violation_access = self.service_config[0].violation_access(
-            self.service_config[0].engine)
+        violation_access = self.service_config.violation_access(
+            self.service_config.engine)
         violation_access.create(violations)
         # TODO: figure out what to do with the errors. For now, just log it.
         LOGGER.debug('Inserted %s rows with %s errors',

--- a/google/cloud/forseti/scanner/scanners/firewall_rules_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/firewall_rules_scanner.py
@@ -44,7 +44,7 @@ class FirewallPolicyScanner(base_scanner.BaseScanner):
         Args:
             global_configs (dict): Global configurations.
             scanner_configs (dict): Scanner configurations.
-            service_config (ServiceConfig): Forseti 2.0 service configs
+            service_config (ServiceConfig): Service configuration.
             model_name (str): name of the data model
             snapshot_timestamp (str): Timestamp, formatted as YYYYMMDDTHHMMSSZ.
             rules (str): Fully-qualified path and filename of the rules file.
@@ -182,7 +182,7 @@ class FirewallPolicyScanner(base_scanner.BaseScanner):
             int: The resource count.
         """
 
-        model_manager = self.service_config[0].model_manager
+        model_manager = self.service_config.model_manager
         scoped_session, data_access = model_manager.get(self.model_name)
         with scoped_session as session:
             firewall_policies = []

--- a/tests/scanner/scanners/firewall_rules_scanner_test.py
+++ b/tests/scanner/scanners/firewall_rules_scanner_test.py
@@ -336,8 +336,8 @@ class FirewallRulesScannerTest(unittest_utils.ForsetiTestCase):
         mock_data_access.scanner_iter.return_value = [mock_resource1,
                                                       mock_resource2]
         mock_service_config = mock.MagicMock()
-        mock_service_config[0].model_manager = mock.MagicMock()
-        mock_service_config[0].model_manager.get.return_value = mock.MagicMock(), mock_data_access
+        mock_service_config.model_manager = mock.MagicMock()
+        mock_service_config.model_manager.get.return_value = mock.MagicMock(), mock_data_access
 
 
         scanner = firewall_rules_scanner.FirewallPolicyScanner(
@@ -383,8 +383,8 @@ class FirewallRulesScannerTest(unittest_utils.ForsetiTestCase):
         mock_data_access = mock.MagicMock()
         mock_data_access.scanner_iter.return_value = [mock_resource1]
         mock_service_config = mock.MagicMock()
-        mock_service_config[0].model_manager = mock.MagicMock()
-        mock_service_config[0].model_manager.get.return_value = (
+        mock_service_config.model_manager = mock.MagicMock()
+        mock_service_config.model_manager.get.return_value = (
             mock.MagicMock(), mock_data_access)
 
         scanner = firewall_rules_scanner.FirewallPolicyScanner(


### PR DESCRIPTION
* Change sys.exit(1) to return some int value, just so the client doesn't hang if there's an error
* Don't use the snapshot_timestamp