### PR TITLE
fixes: group members inventory marked as success when groups failed

### DIFF
--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -193,6 +193,9 @@ def _postprocess_statuses(pipelines, run_statuses):
     Example: if the `groups` pipeline failed then the `group_members` pipeline
     should be marked as a failure as well.
 
+    Please note: this function will modify the data passed to it via the
+    arguments below if/as needed.
+
     Args:
         pipelines (list): List of pipelines that were run.
         run_statuses (list): a list of booleans indicating whether each

--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -201,7 +201,21 @@ def _postprocess_statuses(pipelines, run_statuses):
         list: a (possibly adjusted) list of booleans indicating whether each
         pipeline completed successfully or not.
     """
-    pass
+    indices = dict(
+        (v, i) for (i, v) in enumerate(p.RESOURCE_NAME for p in pipelines))
+    grps_idx = indices.get('groups')
+    grp_members_idx = indices.get('group_members')
+    # Do nothing unless the status for both 'group_members' and 'groups' is
+    # present and the latter is `False`.
+    if (grps_idx is None or grp_members_idx is None or run_statuses[grps_idx]):
+        return run_statuses
+
+    if run_statuses[grp_members_idx]:
+        run_statuses[grp_members_idx] = False
+        pipelines[grp_members_idx].status = 'FAILURE'
+
+    return run_statuses
+
 
 def _complete_snapshot_cycle(inventory_dao, cycle_timestamp, status):
     """Complete the snapshot cycle.

--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -163,7 +163,7 @@ def _run_pipelines(pipelines):
         pipelines (list): List of pipelines to be run.
 
     Returns:
-        list: a list of booleans whether each pipeline completed
+        list: a list of booleans indicating whether each pipeline completed
             successfully or not.
     """
     # TODO: Define these status codes programmatically.
@@ -186,6 +186,22 @@ def _run_pipelines(pipelines):
             pipeline.status = 'FAILURE'
         run_statuses.append(pipeline.status == 'SUCCESS')
     return run_statuses
+
+def _postprocess_statuses(pipelines, run_statuses):
+    """Look at related `pipelines` and adjust run statuses as needed.
+    Example: if the `groups` pipeline failed then the `group_members` pipeline
+    should be marked as a failure as well.
+
+    Args:
+        pipelines (list): List of pipelines that were run.
+        run_statuses (list): a list of booleans indicating whether each
+        pipeline completed successfully or not.
+
+    Returns:
+        list: a (possibly adjusted) list of booleans indicating whether each
+        pipeline completed successfully or not.
+    """
+    pass
 
 def _complete_snapshot_cycle(inventory_dao, cycle_timestamp, status):
     """Complete the snapshot cycle.

--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -200,7 +200,7 @@ def _adjust_group_members_status(pipelines, run_statuses):
     Args:
         pipelines (list): List of pipelines that were run.
         run_statuses (list): a list of booleans indicating whether each
-        pipeline completed successfully or not.
+            pipeline completed successfully or not.
     """
     indices = dict(
         (v, i) for (i, v) in enumerate(p.RESOURCE_NAME for p in pipelines))

--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -185,16 +185,17 @@ def _run_pipelines(pipelines):
                          exc_info=True)
             pipeline.status = 'FAILURE'
         run_statuses.append(pipeline.status == 'SUCCESS')
-    _postprocess_statuses(pipelines, run_statuses)
+    _adjust_group_members_status(pipelines, run_statuses)
     return run_statuses
 
-def _postprocess_statuses(pipelines, run_statuses):
-    """Look at related `pipelines` and adjust run statuses as needed.
-    Example: if the `groups` pipeline failed then the `group_members` pipeline
+def _adjust_group_members_status(pipelines, run_statuses):
+    """Adjust the `run_status` for the `group_members` pipeline if needed.
+
+    If the `groups` pipeline failed then the `group_members` pipeline
     should be marked as a failure as well.
 
-    Please note: this function will modify the data passed to it via the
-    arguments below if/as needed.
+    Please note: this function will modify the data passed to it directly
+    if/as needed.
 
     Args:
         pipelines (list): List of pipelines that were run.

--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -200,11 +200,7 @@ def _postprocess_statuses(pipelines, run_statuses):
         pipelines (list): List of pipelines that were run.
         run_statuses (list): a list of booleans indicating whether each
         pipeline completed successfully or not.
-
-    Returns:
-        bool: `True` if adjustments were made and `False` otherwise.
     """
-    result = False
     indices = dict(
         (v, i) for (i, v) in enumerate(p.RESOURCE_NAME for p in pipelines))
     grps_idx = indices.get('groups')
