### PR TITLE
Clarify GKE scanner rule

### DIFF
--- a/rules/gke_rules.yaml
+++ b/rules/gke_rules.yaml
@@ -50,9 +50,9 @@ rules:
     # Master versions are always greater or equal to the node pool version.
     check_serverconfig_valid_master_versions: false
 
-# This rule checks for any node pools that are running a version less than
-# the minimum allowed version, regardless of if it is supported or not.
-  - name: Meltdown and Spectre patches applied
+# This rule checks for any node pools that are running a version
+# that is not patched for Meltdown & Spectre.
+  - name: Meltdown and Spectre patches not applied
     resource:
       - type: organization
         resource_ids:


### PR DESCRIPTION
Also, a qq: do we need to keep this rule up-to-date, by adding version 1.10 to ```allowed_nodepool_versions``` portion, when v1.10 comes out?