### PR TITLE
Create a full_name for group violation data

### DIFF
--- a/google/cloud/forseti/scanner/scanners/groups_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/groups_scanner.py
@@ -50,10 +50,11 @@ class GroupsScanner(base_scanner.BaseScanner):
                 'parent_status': violation.parent.member_status,
                 'parent_type': violation.parent.member_type
             }
+            full_name = violation.parent.member_id + ':' + violation.member_id
             yield {
                 'resource_id': violation.member_email,
                 'resource_type': 'group_member',
-                'full_name': None,
+                'full_name': full_name,
                 'rule_index': None,
                 'rule_name': violation.violated_rule_names,
                 'violation_type': 'GROUP_VIOLATION',


### PR DESCRIPTION
This creates a unique `full_name` for groups when saving violation data.

An example of what this looks like:
```
group/my_group@my_company.com:user/foo@gmail.com
```

Fixes #1072 