### PR TITLE
Use_model will raise warning when model is not usable

### DIFF
--- a/google/cloud/forseti/services/cli.py
+++ b/google/cloud/forseti/services/cli.py
@@ -702,8 +702,11 @@ def run_model(client, config, output, config_env):
     def do_use_model():
         """Use a model."""
         model = client.get_model(config.model)
-        if model:
+        if model and model.status in ["SUCCESS", "PARTIAL_SUCCESS"]:
             config_env['model'] = model.handle
+        else:
+            raise Warning('use_model failed, the specified model is '
+                            'either not existed or not usable.')
         DefaultConfigParser.persist(config_env)
 
     actions = {

--- a/google/cloud/forseti/services/cli.py
+++ b/google/cloud/forseti/services/cli.py
@@ -700,13 +700,17 @@ def run_model(client, config, output, config_env):
         output.write(result)
 
     def do_use_model():
-        """Use a model."""
+        """Use a model.
+
+        Raises:
+            Warning: When the specified model is not usable or not existed
+        """
         model = client.get_model(config.model)
         if model and model.status in ["SUCCESS", "PARTIAL_SUCCESS"]:
             config_env['model'] = model.handle
         else:
             raise Warning('use_model failed, the specified model is '
-                            'either not existed or not usable.')
+                          'either not existed or not usable.')
         DefaultConfigParser.persist(config_env)
 
     actions = {


### PR DESCRIPTION
Addressing issue 907

forseti model use A
if A is not usable, the config will not change and the client will raise a warning.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [ ] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [ ] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [ ] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [ ] My PR has been functionally tested.
- [ ] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests) still pass.
- [ ] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
