### PR TITLE
Added error handling for scanner and notifier cli

### DIFF
--- a/google/cloud/forseti/scanner/scanner.py
+++ b/google/cloud/forseti/scanner/scanner.py
@@ -33,7 +33,6 @@ def run(model_name=None, progress_queue=None, service_config=None):
     Returns:
         int: Status code.
     """
-
     global_configs = service_config.get_global_config()
     scanner_configs = service_config.get_scanner_config()
 

--- a/google/cloud/forseti/services/client.py
+++ b/google/cloud/forseti/services/client.py
@@ -121,12 +121,12 @@ class ScannerClient(ForsetiClient):
     def run(self):
         """Runs the scanner
 
-        Returns:
+        Yields:
             proto: the returned proto message.
         """
         request = scanner_pb2.RunRequest()
         return self.stub.Run(request,
-                             metadata=self.metadata())
+                            metadata=self.metadata())
 
 
 class NotifierClient(ForsetiClient):

--- a/google/cloud/forseti/services/client.py
+++ b/google/cloud/forseti/services/client.py
@@ -121,12 +121,12 @@ class ScannerClient(ForsetiClient):
     def run(self):
         """Runs the scanner
 
-        Yields:
+        Returns:
             proto: the returned proto message.
         """
         request = scanner_pb2.RunRequest()
         return self.stub.Run(request,
-                            metadata=self.metadata())
+                             metadata=self.metadata())
 
 
 class NotifierClient(ForsetiClient):

--- a/google/cloud/forseti/services/client.py
+++ b/google/cloud/forseti/services/client.py
@@ -118,14 +118,12 @@ class ScannerClient(ForsetiClient):
         echo = self.stub.Ping(scanner_pb2.PingRequest(data=data)).data
         return echo == data
 
-    @require_model
     def run(self):
         """Runs the scanner
 
         Returns:
             proto: the returned proto message.
         """
-
         request = scanner_pb2.RunRequest()
         return self.stub.Run(request,
                              metadata=self.metadata())

--- a/google/cloud/forseti/services/notifier/service.py
+++ b/google/cloud/forseti/services/notifier/service.py
@@ -97,13 +97,12 @@ class GrpcNotifier(notifier_pb2_grpc.NotifierServicer):
             inventory_index_id (str): Inventory index id.
             progress_queue (Queue): Progress queue.
         """
-        # pylint: disable=broad-except
         try:
             self.notifier.run(
                 inventory_index_id,
                 progress_queue,
                 self.service_config)
-        except Exception as e:
+        except Exception as e: # pylint: disable=broad-except
             LOGGER.error(e)
             progress_queue.put('Error occurred during the '
                                'notification process.')

--- a/google/cloud/forseti/services/notifier/service.py
+++ b/google/cloud/forseti/services/notifier/service.py
@@ -84,13 +84,30 @@ class GrpcNotifier(notifier_pb2_grpc.NotifierServicer):
         LOGGER.info('Run notifier service with inventory index id: %s',
                     request.inventory_index_id)
         self.service_config.run_in_background(
-            lambda: self.notifier.run(
-                request.inventory_index_id,
-                progress_queue,
-                self.service_config))
+            lambda: self._run_notifier(request.inventory_index_id,
+                                       progress_queue))
 
         for progress_message in iter(progress_queue.get, None):
             yield notifier_pb2.Progress(message=progress_message)
+
+    def _run_notifier(self, inventory_index_id, progress_queue):
+        """Run notifier.
+
+        Args:
+            inventory_index_id (str): Inventory index id.
+            progress_queue (Queue): Progress queue.
+        """
+        # pylint: disable=broad-except
+        try:
+            self.notifier.run(
+                inventory_index_id,
+                progress_queue,
+                self.service_config)
+        except Exception as e:
+            LOGGER.error(e)
+            progress_queue.put('Error occurred during the '
+                               'notification process.')
+            progress_queue.put(None)
 
 
 class GrpcNotifierFactory(object):

--- a/google/cloud/forseti/services/scanner/service.py
+++ b/google/cloud/forseti/services/scanner/service.py
@@ -82,9 +82,15 @@ class GrpcScanner(scanner_pb2_grpc.ScannerServicer):
         progress_queue = Queue()
 
         model_name = self._get_handle(context)
-        LOGGER.info('Run scanner service with model: %s', model_name)
-        self.service_config.run_in_background(
-            lambda: self._run_scanner(model_name, progress_queue))
+        if not model_name:
+            progress_queue.put(
+                'You must specify a model before running the Forseti'
+                ' scanner. Run `forseti model -h` for more information.')
+            progress_queue.put(None)
+        else:
+            LOGGER.info('Run scanner service with model: %s', model_name)
+            self.service_config.run_in_background(
+                lambda: self._run_scanner(model_name, progress_queue))
 
         for progress_message in iter(progress_queue.get, None):
             yield scanner_pb2.Progress(message=progress_message)

--- a/google/cloud/forseti/services/scanner/service.py
+++ b/google/cloud/forseti/services/scanner/service.py
@@ -102,12 +102,11 @@ class GrpcScanner(scanner_pb2_grpc.ScannerServicer):
             model_name (str): Model name.
             progress_queue (Queue): Progress queue.
         """
-        # pylint: disable=broad-except
         try:
             self.scanner.run(model_name,
                              progress_queue,
                              self.service_config)
-        except Exception as e:
+        except Exception as e: # pylint: disable=broad-except
             LOGGER.error(e)
             progress_queue.put('Error occurred during the scanning process.')
             progress_queue.put(None)


### PR DESCRIPTION
To ensure that if there is an exception occurred while scanning/notifying, the cli terminates with some error message.
Using scanner without setting the model should now be handled properly, too.