### PR TITLE
Create the docs/use/ documentation path.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,6 +59,10 @@ defaults:
     values:
       category: Setup
   - scope:
+      path: _docs/use
+    values:
+      category: Use
+  - scope:
       path: _docs/configure
     values:
       category: Configure

--- a/_data/doc_categories.yml
+++ b/_data/doc_categories.yml
@@ -4,6 +4,8 @@
   href: docs/concepts/
 - title: Setup
   href: docs/setup/
+- title: Use
+  href: docs/use/
 - title: Configure
   href: docs/configure/
 - title: Develop

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -13,6 +13,10 @@ Learn the core concepts and get an overview of each Forseti Security module.
 
 Setup and install Forseti.
 
+**[Using]({% link _docs/use/index.md %})**
+
+Using Forseti.
+
 **[Configure]({% link _docs/configure/index.md %})**
 
 Get started with Forseti Security and modules in a few minutes.

--- a/_docs/use/index.md
+++ b/_docs/use/index.md
@@ -1,0 +1,6 @@
+---
+title: Use
+order: 002
+---
+
+TBD


### PR DESCRIPTION
This creates the _docs/use/ directory path. One small change is from using to use as that better aligns with the tense of the other document category names.