@@ -212,14 +208,11 @@ def _postprocess_statuses(pipelines, run_statuses):
     # Do nothing unless the status for both 'group_members' and 'groups' is
     # present and the latter is `False`.
     if (grps_idx is None or grp_members_idx is None or run_statuses[grps_idx]):
-        return result
+        return
 
     if run_statuses[grp_members_idx]:
-        result = True
         run_statuses[grp_members_idx] = False
         pipelines[grp_members_idx].status = 'FAILURE'
-
-    return result
 
 
 def _complete_snapshot_cycle(inventory_dao, cycle_timestamp, status):

--- a/tests/inventory/inventory_loader_test.py
+++ b/tests/inventory/inventory_loader_test.py
@@ -23,9 +23,9 @@ from google.cloud.security.inventory import inventory_loader
 
 class _PIPELINE(object):
     """Mock `Pipeline` class."""
-    def __init__(this, RESOURCE_NAME, status):
-        this.RESOURCE_NAME = RESOURCE_NAME
-        this.status = status
+    def __init__(self, RESOURCE_NAME, status):
+        self.RESOURCE_NAME = RESOURCE_NAME
+        self.status = status
 
 
 class InventoryLoaderTest(ForsetiTestCase):

--- a/tests/inventory/inventory_loader_test.py
+++ b/tests/inventory/inventory_loader_test.py
@@ -61,6 +61,15 @@ class InventoryLoaderTest(ForsetiTestCase):
         self.assertFalse(
             inventory_loader._postprocess_statuses(pipelines, statuses))
 
+    def testPostprocessWithBothGroupsAndMembersFailed(self):
+        pipelines = [
+                _PIPELINE('groups', 'FAILURE'),
+                _PIPELINE('service_accounts', 'FAILURE'),
+                _PIPELINE('group_members', 'FAILURE')]
+        statuses = [False] * 3
+        self.assertFalse(
+            inventory_loader._postprocess_statuses(pipelines, statuses))
+
     def testPostprocessWithoutGroupmembersInventory(self):
         pipelines = [
                 _PIPELINE('instances', 'SUCCESS'),

--- a/tests/inventory/inventory_loader_test.py
+++ b/tests/inventory/inventory_loader_test.py
@@ -38,8 +38,9 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('group_members', 'SUCCESS')]
         statuses = [False, True, True]
         expected = [False, True, False]
-        actual = inventory_loader._postprocess_statuses(pipelines, statuses)
-        self.assertEqual(expected, actual)
+        self.assertTrue(
+            inventory_loader._postprocess_statuses(pipelines, statuses))
+        self.assertEqual(expected, statuses)
         self.assertEqual('FAILURE', pipelines[2].status)
 
     def testPostprocessWithGroupsInventorySuccess(self):
@@ -48,8 +49,8 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('service_accounts', 'SUCCESS'),
                 _PIPELINE('group_members', 'SUCCESS')]
         statuses = [True] * 3
-        actual = inventory_loader._postprocess_statuses(pipelines, statuses)
-        self.assertEqual(statuses, actual)
+        self.assertFalse(
+            inventory_loader._postprocess_statuses(pipelines, statuses))
 
     def testPostprocessWithoutGroupsInventory(self):
         pipelines = [
@@ -57,8 +58,8 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('service_accounts', 'SUCCESS'),
                 _PIPELINE('group_members', 'FAILURE')]
         statuses = [True, True, False]
-        actual = inventory_loader._postprocess_statuses(pipelines, statuses)
-        self.assertEqual(statuses, actual)
+        self.assertFalse(
+            inventory_loader._postprocess_statuses(pipelines, statuses))
 
     def testPostprocessWithoutGroupmembersInventory(self):
         pipelines = [
@@ -66,8 +67,8 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('service_accounts', 'SUCCESS'),
                 _PIPELINE('groups', 'FAILURE')]
         statuses = [True, True, False]
-        actual = inventory_loader._postprocess_statuses(pipelines, statuses)
-        self.assertEqual(statuses, actual)
+        self.assertFalse(
+            inventory_loader._postprocess_statuses(pipelines, statuses))
 
     def testPostprocessWithFailedGroupMembersInventory(self):
         pipelines = [
@@ -75,8 +76,8 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('service_accounts', 'SUCCESS'),
                 _PIPELINE('group_members', 'FAILURE')]
         statuses = [True, True, False]
-        actual = inventory_loader._postprocess_statuses(pipelines, statuses)
-        self.assertEqual(statuses, actual)
+        self.assertFalse(
+            inventory_loader._postprocess_statuses(pipelines, statuses))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/inventory/inventory_loader_test.py
+++ b/tests/inventory/inventory_loader_test.py
@@ -52,7 +52,7 @@ class InventoryLoaderTest(ForsetiTestCase):
         statuses = [False, True, True]
         expected = [False, True, False]
         self._take_snapshot(pipelines, statuses)
