### PR TITLE
Clean up temp file after emailing violations

### DIFF
--- a/google/cloud/security/notifier/pipelines/email_violations_pipeline.py
+++ b/google/cloud/security/notifier/pipelines/email_violations_pipeline.py
@@ -57,7 +57,6 @@ class EmailViolationsPipeline(bnp.BaseNotificationPipeline):
                                                       notifier_config,
                                                       pipeline_config)
         self.mail_util = EmailUtil(self.pipeline_config['sendgrid_api_key'])
-        self.tmp_file = tempfile.NamedTemporaryFile(delete=False)
 
     def _get_output_filename(self):
         """Create the output filename.
@@ -78,17 +77,18 @@ class EmailViolationsPipeline(bnp.BaseNotificationPipeline):
         Returns:
             attachment: SendGrid attachment object.
         """
-        self.tmp_file.write(parser.json_stringify(self.violations))
-        self.tmp_file.close()
+        tmp_file = tempfile.NamedTemporaryFile(delete=False)
+        tmp_file.write(parser.json_stringify(self.violations))
+        tmp_file.close()
         attachment = self.mail_util.create_attachment(
-            file_location=self.tmp_file.name,
+            file_location=tmp_file.name,
             content_type='text/json',
             filename=self._get_output_filename(),
             disposition='attachment',
             content_id='Violations'
         )
 
-        os.unlink(self.tmp_file.name)
+        os.unlink(tmp_file.name)
         return attachment
 
     def _make_content(self):

--- a/google/cloud/security/notifier/pipelines/email_violations_pipeline.py
+++ b/google/cloud/security/notifier/pipelines/email_violations_pipeline.py
@@ -14,9 +14,9 @@
 
 """Email pipeline to perform notifications"""
 
-import tempfile
 from datetime import datetime
 import os
+import tempfile
 
 # TODO: Investigate improving so we can avoid the pylint disable.
 # pylint: disable=line-too-long

--- a/google/cloud/security/notifier/pipelines/email_violations_pipeline.py
+++ b/google/cloud/security/notifier/pipelines/email_violations_pipeline.py
@@ -15,6 +15,7 @@
 """Email pipeline to perform notifications"""
 
 from datetime import datetime
+import os
 
 # TODO: Investigate improving so we can avoid the pylint disable.
 # pylint: disable=line-too-long
@@ -31,6 +32,15 @@ LOGGER = log_util.get_logger(__name__)
 TEMP_DIR = '/tmp'
 VIOLATIONS_JSON_FMT = 'violations.{}.{}.{}.json'
 OUTPUT_TIMESTAMP_FMT = '%Y%m%dT%H%M%SZ'
+
+
+def tmp_dir():
+    """Helper function, observes the `TMPDIR` environment variable.
+
+    Returns:
+        str: the value of `$TMPDIR` if set, `/tmp` otherwise."""
+    result = os.environ.get('TMPDIR')
+    return result if result else TEMP_DIR
 
 
 class EmailViolationsPipeline(bnp.BaseNotificationPipeline):
