### PR TITLE
Fix group_email to use @googlegroups.com

### DIFF
--- a/rules/bigquery_rules.yaml
+++ b/rules/bigquery_rules.yaml
@@ -41,7 +41,7 @@ rules:
     special_group: '*'
     user_email: '*'
     domain: '*'
-    group_email: '*@gmail.com'
+    group_email: '*@googlegroups.com'
     role: '*'
     resource:
       - type: organization


### PR DESCRIPTION
Google Groups uses @googlegroups.com not @gmail.com for public groups.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [ ] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [ ] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [ ] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [ ] My PR has been functionally tested.
- [ ] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests) still pass.
- [ ] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
