### PR TITLE
Improving setup

### DIFF
--- a/deployment-templates/compute-engine/forseti-instance.py
+++ b/deployment-templates/compute-engine/forseti-instance.py
@@ -161,9 +161,8 @@ sudo apt-get install -y git unzip
 sudo apt-get install -y $(cat setup/dependencies/apt_packages.txt | grep -v "#" | xargs)
 
 # Forseti dependencies
-pip install --upgrade pip
-pip install --upgrade setuptools
-pip install -r setup/dependencies/pip_packages.txt
+pip install -q --upgrade setuptools pkg_resources pip wheel
+pip install -q --upgrade -r requirements.txt
 
 # Set ownership of config and rules to $USER
 chown -R $USER {forseti_home}/configs {forseti_home}/rules {forseti_home}/setup/gcp/scripts/run_forseti.sh

--- a/deployment-templates/compute-engine/forseti-instance.py
+++ b/deployment-templates/compute-engine/forseti-instance.py
@@ -161,14 +161,11 @@ sudo apt-get install -y git unzip
 sudo apt-get install -y $(cat setup/dependencies/apt_packages.txt | grep -v "#" | xargs)
 
 # Forseti dependencies
-pip install -q --upgrade setuptools pkg_resources pip wheel
+pip install -q --upgrade setuptools pip wheel
 pip install -q --upgrade -r requirements.txt
 
 # Set ownership of config and rules to $USER
 chown -R $USER {forseti_home}/configs {forseti_home}/rules {forseti_home}/setup/gcp/scripts/run_forseti.sh
-
-# Build protos.
-python setup.py build_protos
 
 # Install Forseti
 python setup.py install

--- a/google/cloud/forseti/scanner/scanners/groups_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/groups_scanner.py
@@ -14,8 +14,8 @@
 
 """Scanner for Google Groups."""
 
-import anytree
 import yaml
+import anytree
 
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.scanner.scanners import base_scanner

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 protobuf
 grpcio
 grpcio-tools
+pyYAML
 
 # Needed for CI/CD and Development.
 codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# These are here instead of setup.py, that way they won't build from source.
+# Needed for compliation of Forseti protos during the build & install.
 protobuf
 grpcio
 grpcio-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-# Needed for compliation of Forseti protos during the build & install.
+# Any dependencies added here should be related to the compiling/testing of Forseti. Additions,
+# here should also be added to setup.py
+
+# Needed for compiling of Forseti protos during the build & install.
 protobuf
 grpcio
 grpcio-tools

--- a/setup/docker/base
+++ b/setup/docker/base
@@ -22,5 +22,5 @@ FROM ubuntu:16.04
 ADD . /forseti-security/
 WORKDIR /forseti-security/
 RUN apt-get update -qq 1> /dev/null
-RUN apt-get install -qq -y $(cat setup/dependencies/apt_packages.txt | grep -v "#" | xargs) 1> /devnull
+RUN apt-get install -qq -y $(cat setup/dependencies/apt_packages.txt | grep -v "#" | xargs) 1> /dev/null
 RUN rm -rf /var/lib/apt/lists/*

--- a/setup/docker/forseti
+++ b/setup/docker/forseti
@@ -21,10 +21,10 @@ WORKDIR /forseti-security/
 
 # Install Forseti Security dependencies.
 RUN pip install -q --upgrade setuptools pip wheel 1> /dev/null
-RUN pip install -q --upgrade -r setup/dependencies/pip_packages.txt 1> /dev/null
+RUN pip install -q --upgrade -r requirements.txt 1> /dev/null
 
 # Install Forseti Security.
-RUN pip install .
+RUN python setup.py install
 
 # Test to see Forseti Security was installed.
 RUN yes | which forseti_server

--- a/setup/docker/forseti
+++ b/setup/docker/forseti
@@ -20,6 +20,8 @@ ADD . /forseti-security/
 WORKDIR /forseti-security/
 
 # Install Forseti Security dependencies.
+# This should stay in sync with the deployment script used on the host machine in
+#   deployment-templates/compute-engine/forseti-instance.py
 RUN pip install -q --upgrade setuptools pip wheel 1> /dev/null
 RUN pip install -q --upgrade -r requirements.txt 1> /dev/null
 

--- a/setup/docker/forseti
+++ b/setup/docker/forseti
@@ -18,7 +18,7 @@ FROM ${BASE_IMAGE}
 ADD . /forseti-security/
 WORKDIR /forseti-security/
 
-RUN pip install -q --upgrade setuptools pkg_resources pip wheel 1> /dev/null
+RUN pip install -q --upgrade setuptools pip wheel 1> /dev/null
 RUN pip install -q --upgrade -r requirements.txt 1> /dev/null
-RUN python setup.py install 1> /dev/null
+RUN pip install .
 RUN yes | which forseti_server

--- a/setup/docker/forseti
+++ b/setup/docker/forseti
@@ -19,6 +19,6 @@ ADD . /forseti-security/
 WORKDIR /forseti-security/
 
 RUN pip install -q --upgrade setuptools pkg_resources pip wheel 1> /dev/null
-RUN pip install -q -r requirements.txt --upgrade 1> /dev/null
+RUN pip install -q --upgrade -r requirements.txt 1> /dev/null
 RUN python setup.py install 1> /dev/null
 RUN yes | which forseti_server

--- a/setup/docker/forseti
+++ b/setup/docker/forseti
@@ -18,7 +18,7 @@ FROM ${BASE_IMAGE}
 ADD . /forseti-security/
 WORKDIR /forseti-security/
 
-RUN pip install -q --upgrade pip 1> /dev/null
-RUN pip install -q -r setup/dependencies/pip_packages.txt --upgrade 1> /dev/null
+RUN pip install -q --upgrade setuptools pkg_resources pip wheel 1> /dev/null
+RUN pip install -q -r requirements.txt --upgrade 1> /dev/null
 RUN python setup.py install 1> /dev/null
 RUN yes | which forseti_server


### PR DESCRIPTION
This should finally unify our dependencies and setup needs.

Installation of forseti including its build requirements that works universally is now completed as:

`pip install --upgrade -r requirements.txt`
`python setup.py install`

This ensures `libyaml` and the `protoc` compiler are installed on the host prior to installation so we can build our protos effectively.