### PR TITLE
Improve created_at field in the violations table

### DIFF
--- a/google/cloud/forseti/common/util/string_formats.py
+++ b/google/cloud/forseti/common/util/string_formats.py
@@ -1,0 +1,27 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common formatting methods."""
+
+# Example: '2018-03-01T21:31:52'
+TIMESTAMP_UTC_OFFSET = '%Y-%m-%dT%H:%M:%S%z'
+
+# Example: '2018-03-01T21:32:24.491644'
+TIMESTAMP_MICROS = '%Y-%m-%dT%H:%M:%S.%f'
+
+# Example: '2018-03-01T21:33:59Z'
+TIMESTAMP_TIMEZONE_NAME = '%Y-%m-%dT%H:%M:%SZ'
+
+# Example: '01 March 2018 - 21:38:12'
+TIMESTAMP_HUMAN_READABLE = '%d %B %Y - %H:%M:%S'

--- a/google/cloud/forseti/services/scanner/dao.py
+++ b/google/cloud/forseti/services/scanner/dao.py
@@ -20,6 +20,7 @@ import hashlib
 import json
 
 from sqlalchemy import Column
+from sqlalchemy import DateTime
 from sqlalchemy import String
 from sqlalchemy import Integer
 from sqlalchemy import Text
@@ -39,8 +40,16 @@ LOGGER = logger.get_logger(__name__)
 
 TIMESTAMP_FORMAT = string_formats.TIMESTAMP_TIMEZONE_NAME
 
-def _get_created_at_timestamp(str_format=TIMESTAMP_FORMAT):
-    """Create a string representation of a timestamp with utcnow().
+def _get_utc_now():
+    """Get a datetime object for utcnow()
+
+    Returns:
+          datetime: A datetime object representin utcnow().
+    """
+    return datetime.utcnow()
+
+def _get_utc_now_timestamp(str_format=TIMESTAMP_FORMAT):
+    """Get a str representing utcnow()
 
     Args:
         str_format (str): The requested format string.
@@ -48,7 +57,9 @@ def _get_created_at_timestamp(str_format=TIMESTAMP_FORMAT):
     Returns:
           str: A timestamp in the classes default timestamp format.
     """
-    return datetime.utcnow().strftime(str_format)
+    utc_now = _get_utc_now()
+
+    return utc_now.strftime(str_format)
 
 def define_violation(dbengine):
     """Defines table class for violations.
@@ -71,7 +82,7 @@ def define_violation(dbengine):
         __tablename__ = violations_tablename
 
         id = Column(Integer, primary_key=True)
-        created_at_timestamp = Column(String(256))
+        created_at_datetime = Column(DateTime())
         full_name = Column(String(1024))
         inventory_data = Column(Text(16777215))
         inventory_index_id = Column(String(256))
@@ -128,9 +139,8 @@ def define_violation(dbengine):
                 inventory_index_id (str): Id of the inventory index.
             """
             with self.violationmaker() as session:
-                created_at_timestamp = self._get_created_at_timestamp()
+                created_at_datetime =_get_utc_now()
                 for violation in violations:
-
                     violation_hash = _create_violation_hash(
                         violation.get('full_name', ''),
                         violation.get('inventory_data', ''),
@@ -149,7 +159,7 @@ def define_violation(dbengine):
                             violation.get('violation_data')),
                         inventory_data=violation.get('inventory_data'),
                         violation_hash=violation_hash,
-                        created_at_timestamp=created_at_timestamp
+                        created_at_datetime=created_at_datetime
                     )
 
                     session.add(violation)

