### PR TITLE
Add configurable cleanup of inventory tables (#438)

### DIFF
--- a/configs/forseti_conf.yaml.in
+++ b/configs/forseti_conf.yaml.in
@@ -55,6 +55,9 @@ inventory:
     # Valid values are: debug, info, warning, error
     loglevel: info
 
+    # Number of days to retain inventory data, 0 to keep forever
+    retention_days: 30
+
     pipelines:
         - resource: appengine
           enabled: true

--- a/configs/forseti_conf.yaml.in
+++ b/configs/forseti_conf.yaml.in
@@ -55,8 +55,10 @@ inventory:
     # Valid values are: debug, info, warning, error
     loglevel: info
 
-    # Number of days to retain inventory data, 0 to keep forever
-    retention_days: 30
+    # Number of days to retain inventory data: 
+    #  -1 : (default) keep all previous data forever
+    #   0 : delete all previous inventory data before running
+    retention_days: -1
 
     pipelines:
         - resource: appengine

--- a/configs/forseti_conf.yaml.sample
+++ b/configs/forseti_conf.yaml.sample
@@ -50,6 +50,11 @@ inventory:
     # Valid values are: debug, info, warning, error
     loglevel: info
 
+    # Number of days to retain inventory data: 
+    #  -1 : (default) keep all previous data forever
+    #   0 : delete all previous inventory data before running
+    retention_days: -1
+
     pipelines:
         - resource: appengine
           enabled: true

--- a/google/cloud/security/common/data_access/forseti_system_dao.py
+++ b/google/cloud/security/common/data_access/forseti_system_dao.py
@@ -45,11 +45,8 @@ class ForsetiSystemDao(dao.Dao):
         result = self.execute_sql_with_fetch(
             cleanup_tables_sql.RESOURCE_NAME,
             sql,
-<<<<<<< HEAD
             [retention_days, self.db_name])
-=======
-            [retention_days])
->>>>>>> c39d48d5fa3e289c328afdc372e965111502f67c
+
         LOGGER.info(
             'Found %s tables to clean up that are older than %s days',
             len(result),

--- a/google/cloud/security/common/data_access/forseti_system_dao.py
+++ b/google/cloud/security/common/data_access/forseti_system_dao.py
@@ -24,7 +24,13 @@ LOGGER = log_util.get_logger(__name__)
 
 
 class ForsetiSystemDao(dao.Dao):
-    """Data access object (DAO) for Forseti system management."""
+    """Data access object (DAO) for Forseti system management.
+        Args:
+            global_configs (dict): Global config - used to lookup db_name
+    """
+    def __init__(self, global_configs=None):
+        dao.Dao.__init__(self, global_configs)
+        self.db_name = global_configs['db_name']
 
     def cleanup_inventory_tables(self, retention_days):
         """Clean up old inventory tables based on their age
@@ -39,7 +45,7 @@ class ForsetiSystemDao(dao.Dao):
         result = self.execute_sql_with_fetch(
             cleanup_tables_sql.RESOURCE_NAME,
             sql,
-            [retention_days])
+            [retention_days, self.db_name])
         LOGGER.info(
             'Found %s tables to clean up that are older than %s days',
             len(result),

--- a/google/cloud/security/common/data_access/forseti_system_dao.py
+++ b/google/cloud/security/common/data_access/forseti_system_dao.py
@@ -1,0 +1,53 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provides the data access object (DAO) for Forseti system management."""
+
+from google.cloud.security.common.data_access import dao
+# pylint: disable=line-too-long
+from google.cloud.security.common.data_access.sql_queries import cleanup_tables_sql
+from google.cloud.security.common.util import log_util
+
+
+LOGGER = log_util.get_logger(__name__)
+
+
+class ForsetiSystemDao(dao.Dao):
+    """Data access object (DAO) for Forseti system management."""
+
+    def cleanup_inventory_tables(self, retention_days):
+        """Clean up old inventory tables based on their age
+
+        Will detect tables based on snapshot end time in snapshot table,
+        and drop tables older than retention_days specified.
+
+        Args:
+            retention_days (int): Days of inventory tables to retain.
+        """
+        sql = cleanup_tables_sql.SELECT_SNAPSHOT_TABLES_OLDER_THAN
+        result = self.execute_sql_with_fetch(
+            cleanup_tables_sql.RESOURCE_NAME,
+            sql,
+            [retention_days])
+        LOGGER.info(
+            'Found %s tables to clean up that are older than %s days',
+            len(result),
+            retention_days)
+
+        for row in result:
+            LOGGER.debug('Dropping table: %s', row['table'])
+            self.execute_sql_with_commit(
+                cleanup_tables_sql.RESOURCE_NAME,
+                cleanup_tables_sql.DROP_TABLE.format(row['table']),
+                None)

--- a/google/cloud/security/common/data_access/forseti_system_dao.py
+++ b/google/cloud/security/common/data_access/forseti_system_dao.py
@@ -25,7 +25,8 @@ LOGGER = log_util.get_logger(__name__)
 
 class ForsetiSystemDao(dao.Dao):
     """Data access object (DAO) for Forseti system management.
-        Args:
+
+    Args:
             global_configs (dict): Global config - used to lookup db_name
     """
     def __init__(self, global_configs=None):
@@ -35,7 +36,7 @@ class ForsetiSystemDao(dao.Dao):
     def cleanup_inventory_tables(self, retention_days):
         """Clean up old inventory tables based on their age
 
-        Will detect tables based on snapshot end time in snapshot table,
+        Will detect tables based on snapshot start time in snapshot table,
         and drop tables older than retention_days specified.
 
         Args:

--- a/google/cloud/security/common/data_access/sql_queries/cleanup_tables_sql.py
+++ b/google/cloud/security/common/data_access/sql_queries/cleanup_tables_sql.py
@@ -1,0 +1,28 @@
+# Copyright 2018 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+"""SQL queries for management of inventory tables."""
+
+RESOURCE_NAME = 'cleanup_tables'
+
+SELECT_SNAPSHOT_TABLES_OLDER_THAN = """
+    SELECT tables.TABLE_NAME 'table'
+    from information_schema.tables as tables
+    inner join snapshot_cycles as snap
+    ON snap.complete_time < DATE_SUB(NOW(), INTERVAL %s DAY)
+    AND tables.TABLE_NAME LIKE CONCAT('%%', snap.cycle_timestamp);
+"""
+
+DROP_TABLE = "DROP TABLE {0}"

--- a/google/cloud/security/common/data_access/sql_queries/cleanup_tables_sql.py
+++ b/google/cloud/security/common/data_access/sql_queries/cleanup_tables_sql.py
@@ -21,8 +21,9 @@ SELECT_SNAPSHOT_TABLES_OLDER_THAN = """
     SELECT tables.TABLE_NAME 'table'
     from information_schema.tables as tables
     inner join snapshot_cycles as snap
-    ON snap.complete_time < DATE_SUB(NOW(), INTERVAL %s DAY)
-    AND tables.TABLE_NAME LIKE CONCAT('%%', snap.cycle_timestamp);
+    ON snap.start_time < DATE_SUB(NOW(), INTERVAL %s DAY)
+    AND tables.TABLE_NAME LIKE CONCAT('%%', snap.cycle_timestamp)
+    WHERE tables.TABLE_SCHEMA = %s;
 """
 
 DROP_TABLE = "DROP TABLE {0}"

--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -355,8 +355,6 @@ def main(_):
     _complete_snapshot_cycle(dao_map.get('dao'), cycle_timestamp,
                              snapshot_cycle_status)
 
-    _cleanup_tables(inventory_configs, dao_map)
-
     if global_configs.get('email_recipient') is not None:
         payload = {
             'email_sender': global_configs.get('email_sender'),

--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -293,9 +293,9 @@ def _cleanup_tables(inventory_configs, dao_map):
         dao_map (dict): Lookup dict for DAO objects
     """
 
-    retention_days = max(0, inventory_configs.get('retention_days', 0))
+    retention_days = max(-1, inventory_configs.get('retention_days', -1))
     LOGGER.info('Retention period: %s days', retention_days)
-    if retention_days:
+    if retention_days > -1:
         system_dao = dao_map.get('forseti_system_dao')
         system_dao.cleanup_inventory_tables(retention_days)
 
@@ -331,6 +331,8 @@ def main(_):
 
     dao_map = _create_dao_map(global_configs)
 
+    _cleanup_tables(inventory_configs, dao_map)
+
     cycle_time, cycle_timestamp = _start_snapshot_cycle(dao_map.get('dao'))
 
     pipeline_builder = builder.PipelineBuilder(
@@ -352,8 +354,6 @@ def main(_):
 
     _complete_snapshot_cycle(dao_map.get('dao'), cycle_timestamp,
                              snapshot_cycle_status)
-
-    _cleanup_tables(inventory_configs, dao_map)
 
     if global_configs.get('email_recipient') is not None:
         payload = {

--- a/google/cloud/security/inventory/inventory_loader.py
+++ b/google/cloud/security/inventory/inventory_loader.py
@@ -49,6 +49,7 @@ from google.cloud.security.common.data_access import organization_dao
 from google.cloud.security.common.data_access import project_dao
 from google.cloud.security.common.data_access import service_account_dao
 from google.cloud.security.common.data_access.sql_queries import snapshot_cycles_sql
+from google.cloud.security.common.data_access.sql_queries import cleanup_tables_sql
 from google.cloud.security.common.gcp_api import errors as api_errors
 from google.cloud.security.common.util import file_loader
 from google.cloud.security.common.util import log_util
@@ -282,6 +283,39 @@ def _create_dao_map(global_configs):
         LOGGER.error('Error to creating DAO map.\n%s', e)
         sys.exit()
 
+def _cleanup_inventory(inventory_dao, retention_days):
+    """Clean up old inventory tables based on their age
+
+    Will detect tables based on snapshot end time in snapshot table,
+    and drop tables older than retention_days specified.
+
+    Args:
+        inventory_dao (data_access.Dao): Data access object.
+        retention_days (int): Days of inventory tables to retain.
+    """
+
+    try:
+        sql = cleanup_tables_sql.SELECT_SNAPSHOT_TABLES_OLDER_THAN
+        result = inventory_dao.execute_sql_with_fetch(
+            cleanup_tables_sql.RESOURCE_NAME,
+            sql,
+            [retention_days])
+        LOGGER.info(
+            'Found %s tables to clean up that are older than %s days',
+            len(result),
+            retention_days)
+
+        for row in result:
+            LOGGER.debug('Dropping table: %s', row['table'])
+            inventory_dao.execute_sql_with_commit(
+                cleanup_tables_sql.RESOURCE_NAME,
+                cleanup_tables_sql.DROP_TABLE.format(row['table']),
+                None)
+
+    except data_access_errors.MySQLError as e:
+        LOGGER.error('Error in attempt to cleanup inventory: %s', e)
+        sys.exit()
+
 def main(_):
     """Runs the Inventory Loader.
 
@@ -334,6 +368,13 @@ def main(_):
 
     _complete_snapshot_cycle(dao_map.get('dao'), cycle_timestamp,
                              snapshot_cycle_status)
+
+
+    retention_days = max(0, inventory_configs.get('retention_days', 0))
+    LOGGER.info('Retention period: %s days', retention_days)
+    if retention_days:
+        _cleanup_inventory(dao_map.get('dao'), retention_days)
+
 
     if global_configs.get('email_recipient') is not None:
         payload = {

--- a/tests/common/data_access/forseti_system_dao_test.py
+++ b/tests/common/data_access/forseti_system_dao_test.py
@@ -1,0 +1,64 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests the ForsetiSystemDao."""
+
+import json
+
+from tests.unittest_utils import ForsetiTestCase
+import mock
+import unittest
+
+from MySQLdb import DataError
+
+from google.cloud.security.common.data_access import _db_connector
+from google.cloud.security.common.data_access import errors
+from google.cloud.security.common.data_access import forseti_system_dao
+from google.cloud.security.common.data_access.sql_queries import cleanup_tables_sql
+
+
+class ForsetiSystemDaoTest(ForsetiTestCase):
+    """Tests for the ForsetiSystemDao."""
+
+    @mock.patch.object(_db_connector.DbConnector, '__init__', autospec=True)
+    def setUp(self, mock_db_connector):
+        mock_db_connector.return_value = None
+        self.system_dao = forseti_system_dao.ForsetiSystemDao()
+        self.fetch_mock = mock.MagicMock()
+        self.commit_mock = mock.MagicMock()
+        self.system_dao.execute_sql_with_fetch = self.fetch_mock
+        self.system_dao.execute_sql_with_commit = self.commit_mock
+
+    def test_cleanup_inventory_tables(self):
+        """Test cleanup_inventory_tables(int)"""
+        self.fetch_mock.return_value = [{'table': 'foo'}, {'table': 'bar'}]
+        self.system_dao.cleanup_inventory_tables(7)
+
+        self.fetch_mock.assert_called_once_with(
+            cleanup_tables_sql.RESOURCE_NAME,
+            cleanup_tables_sql.SELECT_SNAPSHOT_TABLES_OLDER_THAN,
+            [7])
+
+        calls = [mock.call(
+            cleanup_tables_sql.RESOURCE_NAME,
+            cleanup_tables_sql.DROP_TABLE.format('foo'),
+            None),
+            mock.call(
+            cleanup_tables_sql.RESOURCE_NAME,
+            cleanup_tables_sql.DROP_TABLE.format('bar'),
+            None)]
+        self.commit_mock.assert_has_calls(calls)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/common/data_access/forseti_system_dao_test.py
+++ b/tests/common/data_access/forseti_system_dao_test.py
@@ -34,7 +34,8 @@ class ForsetiSystemDaoTest(ForsetiTestCase):
     @mock.patch.object(_db_connector.DbConnector, '__init__', autospec=True)
     def setUp(self, mock_db_connector):
         mock_db_connector.return_value = None
-        self.system_dao = forseti_system_dao.ForsetiSystemDao()
+        self.system_dao = forseti_system_dao.ForsetiSystemDao(
+            global_configs={'db_name': 'forseti_security'})
         self.fetch_mock = mock.MagicMock()
         self.commit_mock = mock.MagicMock()
         self.system_dao.execute_sql_with_fetch = self.fetch_mock
@@ -48,7 +49,7 @@ class ForsetiSystemDaoTest(ForsetiTestCase):
         self.fetch_mock.assert_called_once_with(
             cleanup_tables_sql.RESOURCE_NAME,
             cleanup_tables_sql.SELECT_SNAPSHOT_TABLES_OLDER_THAN,
-            [7])
+            [7, 'forseti_security'])
 
         calls = [mock.call(
             cleanup_tables_sql.RESOURCE_NAME,


### PR DESCRIPTION
Proposed solution for #438 

Adds a _retention_days_ property to the inventory configuration - at the end of the inventory run, it will drop any tables created by snapshot more than _retention_days_ old