### PR TITLE
Fix group_email to use @googlegroups.com

### DIFF
--- a/rules/bigquery_rules.yaml
+++ b/rules/bigquery_rules.yaml
@@ -36,12 +36,12 @@ rules:
       - type: organization
         resource_ids:
           - {ORGANIZATION_ID}
-  - name: sample BigQuery rule to search for datasets accessible by groups with gmail.com addresses
+  - name: sample BigQuery rule to search for datasets accessible by groups with googlegroups.com addresses
     dataset_id: '*'
     special_group: '*'
     user_email: '*'
     domain: '*'
-    group_email: '*@gmail.com'
+    group_email: '*@googlegroups.com'
     role: '*'
     resource:
       - type: organization


### PR DESCRIPTION
Google Groups uses @googlegroups.com not @gmail.com for public groups.

Fix for 2.0 as requested in https://github.com/GoogleCloudPlatform/forseti-security/pull/1237#pullrequestreview-102798789