--- a/google/cloud/forseti/services/scanner/dao.py
+++ b/google/cloud/forseti/services/scanner/dao.py
@@ -139,7 +139,7 @@ def define_violation(dbengine):
                 inventory_index_id (str): Id of the inventory index.
             """
             with self.violationmaker() as session:
-                created_at_datetime =_get_utc_now()
+                created_at_datetime = _get_utc_now()
                 for violation in violations:
                     violation_hash = _create_violation_hash(
                         violation.get('full_name', ''),

--- a/tests/services/scanner/scanner_dao_test.py
+++ b/tests/services/scanner/scanner_dao_test.py
@@ -14,6 +14,7 @@
 
 """ Unit Tests for Scanner DAO. """
 
+from datetime import datetime
 import hashlib
 
 from itertools import izip
@@ -96,7 +97,7 @@ class ScannerDaoTest(ForsetiTestCase):
         keys = ['inventory_index_id', 'resource_id', 'full_name',
                 'resource_type', 'rule_name', 'rule_index', 'violation_type',
                 'violation_data', 'violation_hash', 'inventory_data',
-                'created_at_timestamp']
+                'created_at_datetime']
 
         for fake, saved in izip(FAKE_EXPECTED_VIOLATIONS, saved_violations):
             for key in keys:
@@ -117,11 +118,12 @@ class ScannerDaoTest(ForsetiTestCase):
                         '\nFound: %s' % (key, ',\n'.join(expected_hash_values),
                                          saved_key_value)
                     )
-                elif key == 'created_at_timestamp':
-                    # Don't check values, just its presence.
-                    self.assertIsNotNone(
-                        'The key value of "%s" is null: %s' % (
-                          key, saved_key_value)
+                elif key == 'created_at_datetime':
+                    self.assertIsInstance(
+                        saved_key_value, datetime,
+                        'The key value of "%s" differs:\n Expected type: %s'
+                        '\nFound type: %s' % (key, type(datetime),
+                                              type(saved_key_value))
                     )
                 else:
                     self.assertEquals(
@@ -175,10 +177,10 @@ class ScannerDaoTest(ForsetiTestCase):
             }
         ]
 
-        # It's useless testing 'created_at' as we can't mock datetime and we
-        # only care about its type and not its value.
+        # It's useless testing 'created_at_datetime' as we can't mock datetime
+        # and we only care about its type and not its value.
         for violation in converted_violations_as_dict:
-            del violation['created_at_timestamp']
+            del violation['created_at_datetime']
 
         self.assertEqual(expected_violations_as_dict,
                          converted_violations_as_dict)

--- a/tests/services/scanner/scanner_dao_test.py
+++ b/tests/services/scanner/scanner_dao_test.py
@@ -14,8 +14,6 @@
 
 """ Unit Tests for Scanner DAO. """
 
-from datetime import datetime
-
 import hashlib
 
 from itertools import izip
@@ -26,7 +24,6 @@ import unittest
 from google.cloud.forseti.services.scanner import dao as scanner_dao
 from tests.unittest_utils import ForsetiTestCase
 from tests.services.util.db import create_test_engine
-
 
 FAKE_INVENTORY_INDEX_ID = 'aaa'
 FAKE_VIOLATION_HASH = (u'111111111111111111111111111111111111111111111111111111'
@@ -63,7 +60,6 @@ FAKE_EXPECTED_VIOLATIONS = [
 ]
 
 
-
 class ScannerDaoTest(ForsetiTestCase):
     """Test scanner data access."""
 
@@ -86,7 +82,6 @@ class ScannerDaoTest(ForsetiTestCase):
         engine = create_test_engine()
         violation_access_cls = scanner_dao.define_violation(engine)
         violation_access = violation_access_cls(engine)
-
         violation_access.create(FAKE_EXPECTED_VIOLATIONS,
                                 FAKE_INVENTORY_INDEX_ID)
         saved_violations = violation_access.list()
@@ -101,7 +96,7 @@ class ScannerDaoTest(ForsetiTestCase):
         keys = ['inventory_index_id', 'resource_id', 'full_name',
                 'resource_type', 'rule_name', 'rule_index', 'violation_type',
                 'violation_data', 'violation_hash', 'inventory_data',
-                'created_at']
+                'created_at_timestamp']
 
         for fake, saved in izip(FAKE_EXPECTED_VIOLATIONS, saved_violations):
             for key in keys:
@@ -122,12 +117,11 @@ class ScannerDaoTest(ForsetiTestCase):
                         '\nFound: %s' % (key, ',\n'.join(expected_hash_values),
                                          saved_key_value)
                     )
-                elif key == 'created_at':
-                    self.assertIsInstance(
-                       saved_key_value, datetime,
-                        'The key value of "%s" differs:\n Expected type: %s'
-                        '\nFound type: %s' % (key, type(datetime),
-                                              type(saved_key_value))
+                elif key == 'created_at_timestamp':
+                    # Don't check values, just its presence.
+                    self.assertIsNotNone(
+                        'The key value of "%s" is null: %s' % (
+                          key, saved_key_value)
                     )
                 else:
                     self.assertEquals(
@@ -184,7 +178,7 @@ class ScannerDaoTest(ForsetiTestCase):
         # It's useless testing 'created_at' as we can't mock datetime and we
         # only care about its type and not its value.
         for violation in converted_violations_as_dict:
-            del violation['created_at']
+            del violation['created_at_timestamp']
 
         self.assertEqual(expected_violations_as_dict,
                          converted_violations_as_dict)


### PR DESCRIPTION
`created_at` is a uniqueness string for all given violations in a particular run of scanner. I've refactored this to be more explicit and store it as a datetime object: `created_at_datetime`.

As part of this I've laid the groundwork for common timestamp formats.