### PR TITLE
Use a temporary .forseti that gets cleaned up after unit tests for cli

### DIFF
--- a/tests/services/cli_test.py
+++ b/tests/services/cli_test.py
@@ -16,15 +16,17 @@
 from argparse import ArgumentParser
 from copy import copy
 import json
+import mock
 import os
-import shutil
 import shlex
+import shutil
 import StringIO
 import tempfile
 import unittest
-import mock
-from tests.unittest_utils import ForsetiTestCase
+
 from google.cloud.forseti.services import cli
+from tests.unittest_utils import ForsetiTestCase
+
 CLIENT = mock.Mock()
 
 CLIENT.playground = CLIENT

--- a/tests/services/cli_test.py
+++ b/tests/services/cli_test.py
@@ -199,7 +199,7 @@ class ImporterTest(ForsetiTestCase):
         """Test if the CLI hits specific client methods."""
         tmp_config = os.path.join(self.test_dir, '.forseti')
         with mock.patch.dict(
-            os.environ, {'FORSETI_CLIENT_CONFIG': tmp_config}) as mock_config:
+            os.environ, {'FORSETI_CLIENT_CONFIG': tmp_config}):
             for commandline, client_func, func_args,\
                 func_kwargs, config_string, config_expect\
                     in test_cases:


### PR DESCRIPTION
Instead of overwriting the default .forseti in $HOME, create a temp directory and temp file for the Forseti configuration and clean it up after running the CLI tests.