-        inventory_loader._postprocess_statuses(pipelines, statuses)
+        inventory_loader._adjust_group_members_status(pipelines, statuses)
         self.assertEqual(expected, statuses)
         self.assertEqual('FAILURE', pipelines[2].status)
         self.assertFalse(self._equals_the_originals(pipelines, statuses))
@@ -64,7 +64,7 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('group_members', 'SUCCESS')]
         statuses = [True] * 3
         self._take_snapshot(pipelines, statuses)
-        inventory_loader._postprocess_statuses(pipelines, statuses)
+        inventory_loader._adjust_group_members_status(pipelines, statuses)
         self.assertTrue(self._equals_the_originals(pipelines, statuses))
 
     def testPostprocessWithoutGroupsInventory(self):
@@ -74,7 +74,7 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('group_members', 'FAILURE')]
         statuses = [True, True, False]
         self._take_snapshot(pipelines, statuses)
-        inventory_loader._postprocess_statuses(pipelines, statuses)
+        inventory_loader._adjust_group_members_status(pipelines, statuses)
         self.assertTrue(self._equals_the_originals(pipelines, statuses))
 
     def testPostprocessWithBothGroupsAndMembersFailed(self):
@@ -84,7 +84,7 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('group_members', 'FAILURE')]
         statuses = [False] * 3
         self._take_snapshot(pipelines, statuses)
-        inventory_loader._postprocess_statuses(pipelines, statuses)
+        inventory_loader._adjust_group_members_status(pipelines, statuses)
         self.assertTrue(self._equals_the_originals(pipelines, statuses))
 
     def testPostprocessWithoutGroupmembersInventory(self):
@@ -94,7 +94,7 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('groups', 'FAILURE')]
         statuses = [True, True, False]
         self._take_snapshot(pipelines, statuses)
-        inventory_loader._postprocess_statuses(pipelines, statuses)
+        inventory_loader._adjust_group_members_status(pipelines, statuses)
         self.assertTrue(self._equals_the_originals(pipelines, statuses))
 
     def testPostprocessWithFailedGroupMembersInventory(self):
@@ -104,7 +104,7 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('group_members', 'FAILURE')]
         statuses = [True, True, False]
         self._take_snapshot(pipelines, statuses)
-        inventory_loader._postprocess_statuses(pipelines, statuses)
+        inventory_loader._adjust_group_members_status(pipelines, statuses)
         self.assertTrue(self._equals_the_originals(pipelines, statuses))
 
 if __name__ == '__main__':

--- a/tests/inventory/inventory_loader_test.py
+++ b/tests/inventory/inventory_loader_test.py
@@ -52,8 +52,7 @@ class InventoryLoaderTest(ForsetiTestCase):
         statuses = [False, True, True]
         expected = [False, True, False]
         self._take_snapshot(pipelines, statuses)
-        self.assertTrue(
-            inventory_loader._postprocess_statuses(pipelines, statuses))
+        inventory_loader._postprocess_statuses(pipelines, statuses)
         self.assertEqual(expected, statuses)
         self.assertEqual('FAILURE', pipelines[2].status)
         self.assertFalse(self._equals_the_originals(pipelines, statuses))
@@ -65,8 +64,7 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('group_members', 'SUCCESS')]
         statuses = [True] * 3
         self._take_snapshot(pipelines, statuses)
-        self.assertFalse(
-            inventory_loader._postprocess_statuses(pipelines, statuses))
+        inventory_loader._postprocess_statuses(pipelines, statuses)
         self.assertTrue(self._equals_the_originals(pipelines, statuses))
 
     def testPostprocessWithoutGroupsInventory(self):
@@ -76,8 +74,7 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('group_members', 'FAILURE')]
         statuses = [True, True, False]
         self._take_snapshot(pipelines, statuses)
-        self.assertFalse(
-            inventory_loader._postprocess_statuses(pipelines, statuses))
+        inventory_loader._postprocess_statuses(pipelines, statuses)
         self.assertTrue(self._equals_the_originals(pipelines, statuses))
 
     def testPostprocessWithBothGroupsAndMembersFailed(self):
@@ -87,8 +84,7 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('group_members', 'FAILURE')]
         statuses = [False] * 3
         self._take_snapshot(pipelines, statuses)
-        self.assertFalse(
-            inventory_loader._postprocess_statuses(pipelines, statuses))
+        inventory_loader._postprocess_statuses(pipelines, statuses)
         self.assertTrue(self._equals_the_originals(pipelines, statuses))
 
     def testPostprocessWithoutGroupmembersInventory(self):
