### PR TITLE
Replace IAM Explain with just Explain

### DIFF
--- a/_docs/concepts/forseti-service-accounts.md
+++ b/_docs/concepts/forseti-service-accounts.md
@@ -13,9 +13,9 @@ scenarios for which it's best to use separate service accounts:
  inventory, scanning, and enforcement actions.
  * **[G Suite Groups service account](#g-suite-groups-service-account)**
  (optional): Used to inventory G Suite Groups and their members.
- Forseti IAM Explain requires this to be enabled.
+ Forseti Explain requires this to be enabled.
  * **[Forseti Explain service account](#forseti-explain-service-account)**
- (optional): Used to provide IAM Explain functionality.
+ (optional): Used to provide Explain functionality.
 
 When naming service accounts, it's best to use a descriptive name like
 `forseti-security` or `forseti-security-gsuite`.
@@ -39,13 +39,13 @@ G Suite Group inventory and create a service account, a good name
 for the service account would be `forseti-security-gsuite-groups`.
 
 ### Forseti Explain service account
-You can use the Forseti Security service account for IAM Explain. However,
+You can use the Forseti Security service account for Explain. However,
 since the `explain` service is an interactive tool and runs on its own
 Compute Engine instance, it's best to apply privilege separation principles
-by creating a separate service account for IAM Explain.
+by creating a separate service account for Explain.
 
-If you enable IAM Explain and create a service account, a good name for the
-service account would be `forseti-security-iam-explain`.
+If you enable Explain and create a service account, a good name for the
+service account would be `forseti-security-explain`.
 
 ## Service account key security
 Whether you install and deploy Forseti manually or by using the setup wizard,
@@ -74,7 +74,7 @@ service account needs is read-access on the Groups and Group Members services.
 
  * `https://www.googleapis.com/auth/admin.directory.group.readonly`
  
-### Service account for Forseti IAM Explain
+### Service account for Forseti Explain
 Forseti Explain should have its own service account and it only requires access
 to read from the inventory stored in Cloud SQL.
 

--- a/_docs/configure/explain/index.md
+++ b/_docs/configure/explain/index.md
@@ -1,19 +1,19 @@
 ---
-title: IAM Explain
+title: Explain
 order: 202
 ---
 # {{ page.title }}
 
-IAM Explain is not part of the main Forseti releases from master. Please
-deploy from the [IAM Explain experimental branch](https://github.com/GoogleCloudPlatform/forseti-security/tree/explain-experimental).
+Explain is not part of the main Forseti releases from master. Please
+deploy from the [Explain experimental branch](https://github.com/GoogleCloudPlatform/forseti-security/tree/explain-experimental).
 
-This page describes how to set up IAM Explain for Forseti Security.
-IAM Explain is a client-server based application that helps administrators,
+This page describes how to set up Explain for Forseti Security.
+Explain is a client-server based application that helps administrators,
 auditors, and users of Google Cloud to understand, test, and develop Cloud
 Identity and Access Management (Cloud IAM) policies. It can enumerate access by
 resource or member, answer why a principal has access to a certain resource, or
 offer possible strategies for how to grant a specific resource. You'll use a
-command-line interface to deploy IAM Explain on a dedicated virtual machine.
+command-line interface to deploy Explain on a dedicated virtual machine.
 
 For more detail about your Cloud IAM policies, you can use the denormalizer,
 which calculates all the principals, permissions, and resources for the model.
@@ -23,12 +23,12 @@ denormalizer, run `forseti_iam explainer denormalize` or
 `forseti_iam explainer --help`. You can also explore the `forseti_iam` tool by
 using `forseti_iam --help`.
 
-Because IAM Explain and its API are still in early development, third party
+Because Explain and its API are still in early development, third party
 clients won't be supported until a first stable API version is released.
 
-## Deploying IAM Explain 
+## Deploying Explain 
 
-You can use the provided [IAM Explain deployment script](https://github.com/GoogleCloudPlatform/forseti-security/blob/explain-experimental/scripts/iam_auto_deployment.sh) that will walk you through
+You can use the provided [Explain deployment script](https://github.com/GoogleCloudPlatform/forseti-security/blob/explain-experimental/scripts/iam_auto_deployment.sh) that will walk you through
 the deployment. Make sure you have the permission inside your organization to
 create projects, set IAM policies, create service accounts and enable the required
 APIs.
@@ -50,7 +50,7 @@ startup script to install all dependencies and start the services. You can obser
 the progress by looking at the deployment log at /tmp/deployment.log.
 ## Running the client
 
-The IAM Explain client uses hierarchical command parsing. At the top level,
+The Explain client uses hierarchical command parsing. At the top level,
 commands divide into "explainer" and "playground".
 
 ### Setting up an explain model
@@ -83,7 +83,7 @@ $ forseti_iam --use-model ... explainer denormalize
 
 ## Running the server
 
-The IAM Explain server uses its own database for IAM models, simulations and inventory.
+The Explain server uses its own database for IAM models, simulations and inventory.
 
 
   - Standard start/restart, if you used the deployment manager to create IAM
@@ -97,7 +97,7 @@ The IAM Explain server uses its own database for IAM models, simulations and inv
     - The services should automatically start right after the deployment.
     - You can find a deployment log at `/tmp/deployment.log`.
 
-### Using IAM Explain
+### Using Explain
 
 To use a model, run the commands below:
 
@@ -123,7 +123,7 @@ To use a model, run the commands below:
 
 ### Using the playground
 
-IAM Explain playground is a simluator that allows you to inspect and modify
+Explain playground is a simluator that allows you to inspect and modify
 the current state of a model. For example,
 `forseti_iam playground list_resources` displays all the resources available
 in the model. On its own, it enables you to set and check new policies. When
@@ -131,5 +131,5 @@ used with an explain model, it also enables you to simulate a state
 modification and compare it to the live explain output.
 
 To view all the
-commands available for IAM Explain playground, run
+commands available for Explain playground, run
 `forseti_iam playground --help`.

--- a/_docs/setup/install-forseti-security.md
+++ b/_docs/setup/install-forseti-security.md
@@ -84,7 +84,7 @@ in Cloud Shell. To prepare to run the Forseti setup wizard, follow the steps bel
        to whom Forseti should send the email notifications.
      * G Suite super admin email: This is part of the 
        [G Suite Google Groups collection]({% link _docs/configure/gsuite-group-collection.md %}) 
-       and is necessary for running [IAM Explain]({% link _docs/configure/explain/index.md %}). 
+       and is necessary for running [Explain]({% link _docs/configure/explain/index.md %}). 
        Ask your G Suite Admin if you don't know what the super admin email is.
 
   1. If you previously used Cloud Shell to SSH to a Compute Engine instance and 
@@ -95,7 +95,7 @@ in Cloud Shell. To prepare to run the Forseti setup wizard, follow the steps bel
 
   1. After the setup wizard successfully completes Forseti setup and deployment, 
      complete the steps to [enable G Suite Google Groups collection]({% link _docs/configure/gsuite-group-collection.md %}).
-     This is a **required** step if you also plan to deploy IAM Explain.
+     This is a **required** step if you also plan to deploy Explain.
 
 ## What's next
 

--- a/about/index.md
+++ b/about/index.md
@@ -80,9 +80,9 @@ notifying you when specific policies change unexpectedly.
 
 ### [Explain]({% link _docs/configure/explain/index.md %})
 
-Use an addon module like IAM Explain to understand your Cloud Identity and
+Use an addon module like Explain to understand your Cloud Identity and
 Access Management (Cloud IAM) access policies in context of your groups and
-resources. IAM Explain can help you understand the following:
+resources. Explain can help you understand the following:
 
 Who has access to what resource and how that user can interact with the
 resource. Why a principal has permission on a resource, or why they don't have a


### PR DESCRIPTION
This PR simplifies the naming of IAM explain to just Explain. This PR does NOT apply any logic to whether the changed documents should still exist and/or are relevant in 2.0. It just simply removes the reference. 