### PR TITLE
Fix the construction of IAM policy 'full_name'.

### DIFF
--- a/google/cloud/forseti/services/model/importer/importer.py
+++ b/google/cloud/forseti/services/model/importer/importer.py
@@ -680,7 +680,7 @@ class InventoryImporter(object):
         parent, full_res_name = self._get_parent(iam_policy)
         iam_policy_type_name = to_type_name(
             iam_policy.get_type_class(),
-            '-'.join(parent.type_name.split('/')))
+            ':'.join(parent.type_name.split('/')))
         iam_policy_full_res_name = to_full_resource_name(
             full_res_name,
             iam_policy_type_name)

--- a/google/cloud/forseti/services/model/importer/importer.py
+++ b/google/cloud/forseti/services/model/importer/importer.py
@@ -679,8 +679,7 @@ class InventoryImporter(object):
         """
         parent, full_res_name = self._get_parent(iam_policy)
         iam_policy_type_name = to_type_name(
-            iam_policy.get_type_class(),
-            parent.type_name)
+            iam_policy.get_type_class(), parent.name)
         iam_policy_full_res_name = to_full_resource_name(
             full_res_name,
             iam_policy_type_name)

--- a/google/cloud/forseti/services/model/importer/importer.py
+++ b/google/cloud/forseti/services/model/importer/importer.py
@@ -679,7 +679,8 @@ class InventoryImporter(object):
         """
         parent, full_res_name = self._get_parent(iam_policy)
         iam_policy_type_name = to_type_name(
-            iam_policy.get_type_class(), parent.name)
+            iam_policy.get_type_class(),
+            '-'.join(parent.type_name.split('/')))
         iam_policy_full_res_name = to_full_resource_name(
             full_res_name,
             iam_policy_type_name)

--- a/tests/services/model/importer/importer_test.py
+++ b/tests/services/model/importer/importer_test.py
@@ -85,6 +85,12 @@ class ImporterTest(ForsetiTestCase):
                 inventory_id=FAKE_TIMESTAMP)
             import_runner.run()
 
+            # make sure the 'full_name' for policies has an even number of
+            # segments
+            for policy in data_access.scanner_iter(session, 'iam_policy'):
+                self.assertFalse(
+                        len(filter(None, policy.full_name.split('/'))) % 2)
+
         model = self.model_manager.model(self.model_name)
         model_description = self.model_manager.get_description(self.model_name)
 

--- a/tests/services/model/importer/importer_test.py
+++ b/tests/services/model/importer/importer_test.py
@@ -17,12 +17,10 @@ import os
 import shutil
 import tempfile
 import unittest
-import json
 from tests.unittest_utils import ForsetiTestCase
 from google.cloud.forseti.services.dao import create_engine
 from google.cloud.forseti.services.dao import ModelManager
 from google.cloud.forseti.services.model.importer import importer
-from google.cloud.forseti.services.inventory.storage import Storage as Inventory
 FAKE_TIMESTAMP = '2018-01-28T10:20:30.00000'
 
 


### PR DESCRIPTION
@jiyunyao: please make sure this does not affect playground or explain.  Thanks!

The construction of a 'full_name' for 'iam_policy' resources (and
possibly others) is broken since 3 segments are appended to the
'full_name' of the parent resulting e.g. in

    organization/111222333/iam_policy/organization/111222333/

This breaks other code (e.g. get_resources_from_full_name()) assuming
that a full_name consists of pairs of segments i.e.

    organization/111222333/iam_policy/111222333/

Fixes issue #1174.
