### PR TITLE
Add support for fetching ServerConfig from a KE Location.

### DIFF
--- a/google/cloud/forseti/common/gcp_api/_supported_apis.py
+++ b/google/cloud/forseti/common/gcp_api/_supported_apis.py
@@ -45,7 +45,7 @@ SUPPORTED_APIS = {
     },
     'container': {
         'default_version': 'v1',
-        'supported_versions': ['v1']
+        'supported_versions': ['v1', 'v1beta1']
     },
     'iam': {
         'default_version': 'v1',

--- a/google/cloud/forseti/common/gcp_api/container.py
+++ b/google/cloud/forseti/common/gcp_api/container.py
@@ -216,7 +216,7 @@ class ContainerClient(object):
 
         Returns:
             dict: A serverconfig for a given Compute Engine zone.
-            https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.zones/getServerconfig
+            https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/ServerConfig
 
             {
               "defaultClusterVersion": string,
@@ -239,12 +239,12 @@ class ContainerClient(object):
         """
 
         try:
-            if zone and not location:
-                return self.repository.projects_zones.get_serverconfig(
-                    project_id, zone=zone)
-            elif location:
+            if location:
                 return self.repository.projects_locations.get_serverconfig(
                     project_id, location=location)
+            elif zone:
+                return self.repository.projects_zones.get_serverconfig(
+                    project_id, zone=zone)
             raise ValueError('get_serverconfig takes either zone or location, '
                              'got zone: %s, location: %s' % (zone, location))
         except (errors.HttpError, HttpLib2Error) as e:

--- a/google/cloud/forseti/common/gcp_api/container.py
+++ b/google/cloud/forseti/common/gcp_api/container.py
@@ -235,6 +235,7 @@ class ContainerClient(object):
         Raises:
             ApiExecutionError: ApiExecutionError is raised if the call to the
                 GCP API fails
+            ValueError: Raised if neither zone nor location are passed in.
         """
 
         try:

--- a/google/cloud/forseti/common/gcp_api/container.py
+++ b/google/cloud/forseti/common/gcp_api/container.py
@@ -44,17 +44,26 @@ class ContainerRepositoryClient(_base_repository.BaseRepositoryClient):
         if not quota_max_calls:
             use_rate_limiter = False
 
+        self._projects_locations = None
         self._projects_zones = None
         self._projects_zones_clusters = None
 
         super(ContainerRepositoryClient, self).__init__(
-            'container', versions=['v1'],
+            'container', versions=['v1', 'v1beta1'],
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
             use_rate_limiter=use_rate_limiter)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
+    @property
+    def projects_locations(self):
+        """Returns a _ContainerProjectsLocationsRepository instance."""
+        if not self._projects_locations:
+            self._projects_locations = self._init_repository(
+                _ContainerProjectsLocationsRepository, version='v1beta1')
+        return self._projects_locations
+
     @property
     def projects_zones(self):
         """Returns a _ContainerProjectsZonesRepository instance."""
@@ -71,6 +80,49 @@ class ContainerRepositoryClient(_base_repository.BaseRepositoryClient):
                 _ContainerProjectsZonesClustersRepository)
         return self._projects_zones_clusters
     # pylint: enable=missing-return-doc, missing-return-type-doc
+
+
+class _ContainerProjectsLocationsRepository(
+        _base_repository.GCPRepository):
+    """Implementation of Container Projects.Locations repository."""
+
+    def __init__(self, **kwargs):
+        """Constructor.
+
+        Args:
+            **kwargs (dict): The args to pass into GCPRepository.__init__()
+        """
+        super(_ContainerProjectsLocationsRepository, self).__init__(
+            component='projects.locations', **kwargs)
+
+    def get_serverconfig(self, project_id, location, fields=None, **kwargs):
+        """Get KE serverconfig for location.
+
+        Args:
+            project_id (str): The id of the project to query.
+            location (str):  Name of the location to get the configuration for.
+            fields (str): Fields to include in the response - partial response.
+            **kwargs (dict): Optional additional arguments to pass to the query.
+
+        Returns:
+            dict: Response from the API.
+
+        Raises:
+            errors.HttpError: When attempting to get a non-existent entity.
+               ex: HttpError 404 when requesting ... returned
+                   "The resource '...' was not found"
+        """
+        name = 'projects/{}/locations/{}'.format(project_id, location)
+        arguments = {
+            'name': name,
+            'fields': fields,
+        }
+        if kwargs:
+            arguments.update(kwargs)
+        return self.execute_query(
+            verb='getServerConfig',
+            verb_arguments=arguments,
+        )
 
 
 class _ContainerProjectsZonesRepository(
@@ -151,12 +203,16 @@ class ContainerClient(object):
             quota_period=self.DEFAULT_QUOTA_PERIOD,
             use_rate_limiter=kwargs.get('use_rate_limiter', True))
 
-    def get_serverconfig(self, project_id, zone):
-        """Gets the serverconfig for a project and zone.
+    def get_serverconfig(self, project_id, zone=None, location=None):
+        """Gets the serverconfig for a project and zone or location.
+
+        Requires either a zone or a location, if both are passed in, the
+        location is used instead of the zone.
 
         Args:
             project_id (int): The project id for a GCP project.
             zone (str):  Name of the zone to get the configuration for.
+            location (str): Name of the location to get the configuration for.
 
         Returns:
             dict: A serverconfig for a given Compute Engine zone.
@@ -182,8 +238,14 @@ class ContainerClient(object):
         """
 
         try:
-            return self.repository.projects_zones.get_serverconfig(project_id,
-                                                                   zone)
+            if zone and not location:
+                return self.repository.projects_zones.get_serverconfig(
+                    project_id, zone=zone)
+            elif location:
+                return self.repository.projects_locations.get_serverconfig(
+                    project_id, location=location)
+            raise ValueError('get_serverconfig takes either zone or location, '
+                             'got zone: %s, location: %s' % (zone, location))
         except (errors.HttpError, HttpLib2Error) as e:
             LOGGER.warn(api_errors.ApiExecutionError(project_id, e))
             raise api_errors.ApiExecutionError(project_id, e)

--- a/google/cloud/forseti/services/inventory/base/gcp.py
+++ b/google/cloud/forseti/services/inventory/base/gcp.py
@@ -436,17 +436,20 @@ class ApiClientImpl(ApiClient):
             yield cluster
 
     @create_lazy('container', _create_container)
-    def fetch_container_serviceconfig(self, projectid, zone):
+    def fetch_container_serviceconfig(self, projectid, zone=None,
+                                      location=None):
         """Kubernetes Engine per zone service config from gcp API call.
 
         Args:
             projectid (str): id of the project to query
             zone (str): zone of the Kubernetes Engine
+            location (str): location of the Kubernetes Engine
 
         Returns:
             dict: Generator of Kubernetes Engine Cluster resources.
         """
-        return self.container.get_serverconfig(projectid, zone)
+        return self.container.get_serverconfig(projectid, zone=zone,
+                                               location=location)
 
     @create_lazy('storage', _create_storage)
     def iter_buckets(self, projectid):

--- a/tests/common/gcp_api/container_test.py
+++ b/tests/common/gcp_api/container_test.py
@@ -45,7 +45,7 @@ class ContainerTest(unittest_utils.ForsetiTestCase):
         container_client = container.ContainerClient(global_configs={})
         self.assertEqual(None, container_client.repository._rate_limiter)
 
-    def test_get_serverconfig_zone(self):
+    def test_get_serverconfig_by_zone(self):
         """Test get KE serverconfig for zone."""
         http_mocks.mock_http_response(
             fake_container.FAKE_GET_SERVERCONFIG_RESPONSE)
@@ -56,7 +56,7 @@ class ContainerTest(unittest_utils.ForsetiTestCase):
         self.assertEquals(
             json.loads(fake_container.FAKE_GET_SERVERCONFIG_RESPONSE), result)
 
-    def test_get_serverconfig_location(self):
+    def test_get_serverconfig_by_location(self):
         """Test get KE serverconfig for location."""
         http_mocks.mock_http_response(
             fake_container.FAKE_GET_SERVERCONFIG_RESPONSE)
@@ -67,7 +67,7 @@ class ContainerTest(unittest_utils.ForsetiTestCase):
         self.assertEquals(
             json.loads(fake_container.FAKE_GET_SERVERCONFIG_RESPONSE), result)
 
-    def test_get_serverconfig_location_and_zone(self):
+    def test_get_serverconfig_by_location_and_zone(self):
         """Test get KE serverconfig for zone and location."""
         http_mocks.mock_http_response(
             fake_container.FAKE_GET_SERVERCONFIG_RESPONSE)
@@ -79,8 +79,8 @@ class ContainerTest(unittest_utils.ForsetiTestCase):
         self.assertEquals(
             json.loads(fake_container.FAKE_GET_SERVERCONFIG_RESPONSE), result)
 
-    def test_get_serverconfig_valueerror(self):
-        """Test get_serverconfig raises if missing zone and location."""
+    def test_get_serverconfig_missing_location_and_zone(self):
+        """Test get_serverconfig raises if missing location and zone."""
         with self.assertRaises(ValueError):
              self.container_client.get_serverconfig(self.project_id)
 

--- a/tests/common/gcp_api/container_test.py
+++ b/tests/common/gcp_api/container_test.py
@@ -45,16 +45,44 @@ class ContainerTest(unittest_utils.ForsetiTestCase):
         container_client = container.ContainerClient(global_configs={})
         self.assertEqual(None, container_client.repository._rate_limiter)
 
-    def test_get_serverconfig(self):
-        """Test get KE serverconfig."""
+    def test_get_serverconfig_zone(self):
+        """Test get KE serverconfig for zone."""
         http_mocks.mock_http_response(
             fake_container.FAKE_GET_SERVERCONFIG_RESPONSE)
 
-        result = self.container_client.get_serverconfig(self.project_id,
-                                                        self.zone)
+        result = self.container_client.get_serverconfig(
+            self.project_id, zone=self.zone)
 
         self.assertEquals(
             json.loads(fake_container.FAKE_GET_SERVERCONFIG_RESPONSE), result)
+
+    def test_get_serverconfig_location(self):
+        """Test get KE serverconfig for location."""
+        http_mocks.mock_http_response(
+            fake_container.FAKE_GET_SERVERCONFIG_RESPONSE)
+
+        result = self.container_client.get_serverconfig(
+            self.project_id, location=fake_container.FAKE_LOCATION)
+
+        self.assertEquals(
+            json.loads(fake_container.FAKE_GET_SERVERCONFIG_RESPONSE), result)
+
+    def test_get_serverconfig_location_and_zone(self):
+        """Test get KE serverconfig for zone and location."""
+        http_mocks.mock_http_response(
+            fake_container.FAKE_GET_SERVERCONFIG_RESPONSE)
+
+        result = self.container_client.get_serverconfig(
+            self.project_id, zone=self.zone,
+            location=fake_container.FAKE_LOCATION)
+
+        self.assertEquals(
+            json.loads(fake_container.FAKE_GET_SERVERCONFIG_RESPONSE), result)
+
+    def test_get_serverconfig_valueerror(self):
+        """Test get_serverconfig raises if missing zone and location."""
+        with self.assertRaises(ValueError):
+             self.container_client.get_serverconfig(self.project_id)
 
     def test_get_serverconfig_error(self):
         """Test get_serverconfig raises exception on error."""

--- a/tests/common/gcp_api/test_data/fake_container_responses.py
+++ b/tests/common/gcp_api/test_data/fake_container_responses.py
@@ -16,6 +16,7 @@
 
 FAKE_PROJECT_ID = "project1"
 FAKE_ZONE = "us-central1-a"
+FAKE_LOCATION = "europe-west1"
 FAKE_BAD_ZONE = "bad-zone"
 
 FAKE_GET_SERVERCONFIG_RESPONSE = """

--- a/tests/services/inventory/gcp_api_mocks.py
+++ b/tests/services/inventory/gcp_api_mocks.py
@@ -172,9 +172,11 @@ def _mock_container():
     def _mock_ke_get_clusters(projectid):
         return results.KE_GET_CLUSTERS[projectid]
 
-    def _mock_ke_get_service_config(projectid, zone):
+    def _mock_ke_get_service_config(projectid, zone, location):
         del projectid
-        return results.KE_GET_SERVICECONFIG[zone]
+        if zone:
+            return results.KE_GET_SERVICECONFIG[zone]
+        return results.KE_GET_SERVICECONFIG[location]
 
     container_patcher = mock.patch(
         MODULE_PATH + 'container.ContainerClient', spec=True)


### PR DESCRIPTION
 * Add projects.locations API endpoint to Kubernetes Engine API client
 * Update crawler to check for both zones and locations in KE cluster.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