@@ -78,7 +88,7 @@ class EmailViolationsPipeline(bnp.BaseNotificationPipeline):
         """
         # Make attachment
         output_file_name = self._get_output_filename()
-        output_file_path = '{}/{}'.format(TEMP_DIR, output_file_name)
+        output_file_path = '{}/{}'.format(tmp_dir(), output_file_name)
         with open(output_file_path, 'w+') as f:
             f.write(parser.json_stringify(self.violations))
         return output_file_name
@@ -91,7 +101,7 @@ class EmailViolationsPipeline(bnp.BaseNotificationPipeline):
         """
         output_file_name = self._write_temp_attachment()
         attachment = self.mail_util.create_attachment(
-            file_location='{}/{}'.format(TEMP_DIR, output_file_name),
+            file_location='{}/{}'.format(tmp_dir(), output_file_name),
             content_type='text/json',
             filename=output_file_name,
             disposition='attachment',

--- a/tests/notifier/pipelines/email_violations_pipeline_test.py
+++ b/tests/notifier/pipelines/email_violations_pipeline_test.py
@@ -19,12 +19,33 @@ from datetime import datetime
 import glob
 import mock
 import os
+import random
 import shutil
-import tempfile
 import unittest
 
 from google.cloud.security.notifier.pipelines import email_violations_pipeline
 from tests.unittest_utils import ForsetiTestCase
+
+
+_ORIGINAL_TMPDIR = os.environ.get('TMPDIR')
+
+
+def setUpModule():
+    """Module level setup: the first import of `tempfile` "freezes" the value
+    of `os.environ['TMPDIR']`.
+    We thus need to perform this initialization only once and _before_ that
+    first import."""
+    os.environ['TMPDIR'] = '/tmp/forseti--{}'.format(random.randint(1, 100000))
+    os.mkdir(os.environ['TMPDIR'])
+
+
+def tearDownModule():
+    """Module level teardown."""
+    shutil.rmtree(os.environ['TMPDIR'], ignore_errors=True)
+    if _ORIGINAL_TMPDIR:
+        os.environ['TMPDIR'] = _ORIGINAL_TMPDIR
+    else:
+        del(os.environ['TMPDIR'])
 
 
 class EmailViolationsPipelineTest(ForsetiTestCase):
@@ -32,9 +53,6 @@ class EmailViolationsPipelineTest(ForsetiTestCase):
 
     def setUp(self):
         """Setup."""
-        self.original_tmpdir = os.environ.get('TMPDIR')
-        os.environ['TMPDIR'] = tempfile.mkdtemp(prefix='forseti.')
-
         fake_global_conf = {
             'db_host': 'x',
             'db_name': 'y',
@@ -47,38 +65,32 @@ class EmailViolationsPipelineTest(ForsetiTestCase):
             'sendgrid_api_key': 'foo_email_key',
         }
 
-        self.gvp = email_violations_pipeline.EmailViolationsPipeline(
+        self.gvp_args = [
             'abcd',
             datetime.strftime(datetime.utcnow(), '%Y%m%dT%H%M%SZ'),
             ['violation: abc', 'violation: def'],
             fake_global_conf,
             {},
-            fake_pipeline_conf)
-
-    def tearDown(self):
-        """Teardown."""
-        shutil.rmtree(os.environ['TMPDIR'], ignore_errors=True)
-        if self.original_tmpdir:
-            os.environ['TMPDIR'] = self.original_tmpdir
-        else:
-            del(os.environ['TMPDIR'])
+            fake_pipeline_conf]
 
     @mock.patch(
         'google.cloud.security.common.util.email_util.EmailUtil',
         autospec=True)
     def test_make_attachment_cleans_up_tempfile(self, mock_emailutil):
-        """Test that _make_attachment() leaves no temp files behind."""
-        tmp_dir = '{}/violations.*'.format(os.environ['TMPDIR'])
+        """Test that we leave no temp files behind."""
+        tmp_dir = '{}/*'.format(os.environ['TMPDIR'])
         tmp_files_before = glob.glob(tmp_dir)
-        self.gvp.mail_util = mock_emailutil
-        self.gvp.run()
+        gvp = email_violations_pipeline.EmailViolationsPipeline(*self.gvp_args)
+        gvp.mail_util = mock_emailutil
+        gvp.run()
         tmp_files_after = glob.glob(tmp_dir)
         self.assertEquals(tmp_files_before, tmp_files_after)
 
     def test_make_attachment_can_read_tempfile(self):
         """Test that _make_attachment() can read the temp file."""
         violations = '["violation: abc", "violation: def"]'
-        attachment = self.gvp._make_attachment()
+        gvp = email_violations_pipeline.EmailViolationsPipeline(*self.gvp_args)
+        attachment = gvp._make_attachment()
         decoded_content = base64.b64decode(attachment.content)
         self.assertEquals(decoded_content, violations)
 

--- a/tests/notifier/pipelines/email_violations_pipeline_test.py
+++ b/tests/notifier/pipelines/email_violations_pipeline_test.py
@@ -90,7 +90,7 @@ class EmailViolationsPipelineTest(ForsetiTestCase):
         violations = '["violation: abc", "violation: def"]'
         attachment = self.gvp._make_attachment()
         decoded_content = base64.b64decode(attachment.content)
-        self.assertEquals(decoded_content, violations)
+        self.assertEquals(violations, decoded_content)
 
 
 if __name__ == '__main__':

--- a/tests/notifier/pipelines/email_violations_pipeline_test.py
+++ b/tests/notifier/pipelines/email_violations_pipeline_test.py
@@ -14,6 +14,7 @@
 
 """Tests the Email Violations upload pipeline."""
 
+import base64
 from datetime import datetime
 import glob
 import mock
@@ -49,7 +50,7 @@ class EmailViolationsPipelineTest(ForsetiTestCase):
         self.gvp = email_violations_pipeline.EmailViolationsPipeline(
             'abcd',
             datetime.strftime(datetime.utcnow(), '%Y%m%dT%H%M%SZ'),
-            [],
+            ['violation: abc', 'violation: def'],
             fake_global_conf,
             {},
             fake_pipeline_conf)
@@ -74,6 +75,12 @@ class EmailViolationsPipelineTest(ForsetiTestCase):
         tmp_files_after = glob.glob(tmp_dir)
         self.assertEquals(tmp_files_before, tmp_files_after)
 
+    def test_make_attachment_can_read_tempfile(self):
+        """Test that _make_attachment() can read the temp file."""
+        violations = '["violation: abc", "violation: def"]'
+        attachment = self.gvp._make_attachment()
+        decoded_content = base64.b64decode(attachment.content)
+        self.assertEquals(decoded_content, violations)
 
 
 if __name__ == '__main__':

--- a/tests/notifier/pipelines/email_violations_pipeline_test.py
+++ b/tests/notifier/pipelines/email_violations_pipeline_test.py
@@ -1,0 +1,80 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests the Email Violations upload pipeline."""
+
+from datetime import datetime
+import glob
+import mock
+import os
+import shutil
+import tempfile
+import unittest
+
+from google.cloud.security.notifier.pipelines import email_violations_pipeline
+from tests.unittest_utils import ForsetiTestCase
+
+
+class EmailViolationsPipelineTest(ForsetiTestCase):
+    """Tests for email_violations_pipeline."""
+
+    def setUp(self):
+        """Setup."""
+        self.original_tmpdir = os.environ.get('TMPDIR')
+        os.environ['TMPDIR'] = tempfile.mkdtemp(prefix='forseti.')
+
+        fake_global_conf = {
+            'db_host': 'x',
+            'db_name': 'y',
+            'db_user': 'z',
+        }
+
+        fake_pipeline_conf = {
+            'sender': 'foo.sender@company.com',
+            'recipient': 'foo.recipient@company.com',
+            'sendgrid_api_key': 'foo_email_key',
+        }
+
+        self.gvp = email_violations_pipeline.EmailViolationsPipeline(
+            'abcd',
+            datetime.strftime(datetime.utcnow(), '%Y%m%dT%H%M%SZ'),
+            [],
+            fake_global_conf,
+            {},
+            fake_pipeline_conf)
+
+    def tearDown(self):
+        """Teardown."""
+        shutil.rmtree(os.environ['TMPDIR'], ignore_errors=True)
+        if self.original_tmpdir:
+            os.environ['TMPDIR'] = self.original_tmpdir
+        else:
+            del(os.environ['TMPDIR'])
+
+    @mock.patch(
+        'google.cloud.security.common.util.email_util.EmailUtil',
+        autospec=True)
+    def test_make_attachment_cleans_up_tempfile(self, mock_emailutil):
+        """Test that _make_attachment() leaves no temp files behind."""
+        tmp_dir = '{}/violations.*'.format(os.environ['TMPDIR'])
+        tmp_files_before = glob.glob(tmp_dir)
+        self.gvp.mail_util = mock_emailutil
+        self.gvp.run()
+        tmp_files_after = glob.glob(tmp_dir)
+        self.assertEquals(tmp_files_before, tmp_files_after)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/notifier/pipelines/email_violations_pipeline_test.py
+++ b/tests/notifier/pipelines/email_violations_pipeline_test.py
@@ -65,13 +65,13 @@ class EmailViolationsPipelineTest(ForsetiTestCase):
             'sendgrid_api_key': 'foo_email_key',
         }
 
-        self.gvp_args = [
+        self.gvp = email_violations_pipeline.EmailViolationsPipeline(
             'abcd',
             datetime.strftime(datetime.utcnow(), '%Y%m%dT%H%M%SZ'),
             ['violation: abc', 'violation: def'],
             fake_global_conf,
             {},
-            fake_pipeline_conf]
+            fake_pipeline_conf)
 
     @mock.patch(
         'google.cloud.security.common.util.email_util.EmailUtil',
@@ -80,17 +80,15 @@ class EmailViolationsPipelineTest(ForsetiTestCase):
         """Test that we leave no temp files behind."""
         tmp_dir = '{}/*'.format(os.environ['TMPDIR'])
         tmp_files_before = glob.glob(tmp_dir)
-        gvp = email_violations_pipeline.EmailViolationsPipeline(*self.gvp_args)
-        gvp.mail_util = mock_emailutil
-        gvp.run()
+        self.gvp.mail_util = mock_emailutil
+        self.gvp.run()
         tmp_files_after = glob.glob(tmp_dir)
         self.assertEquals(tmp_files_before, tmp_files_after)
 
     def test_make_attachment_can_read_tempfile(self):
         """Test that _make_attachment() can read the temp file."""
         violations = '["violation: abc", "violation: def"]'
-        gvp = email_violations_pipeline.EmailViolationsPipeline(*self.gvp_args)
-        attachment = gvp._make_attachment()
+        attachment = self.gvp._make_attachment()
         decoded_content = base64.b64decode(attachment.content)
         self.assertEquals(decoded_content, violations)
 


### PR DESCRIPTION
Hello there!

This PR fixes issue #757. The tests ascertain that the temp files after `run()` are the same ones as before.
In order to test that nicely I wanted a specific/isolated temp directory upon which the code under test would operate.
That required some fiddling around and module level setup prior to the first import of `tempfile` which does not pay any attention to `os.environ['TMPDIR']` afterwards.

pylint passes as do all the unit tests. Please take a look :-)