### PR TITLE
Forseti 2.0 CLI help should shows 'forseti' instead of 'cli.pyc'

### DIFF
--- a/google/cloud/forseti/services/cli.py
+++ b/google/cloud/forseti/services/cli.py
@@ -452,7 +452,7 @@ def define_parent_parser(parser_cls, config_env):
     LOGGER.debug('parser_cls = %s, config_env = %s',
                  parser_cls, config_env)
 
-    parent_parser = parser_cls()
+    parent_parser = parser_cls(prog='forseti')
     parent_parser.add_argument(
         '--endpoint',
         default=config_env['endpoint'],


### PR DESCRIPTION
Resolves #1217 