### PR TITLE
Use the right resource identifier in the violations

### DIFF
--- a/google/cloud/security/scanner/scanners/bigquery_scanner.py
+++ b/google/cloud/security/scanner/scanners/bigquery_scanner.py
@@ -68,7 +68,7 @@ class BigqueryScanner(base_scanner.BaseScanner):
             violation_data['access_group_by_email'] = violation.group_email
             violation_data['role'] = violation.role
             yield {
-                'resource_id': violation.resource_id,
+                'resource_id': violation.dataset_id,
                 'resource_type': violation.resource_type,
                 'rule_index': violation.rule_index,
                 'rule_name': violation.rule_name,

--- a/google/cloud/security/scanner/scanners/bucket_rules_scanner.py
+++ b/google/cloud/security/scanner/scanners/bucket_rules_scanner.py
@@ -66,7 +66,7 @@ class BucketsAclScanner(base_scanner.BaseScanner):
             violation_data['domain'] = violation.domain
             violation_data['bucket'] = violation.bucket
             yield {
-                'resource_id': violation.resource_id,
+                'resource_id': violation.bucket,
                 'resource_type': violation.resource_type,
                 'rule_index': violation.rule_index,
                 'rule_name': violation.rule_name,

--- a/google/cloud/security/scanner/scanners/cloudsql_rules_scanner.py
+++ b/google/cloud/security/scanner/scanners/cloudsql_rules_scanner.py
@@ -66,7 +66,7 @@ class CloudSqlAclScanner(base_scanner.BaseScanner):
                                                   violation.authorized_networks
             violation_data['ssl_enabled'] = violation.ssl_enabled
             yield {
-                'resource_id': violation.resource_id,
+                'resource_id': violation.instance_name,
                 'resource_type': violation.resource_type,
                 'rule_index': violation.rule_index,
                 'rule_name': violation.rule_name,

--- a/google/cloud/security/scanner/scanners/instance_network_interface_scanner.py
+++ b/google/cloud/security/scanner/scanners/instance_network_interface_scanner.py
@@ -68,7 +68,7 @@ class InstanceNetworkInterfaceScanner(base_scanner.BaseScanner):
             violation_data['ip'] = violation.ip
             violation_data['raw_data'] = violation.raw_data
             yield {
-                'resource_id': 'instance_network_interface',
+                'resource_id': violation.project,
                 'resource_type': violation.resource_type,
                 'rule_index': violation.rule_index,
                 'rule_name': violation.rule_name,


### PR DESCRIPTION
This is the same as in the 2.0 PR #993, and would be nice to have in 1.0 as well.