@@ -98,8 +94,7 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('groups', 'FAILURE')]
         statuses = [True, True, False]
         self._take_snapshot(pipelines, statuses)
-        self.assertFalse(
-            inventory_loader._postprocess_statuses(pipelines, statuses))
+        inventory_loader._postprocess_statuses(pipelines, statuses)
         self.assertTrue(self._equals_the_originals(pipelines, statuses))
 
     def testPostprocessWithFailedGroupMembersInventory(self):
@@ -109,8 +104,7 @@ class InventoryLoaderTest(ForsetiTestCase):
                 _PIPELINE('group_members', 'FAILURE')]
         statuses = [True, True, False]
         self._take_snapshot(pipelines, statuses)
-        self.assertFalse(
-            inventory_loader._postprocess_statuses(pipelines, statuses))
+        inventory_loader._postprocess_statuses(pipelines, statuses)
         self.assertTrue(self._equals_the_originals(pipelines, statuses))
 
 if __name__ == '__main__':

--- a/tests/inventory/inventory_loader_test.py
+++ b/tests/inventory/inventory_loader_test.py
@@ -44,7 +44,7 @@ class InventoryLoaderTest(ForsetiTestCase):
         """True if the data passed equals the most recent snapshots."""
         return (self.a_copy == a) and (self.b_copy == b)
 
-    def testPostprocessWithFailedGroupsInventory(self):
+    def test_adjust_group_members_status_with_failed_groups_inventory(self):
         pipelines = [
                 _PIPELINE('groups', 'FAILURE'),
                 _PIPELINE('service_accounts', 'SUCCESS'),
@@ -57,7 +57,7 @@ class InventoryLoaderTest(ForsetiTestCase):
         self.assertEqual('FAILURE', pipelines[2].status)
         self.assertFalse(self._equals_the_originals(pipelines, statuses))
 
-    def testPostprocessWithGroupsInventorySuccess(self):
+    def test_adjust_group_members_status_with_groups_inventory_success(self):
         pipelines = [
                 _PIPELINE('groups', 'SUCCESS'),
                 _PIPELINE('service_accounts', 'SUCCESS'),
@@ -67,7 +67,7 @@ class InventoryLoaderTest(ForsetiTestCase):
         inventory_loader._adjust_group_members_status(pipelines, statuses)
         self.assertTrue(self._equals_the_originals(pipelines, statuses))
 
-    def testPostprocessWithoutGroupsInventory(self):
+    def test_adjust_group_members_status_without_groups_inventory(self):
         pipelines = [
                 _PIPELINE('instances', 'SUCCESS'),
                 _PIPELINE('service_accounts', 'SUCCESS'),
@@ -77,7 +77,7 @@ class InventoryLoaderTest(ForsetiTestCase):
         inventory_loader._adjust_group_members_status(pipelines, statuses)
         self.assertTrue(self._equals_the_originals(pipelines, statuses))
 
-    def testPostprocessWithBothGroupsAndMembersFailed(self):
+    def test_adjust_group_members_status_with_both_groups_and_members_failed(self):
         pipelines = [
                 _PIPELINE('groups', 'FAILURE'),
                 _PIPELINE('service_accounts', 'FAILURE'),
@@ -87,7 +87,7 @@ class InventoryLoaderTest(ForsetiTestCase):
         inventory_loader._adjust_group_members_status(pipelines, statuses)
         self.assertTrue(self._equals_the_originals(pipelines, statuses))
 
-    def testPostprocessWithoutGroupmembersInventory(self):
+    def test_adjust_group_members_status_without_group_members_inventory(self):
         pipelines = [
                 _PIPELINE('instances', 'SUCCESS'),
                 _PIPELINE('service_accounts', 'SUCCESS'),
@@ -97,7 +97,7 @@ class InventoryLoaderTest(ForsetiTestCase):
         inventory_loader._adjust_group_members_status(pipelines, statuses)
         self.assertTrue(self._equals_the_originals(pipelines, statuses))
 
-    def testPostprocessWithFailedGroupMembersInventory(self):
+    def test_adjust_group_members_status_with_failed_group_members_inventory(self):
         pipelines = [
                 _PIPELINE('groups', 'SUCCESS'),
                 _PIPELINE('service_accounts', 'SUCCESS'),


### PR DESCRIPTION
Hello there!

This fixes issue #615. I am seeing a weird issue though. When I remove the `import mock` line in `inventory_loader_test.py` and run the tests (via `python -m unittest tests.inventory.inventory_loader_test.InventoryLoaderTest`) I get the following stack trace: https://pastebin.com/hpygZTnK

With the `import mock` in place all tests pass. Any ideas why this might be?