### PR TITLE
[wip] notifier.run() emits a single notification per violation pipeline

### DIFF
--- a/google/cloud/forseti/notifier/pipelines/base_notification_pipeline.py
+++ b/google/cloud/forseti/notifier/pipelines/base_notification_pipeline.py
@@ -40,7 +40,6 @@ class BaseNotificationPipeline(object):
             pipeline_config (dict): Pipeline configurations.
         """
         self.cycle_timestamp = cycle_timestamp
-        self.resource = resource
         self.global_configs = global_configs
         self.notifier_config = notifier_config
         self.pipeline_config = pipeline_config
@@ -48,7 +47,19 @@ class BaseNotificationPipeline(object):
         # self.api_client = api_client
 
         # Get violations
-        self.violations = violations
+        self.violations = dict()
+        self.violations[resource] = violations
+
+    def add_data(self, resource, violations):
+        """Add violation data for another resource type.
+
+        Args:
+            resource (str): Violation resource name.
+            violations (dict): Violations.
+        """
+        if resource in self.violations:
+            raise ValueError('resource %s specified more than once' % resource)
+        self.violations[resource] = violations
 
     @abc.abstractmethod
     def run(self):


### PR DESCRIPTION
The idea is to make `notifier.run()` emit a single notification per violation pipeline with the least amount of code change
 * the `notifier` section in `forseti_conf.yaml` does not change
 * the violations for all enabled resources are added to a single, shared pipeline instance (see [first commit](https://github.com/GoogleCloudPlatform/forseti-security/pull/1269/commits/a516401ca450f9bdeb57c202002b502341563ceb))
 * all (violation) pipelines need to be adjusted so they can handle violations for 1+ resources (see [second commit](https://github.com/GoogleCloudPlatform/forseti-security/pull/1269/commits/f923c1dc8fd0f4dd07a9eb456d4068688db771e6))

This fixes (part of) issue #1060 

TODO: switch all violation pipelines from `json` to `CVS`.
 