### PR TITLE
Allow user to specify the violation payload format (csv / json)

### DIFF
--- a/google/cloud/forseti/notifier/notifiers/base_notification.py
+++ b/google/cloud/forseti/notifier/notifiers/base_notification.py
@@ -24,14 +24,16 @@ LOGGER = logger.get_logger(__name__)
 
 
 class InvalidDataFormatError(Exception):
-    """Raised in case of an invalid notifier data format.
-
-    Attributes:
-        msg  -- error message detailing the (invalid) data_format
-    """
+    """Raised in case of an invalid notifier data format."""
 
     def __init__(self, invalid_data_format):
-        self.msg = 'Invalid data format: %s' % invalid_data_format
+        """Constructor for the base notifier.
+
+        Args:
+            invalid_data_format (str): the invalid data format in question.
+        """
+        super(InvalidDataFormatError, self).__init__(
+            'Invalid data format: %s' % invalid_data_format)
 
 
 class BaseNotification(object):

--- a/google/cloud/forseti/notifier/notifiers/base_notification.py
+++ b/google/cloud/forseti/notifier/notifiers/base_notification.py
@@ -40,6 +40,7 @@ class BaseNotification(object):
     """Base notifier to perform notifications"""
 
     __metaclass__ = abc.ABCMeta
+    supported_data_formats = ['csv', 'json']
 
     def __init__(self, resource, cycle_timestamp,
                  violations, global_configs, notifier_config,
@@ -65,7 +66,6 @@ class BaseNotification(object):
 
         # Get violations
         self.violations = violations
-        self.supported_data_formats = ['csv', 'json']
 
     @abc.abstractmethod
     def run(self):

--- a/google/cloud/forseti/notifier/notifiers/base_notification.py
+++ b/google/cloud/forseti/notifier/notifiers/base_notification.py
@@ -16,7 +16,9 @@
 
 import abc
 
+from google.cloud.forseti.common.util import date_time
 from google.cloud.forseti.common.util import logger
+from google.cloud.forseti.common.util import string_formats
 
 LOGGER = logger.get_logger(__name__)
 
@@ -55,3 +57,20 @@ class BaseNotification(object):
     def run(self):
         """Runs the notifier."""
         pass
+
+    def _get_output_filename(self, filename_template):
+        """Create the output filename.
+
+        Args:
+            filename_template (string): template to use for the output filename
+
+        Returns:
+            str: The output filename for the violations CSV file.
+        """
+        now_utc = date_time.get_utc_now_datetime()
+        output_timestamp = now_utc.strftime(
+            string_formats.TIMESTAMP_TIMEZONE_FILES)
+
+        output_filename = filename_template.format(
+            self.resource, self.cycle_timestamp, output_timestamp)
+        return output_filename

--- a/google/cloud/forseti/notifier/notifiers/base_notification.py
+++ b/google/cloud/forseti/notifier/notifiers/base_notification.py
@@ -26,14 +26,15 @@ LOGGER = logger.get_logger(__name__)
 class InvalidDataFormatError(Exception):
     """Raised in case of an invalid notifier data format."""
 
-    def __init__(self, invalid_data_format):
+    def __init__(self, notifier, invalid_data_format):
         """Constructor for the base notifier.
 
         Args:
+            notifier (str): the notifier module/name
             invalid_data_format (str): the invalid data format in question.
         """
         super(InvalidDataFormatError, self).__init__(
-            'Invalid data format: %s' % invalid_data_format)
+            '%s: invalid data format: %s' % (notifier, invalid_data_format))
 
 
 class BaseNotification(object):

--- a/google/cloud/forseti/notifier/notifiers/base_notification.py
+++ b/google/cloud/forseti/notifier/notifiers/base_notification.py
@@ -23,6 +23,17 @@ from google.cloud.forseti.common.util import string_formats
 LOGGER = logger.get_logger(__name__)
 
 
+class InvalidDataFormatError(Exception):
+    """Raised in case of an invalid notifier data format.
+
+    Attributes:
+        msg  -- error message detailing the (invalid) data_format
+    """
+
+    def __init__(self, invalid_data_format):
+        self.msg = 'Invalid data format: %s' % invalid_data_format
+
+
 class BaseNotification(object):
     """Base notifier to perform notifications"""
 

--- a/google/cloud/forseti/notifier/notifiers/base_notification.py
+++ b/google/cloud/forseti/notifier/notifiers/base_notification.py
@@ -52,6 +52,7 @@ class BaseNotification(object):
 
         # Get violations
         self.violations = violations
+        self.supported_data_formats = ['csv', 'json']
 
     @abc.abstractmethod
     def run(self):
@@ -67,8 +68,8 @@ class BaseNotification(object):
         Returns:
             str: The output filename for the violations CSV file.
         """
-        now_utc = date_time.get_utc_now_datetime()
-        output_timestamp = now_utc.strftime(
+        utc_now_datetime = date_time.get_utc_now_datetime()
+        output_timestamp = utc_now_datetime.strftime(
             string_formats.TIMESTAMP_TIMEZONE_FILES)
 
         output_filename = filename_template.format(

--- a/google/cloud/forseti/notifier/notifiers/email_violations.py
+++ b/google/cloud/forseti/notifier/notifiers/email_violations.py
@@ -134,16 +134,17 @@ class EmailViolations(base_notification.BaseNotification):
         if data_format not in self.supported_data_formats:
             LOGGER.error(
                 'Email violations: invalid data format: %s', data_format)
+            raise base_notification.InvalidDataFormatError(data_format)
+
+        attachment = None
+        if data_format == 'csv':
+            attachment = self._make_attachment_csv()
         else:
-            attachment = None
-            if data_format == 'csv':
-                attachment = self._make_attachment_csv()
-            else:
-                attachment = self._make_attachment_json()
-            subject, content = self._make_content()
-            email_map['subject'] = subject
-            email_map['content'] = content
-            email_map['attachment'] = attachment
+            attachment = self._make_attachment_json()
+        subject, content = self._make_content()
+        email_map['subject'] = subject
+        email_map['content'] = content
+        email_map['attachment'] = attachment
 
         return email_map
 

--- a/google/cloud/forseti/notifier/notifiers/email_violations.py
+++ b/google/cloud/forseti/notifier/notifiers/email_violations.py
@@ -61,7 +61,7 @@ class EmailViolations(base_notification.BaseNotification):
         Returns:
             attachment: SendGrid attachment object.
         """
-        output_file_name = self._get_output_filename(
+        output_filename = self._get_output_filename(
             string_formats.VIOLATION_CSV_FMT)
         with csv_writer.write_csv(resource_name='violations',
                                   data=self.violations,
@@ -70,7 +70,7 @@ class EmailViolations(base_notification.BaseNotification):
             LOGGER.info('CSV filename: %s', output_csv_name)
             attachment = self.mail_util.create_attachment(
                 file_location=csv_file.name,
-                content_type='text/csv', filename=output_file_name,
+                content_type='text/csv', filename=output_filename,
                 content_id='Violations')
 
         return attachment
@@ -81,7 +81,7 @@ class EmailViolations(base_notification.BaseNotification):
         Returns:
             attachment: SendGrid attachment object.
         """
-        output_file_name = self._get_output_filename(
+        output_filename = self._get_output_filename(
             string_formats.VIOLATION_JSON_FMT)
         with tempfile.NamedTemporaryFile() as tmp_violations:
             tmp_violations.write(parser.json_stringify(self.violations))
@@ -89,7 +89,8 @@ class EmailViolations(base_notification.BaseNotification):
             LOGGER.info('JSON filename: %s', tmp_violations.name)
             attachment = self.mail_util.create_attachment(
                 file_location=tmp_violations.name,
-                content_type='text/csv', filename=output_file_name,
+                content_type='text/json',
+                filename=output_filename,
                 content_id='Violations')
 
         return attachment
@@ -130,7 +131,7 @@ class EmailViolations(base_notification.BaseNotification):
         email_map = {}
 
         data_format = self.notification_config.get('data_format', 'csv')
-        if data_format not in ['json', 'csv']:
+        if data_format not in self.supported_data_formats:
             LOGGER.error(
                 'Email violations: invalid data format: %s', data_format)
         else:

--- a/google/cloud/forseti/notifier/notifiers/email_violations.py
+++ b/google/cloud/forseti/notifier/notifiers/email_violations.py
@@ -132,9 +132,8 @@ class EmailViolations(base_notification.BaseNotification):
 
         data_format = self.notification_config.get('data_format', 'csv')
         if data_format not in self.supported_data_formats:
-            LOGGER.error(
-                'Email violations: invalid data format: %s', data_format)
-            raise base_notification.InvalidDataFormatError(data_format)
+            raise base_notification.InvalidDataFormatError(
+                'Email notifier', data_format)
 
         attachment = None
         if data_format == 'csv':

--- a/google/cloud/forseti/notifier/notifiers/email_violations.py
+++ b/google/cloud/forseti/notifier/notifiers/email_violations.py
@@ -89,7 +89,7 @@ class EmailViolations(base_notification.BaseNotification):
             LOGGER.info('JSON filename: %s', tmp_violations.name)
             attachment = self.mail_util.create_attachment(
                 file_location=tmp_violations.name,
-                content_type='text/json',
+                content_type='application/json',
                 filename=output_filename,
                 content_id='Violations')
 

--- a/google/cloud/forseti/notifier/notifiers/gcs_violations.py
+++ b/google/cloud/forseti/notifier/notifiers/gcs_violations.py
@@ -61,7 +61,9 @@ class GcsViolations(base_notification.BaseNotification):
             data_format = self.notification_config.get('data_format', 'csv')
             if data_format not in self.supported_data_formats:
                 LOGGER.error('GCS upload: invalid data format: %s', data_format)
-            elif data_format == 'csv':
+                raise base_notification.InvalidDataFormatError(data_format)
+
+            if data_format == 'csv':
                 gcs_upload_path = '{}/{}'.format(
                     self.notification_config['gcs_path'],
                     self._get_output_filename(

--- a/google/cloud/forseti/notifier/notifiers/gcs_violations.py
+++ b/google/cloud/forseti/notifier/notifiers/gcs_violations.py
@@ -18,7 +18,6 @@ import tempfile
 
 from google.cloud.forseti.common.data_access import csv_writer
 from google.cloud.forseti.common.gcp_api import storage
-from google.cloud.forseti.common.util import date_time
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.common.util import parser
 from google.cloud.forseti.common.util import string_formats
@@ -30,23 +29,6 @@ LOGGER = logger.get_logger(__name__)
 
 class GcsViolations(base_notification.BaseNotification):
     """Upload violations to GCS."""
-
-    def _get_output_filename(self, filename_template):
-        """Create the output filename.
-
-        Args:
-            filename_template (string): template to use for the output filename
-
-        Returns:
-            str: The output filename for the violations CSV file.
-        """
-        now_utc = date_time.get_utc_now_datetime()
-        output_timestamp = now_utc.strftime(
-            string_formats.TIMESTAMP_TIMEZONE_FILES)
-
-        output_filename = filename_template.format(
-            self.resource, self.cycle_timestamp, output_timestamp)
-        return output_filename
 
     def _upload_json(self, gcs_upload_path):
         """Upload violations in json format.

--- a/google/cloud/forseti/notifier/notifiers/gcs_violations.py
+++ b/google/cloud/forseti/notifier/notifiers/gcs_violations.py
@@ -19,6 +19,7 @@ from google.cloud.forseti.common.data_access import csv_writer
 from google.cloud.forseti.common.gcp_api import storage
 from google.cloud.forseti.common.util import date_time
 from google.cloud.forseti.common.util import logger
+from google.cloud.forseti.common.util import parser
 from google.cloud.forseti.common.util import string_formats
 from google.cloud.forseti.notifier.notifiers import base_notification
 

--- a/google/cloud/forseti/notifier/notifiers/gcs_violations.py
+++ b/google/cloud/forseti/notifier/notifiers/gcs_violations.py
@@ -61,16 +61,15 @@ class GcsViolations(base_notification.BaseNotification):
             data_format = self.notification_config.get('data_format', 'csv')
             if data_format not in ['json', 'csv']:
                 LOGGER.error('GCS upload: invalid data format: %s', data_format)
+            elif data_format == 'csv':
+                gcs_upload_path = '{}/{}'.format(
+                    self.notification_config['gcs_path'],
+                    self._get_output_filename(
+                        string_formats.VIOLATION_CSV_FMT))
+                self._upload_csv(gcs_upload_path)
             else:
-                if data_format == 'csv':
-                    gcs_upload_path = '{}/{}'.format(
-                        self.notification_config['gcs_path'],
-                        self._get_output_filename(
-                            string_formats.VIOLATION_CSV_FMT))
-                    self._upload_csv(gcs_upload_path)
-                else:
-                    gcs_upload_path = '{}/{}'.format(
-                        self.notification_config['gcs_path'],
-                        self._get_output_filename(
-                            string_formats.VIOLATION_JSON_FMT))
-                    self._upload_json(gcs_upload_path)
+                gcs_upload_path = '{}/{}'.format(
+                    self.notification_config['gcs_path'],
+                    self._get_output_filename(
+                        string_formats.VIOLATION_JSON_FMT))
+                self._upload_json(gcs_upload_path)

--- a/google/cloud/forseti/notifier/notifiers/gcs_violations.py
+++ b/google/cloud/forseti/notifier/notifiers/gcs_violations.py
@@ -59,7 +59,7 @@ class GcsViolations(base_notification.BaseNotification):
         """Generate the temporary (CSV xor JSON) file and upload to GCS."""
         if self.notification_config['gcs_path'].startswith('gs://'):
             data_format = self.notification_config.get('data_format', 'csv')
-            if data_format not in ['json', 'csv']:
+            if data_format not in self.supported_data_formats:
                 LOGGER.error('GCS upload: invalid data format: %s', data_format)
             elif data_format == 'csv':
                 gcs_upload_path = '{}/{}'.format(

--- a/google/cloud/forseti/notifier/notifiers/gcs_violations.py
+++ b/google/cloud/forseti/notifier/notifiers/gcs_violations.py
@@ -62,8 +62,8 @@ class GcsViolations(base_notification.BaseNotification):
 
         data_format = self.notification_config.get('data_format', 'csv')
         if data_format not in self.supported_data_formats:
-            LOGGER.error('GCS upload: invalid data format: %s', data_format)
-            raise base_notification.InvalidDataFormatError(data_format)
+            raise base_notification.InvalidDataFormatError(
+                'GCS uploader', data_format)
 
         if data_format == 'csv':
             gcs_upload_path = '{}/{}'.format(

--- a/google/cloud/forseti/notifier/notifiers/gcs_violations.py
+++ b/google/cloud/forseti/notifier/notifiers/gcs_violations.py
@@ -75,7 +75,6 @@ class GcsViolations(base_notification.BaseNotification):
             self.notification_config['gcs_path'],
             self._get_output_filename())
 
-        import pdb; pdb.set_trace()
         if gcs_upload_path.startswith('gs://'):
             data_format = self.notification_config.get('data_format', 'csv')
             if data_format == 'csv':

--- a/google/cloud/forseti/notifier/notifiers/gcs_violations.py
+++ b/google/cloud/forseti/notifier/notifiers/gcs_violations.py
@@ -57,21 +57,23 @@ class GcsViolations(base_notification.BaseNotification):
 
     def run(self):
         """Generate the temporary (CSV xor JSON) file and upload to GCS."""
-        if self.notification_config['gcs_path'].startswith('gs://'):
-            data_format = self.notification_config.get('data_format', 'csv')
-            if data_format not in self.supported_data_formats:
-                LOGGER.error('GCS upload: invalid data format: %s', data_format)
-                raise base_notification.InvalidDataFormatError(data_format)
+        if not self.notification_config['gcs_path'].startswith('gs://'):
+            return
 
-            if data_format == 'csv':
-                gcs_upload_path = '{}/{}'.format(
-                    self.notification_config['gcs_path'],
-                    self._get_output_filename(
-                        string_formats.VIOLATION_CSV_FMT))
-                self._upload_csv(gcs_upload_path)
-            else:
-                gcs_upload_path = '{}/{}'.format(
-                    self.notification_config['gcs_path'],
-                    self._get_output_filename(
-                        string_formats.VIOLATION_JSON_FMT))
-                self._upload_json(gcs_upload_path)
+        data_format = self.notification_config.get('data_format', 'csv')
+        if data_format not in self.supported_data_formats:
+            LOGGER.error('GCS upload: invalid data format: %s', data_format)
+            raise base_notification.InvalidDataFormatError(data_format)
+
+        if data_format == 'csv':
+            gcs_upload_path = '{}/{}'.format(
+                self.notification_config['gcs_path'],
+                self._get_output_filename(
+                    string_formats.VIOLATION_CSV_FMT))
+            self._upload_csv(gcs_upload_path)
+        else:
+            gcs_upload_path = '{}/{}'.format(
+                self.notification_config['gcs_path'],
+                self._get_output_filename(
+                    string_formats.VIOLATION_JSON_FMT))
+            self._upload_json(gcs_upload_path)

--- a/tests/notifier/notifiers/email_violations_test.py
+++ b/tests/notifier/notifiers/email_violations_test.py
@@ -24,6 +24,7 @@ from datetime import datetime
 from google.cloud.forseti.common.util.email import EmailUtil
 from google.cloud.forseti.common.util import string_formats
 from google.cloud.forseti.notifier.notifiers import email_violations
+from tests.notifier.notifiers.test_data import fake_violations
 from tests.unittest_utils import ForsetiTestCase
 
 
@@ -46,52 +47,21 @@ class EmailViolationsTest(ForsetiTestCase):
             'sendgrid_api_key': 'dsvgig9y0u[puv'
         }
 
-        self.violations = [
-            {'full_name': 'o/5/f/4/f/9/p/be-p1-196611/bucket/be-1-ext/',
-             'inventory_data': (
-                 '{"bindings": [{"members": ["projectEditor:be-p1-196611", '
-                 '"projectOwner:be-p1-196611"], "role": "roles/storage.lega'
-                 'cyBucketOwner"}, {"members": ["projectViewer:be-p1-196611'
-                 '"], "role": "roles/storage.legacyBucketReader"}], "etag":'
-                 '"CAE=", "kind": "storage#policy", "resourceId": "projects'
-                 '/_/buckets/be-1-ext"}'),
-             'resource_id': 'be-1-ext',
-             'resource_type': 'bucket',
-             'rule_index': 1,
-             'rule_name': 'Allow only service accounts to have access',
-             'violation_data': {'full_name': 'o/5/f/4/f/9/p/be-p1-196611/bucket/be-1-ext/',
-                                 'member': u'user:abc@example.com',
-                                 'role': u'roles/storage.objectAdmin'},
-             'violation_type': 'ADDED'},
-            {'full_name': 'o/5/f/4/f/9/p/be-p1-196611/bucket/be-1-int/',
-             'inventory_data': (
-                 '{"bindings": [{"members": ["projectEditor:be-p1-196611", '
-                 '"projectOwner:be-p1-196611"], "role": "roles/storage.lega'
-                 'cyBucketOwner"}, {"members": ["projectViewer:be-p1-196611'
-                 '"], "role": "roles/storage.legacyBucketReader"}], "etag":'
-                 '"CAE=", "kind": "storage#policy", "resourceId": "projects'
-                 '/_/buckets/be-1-int"}'),
-             'resource_id': 'be-1-int',
-             'resource_type': 'bucket',
-             'rule_index': 1,
-             'rule_name': 'Allow only service accounts to have access',
-             'violation_data': {'full_name': 'o/5/f/4/f/9/p/be-p1-196611/bucket/be-1-int/',
-                                'member': u'user:ab.cd@example.com',
-                                'role': u'roles/storage.objectViewer'},
-             'violation_type': 'ADDED'}]
         self.expected_attachment_path = os.path.join(
                 os.path.dirname(__file__), 'test_data',
                 'expected_attachment.csv')
+
+        self.cycle_timestamp = '2018-03-24T00:49:02.891287'
         self.evp_init_args = [
             'policy_violations',
-            '2018-03-14T14:49:36.101287',
-            self.violations,
+            self.cycle_timestamp,
+            fake_violations.VIOLATIONS['policy_violations'],
             self.fake_global_conf,
             {},
             self.fake_pipeline_conf]
 
     @mock.patch(
-        'google.cloud.forseti.notifier.notifiers.email_violations.date_time',
+        'google.cloud.forseti.notifier.notifiers.base_notification.date_time',
         autospec=True)
     def test_make_attachment_csv_name(self, mock_date_time):
         """Test the CSV attachment name()."""
@@ -101,7 +71,7 @@ class EmailViolationsTest(ForsetiTestCase):
             string_formats.TIMESTAMP_TIMEZONE_FILES)
 
         evp = email_violations.EmailViolations(*self.evp_init_args)
-        attachment = evp._make_attachment()
+        attachment = evp._make_attachment_csv()
         self.assertEquals(
             string_formats.VIOLATION_CSV_FMT.format(
                 evp.resource, evp.cycle_timestamp, expected_timestamp),
@@ -116,7 +86,7 @@ class EmailViolationsTest(ForsetiTestCase):
         mail_util = mock.MagicMock(spec=EmailUtil)
         mock_mail_util.EmailUtil.return_value = mail_util
         evp = email_violations.EmailViolations(*self.evp_init_args)
-        evp._make_attachment()
+        evp._make_attachment_csv()
         self.assertTrue(mail_util.create_attachment.called)
         self.assertTrue(
             filecmp.cmp(
@@ -131,12 +101,52 @@ class EmailViolationsTest(ForsetiTestCase):
         mail_util = mock.MagicMock(spec=EmailUtil)
         mock_mail_util.EmailUtil.return_value = mail_util
         evp = email_violations.EmailViolations(*self.evp_init_args)
-        evp._make_attachment()
+        evp._make_attachment_csv()
         self.assertTrue(mail_util.create_attachment.called)
         self.assertFalse(
             os.path.exists(
                 mail_util.create_attachment.call_args[1]['file_location']))
 
+
+    @mock.patch(
+        'google.cloud.forseti.notifier.notifiers.email_violations.LOGGER',
+        autospec=True)
+    @mock.patch(
+        'google.cloud.forseti.notifier.notifiers.email_violations.email',
+        autospec=True)
+    @mock.patch('google.cloud.forseti.common.util.parser.json_stringify')
+    @mock.patch('google.cloud.forseti.common.data_access.csv_writer.write_csv')
+    def test_run_with_invalid_data_format(self, mock_write_csv,
+        mock_json_stringify, mock_mail_util, mock_logger):
+        """Test run() with json file format."""
+        notifier_config = (
+            fake_violations.NOTIFIER_CONFIGS_EMAIL_INVALID_DATA_FORMAT)
+        notification_config = notifier_config['resources'][0]['notifiers'][0]['configuration']
+        resource = 'policy_violations'
+        cycle_timestamp = '2018-03-24T00:49:02.891287'
+        mock_json_stringify.return_value = 'test123'
+        evp = email_violations.EmailViolations(
+            resource,
+            cycle_timestamp,
+            fake_violations.VIOLATIONS,
+            fake_violations.GLOBAL_CONFIGS,
+            notifier_config,
+            notification_config)
+
+        evp._get_output_filename = mock.MagicMock()
+        evp._make_attachment_csv = mock.MagicMock()
+        evp._make_attachment_json = mock.MagicMock()
+        evp.run()
+
+        self.assertFalse(evp._get_output_filename.called)
+        self.assertFalse(evp._make_attachment_csv.called)
+        self.assertFalse(evp._make_attachment_json.called)
+        self.assertFalse(mock_write_csv.called)
+        self.assertFalse(mock_json_stringify.called)
+        self.assertTrue(mock_logger.error.called)
+        self.assertEquals(
+            ('Email violations: invalid data format: %s', 'xyz-invalid'),
+            mock_logger.error.call_args[0])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/notifier/notifiers/email_violations_test.py
+++ b/tests/notifier/notifiers/email_violations_test.py
@@ -23,6 +23,7 @@ from datetime import datetime
 
 from google.cloud.forseti.common.util.email import EmailUtil
 from google.cloud.forseti.common.util import string_formats
+from google.cloud.forseti.notifier.notifiers import base_notification
 from google.cloud.forseti.notifier.notifiers import email_violations
 from tests.notifier.notifiers.test_data import fake_violations
 from tests.unittest_utils import ForsetiTestCase
@@ -149,7 +150,8 @@ class EmailViolationsTest(ForsetiTestCase):
         evp._get_output_filename = mock.MagicMock()
         evp._make_attachment_csv = mock.MagicMock()
         evp._make_attachment_json = mock.MagicMock()
-        evp.run()
+        with self.assertRaises(base_notification.InvalidDataFormatError):
+            evp.run()
 
         self.assertFalse(evp._get_output_filename.called)
         self.assertFalse(evp._make_attachment_csv.called)

--- a/tests/notifier/notifiers/email_violations_test.py
+++ b/tests/notifier/notifiers/email_violations_test.py
@@ -47,7 +47,7 @@ class EmailViolationsTest(ForsetiTestCase):
             'sendgrid_api_key': 'dsvgig9y0u[puv'
         }
 
-        self.expected_attachment_path = os.path.join(
+        self.expected_csv_attachment_path = os.path.join(
                 os.path.dirname(__file__), 'test_data',
                 'expected_attachment.csv')
 
@@ -91,7 +91,7 @@ class EmailViolationsTest(ForsetiTestCase):
         self.assertTrue(
             filecmp.cmp(
                 mail_util.create_attachment.call_args[1]['file_location'],
-                self.expected_attachment_path, shallow=False))
+                self.expected_csv_attachment_path, shallow=False))
 
     @mock.patch(
         'google.cloud.forseti.notifier.notifiers.email_violations.email',

--- a/tests/notifier/notifiers/email_violations_test.py
+++ b/tests/notifier/notifiers/email_violations_test.py
@@ -123,15 +123,12 @@ class EmailViolationsTest(ForsetiTestCase):
                 mail_util.create_attachment.call_args[1]['file_location']))
 
     @mock.patch(
-        'google.cloud.forseti.notifier.notifiers.email_violations.LOGGER',
-        autospec=True)
-    @mock.patch(
         'google.cloud.forseti.notifier.notifiers.email_violations.email',
         autospec=True)
     @mock.patch('google.cloud.forseti.common.util.parser.json_stringify')
     @mock.patch('google.cloud.forseti.common.data_access.csv_writer.write_csv')
     def test_run_with_invalid_data_format(self, mock_write_csv,
-        mock_json_stringify, mock_mail_util, mock_logger):
+        mock_json_stringify, mock_mail_util):
         """Test run() with invalid data format."""
         notifier_config = (
             fake_violations.NOTIFIER_CONFIGS_EMAIL_INVALID_DATA_FORMAT)
@@ -158,10 +155,6 @@ class EmailViolationsTest(ForsetiTestCase):
         self.assertFalse(evp._make_attachment_json.called)
         self.assertFalse(mock_write_csv.called)
         self.assertFalse(mock_json_stringify.called)
-        self.assertTrue(mock_logger.error.called)
-        self.assertEquals(
-            ('Email violations: invalid data format: %s', 'xyz-invalid'),
-            mock_logger.error.call_args[0])
 
     @mock.patch(
         'google.cloud.forseti.notifier.notifiers.email_violations.email',

--- a/tests/notifier/notifiers/gcs_violations_test.py
+++ b/tests/notifier/notifiers/gcs_violations_test.py
@@ -44,7 +44,7 @@ class GcsViolationsnotifierTest(ForsetiTestCase):
         }
 
     @mock.patch(
-        'google.cloud.forseti.notifier.notifiers.gcs_violations.date_time',
+        'google.cloud.forseti.notifier.notifiers.base_notification.date_time',
         autospec=True)
     def test_get_output_filename(self, mock_date_time):
         """Test_get_output_filename()."""
@@ -68,7 +68,7 @@ class GcsViolationsnotifierTest(ForsetiTestCase):
             actual_filename)
 
     @mock.patch(
-        'google.cloud.forseti.notifier.notifiers.gcs_violations.date_time',
+        'google.cloud.forseti.notifier.notifiers.base_notification.date_time',
         autospec=True)
     def test_get_output_filename_with_json(self, mock_date_time):
         """Test _get_output_filename()."""

--- a/tests/notifier/notifiers/gcs_violations_test.py
+++ b/tests/notifier/notifiers/gcs_violations_test.py
@@ -101,12 +101,14 @@ class GcsViolationsnotifierTest(ForsetiTestCase):
         autospec=True)
     @mock.patch('google.cloud.forseti.common.util.parser.json_stringify')
     @mock.patch('google.cloud.forseti.common.data_access.csv_writer.write_csv')
-    def test_run_with_json(self, mock_csv_writer, mock_parser, mock_storage):
+    def test_run_with_json(self, mock_write_csv, mock_json_stringify,
+        mock_storage):
         """Test run() with json file format."""
         notifier_config = fake_violations.NOTIFIER_CONFIGS_GCS_JSON
         notification_config = notifier_config['resources'][0]['notifiers'][0]['configuration']
         resource = 'policy_violations'
         cycle_timestamp = '2018-03-24T00:49:02.891287'
+        mock_json_stringify.return_value = 'test123'
         gvp = gcs_violations.GcsViolations(
             resource,
             cycle_timestamp,
@@ -117,8 +119,8 @@ class GcsViolationsnotifierTest(ForsetiTestCase):
 
         gvp.run()
 
-        self.assertFalse(mock_csv_writer.called)
-        self.assertTrue(mock_parser.called)
+        self.assertFalse(mock_write_csv.called)
+        self.assertTrue(mock_json_stringify.called)
 
     @mock.patch(
         'google.cloud.forseti.common.gcp_api.storage.StorageClient',

--- a/tests/notifier/notifiers/gcs_violations_test.py
+++ b/tests/notifier/notifiers/gcs_violations_test.py
@@ -20,6 +20,7 @@ import unittest
 from datetime import datetime
 
 from google.cloud.forseti.common.util import string_formats
+from google.cloud.forseti.notifier.notifiers import base_notification
 from google.cloud.forseti.notifier.notifiers import gcs_violations
 from tests.notifier.notifiers.test_data import fake_violations
 from tests.unittest_utils import ForsetiTestCase
@@ -210,7 +211,8 @@ class GcsViolationsnotifierTest(ForsetiTestCase):
 
         gvp._get_output_filename = mock.MagicMock()
 
-        gvp.run()
+        with self.assertRaises(base_notification.InvalidDataFormatError):
+            gvp.run()
 
         self.assertFalse(gvp._get_output_filename.called)
         self.assertFalse(mock_write_csv.called)

--- a/tests/notifier/notifiers/gcs_violations_test.py
+++ b/tests/notifier/notifiers/gcs_violations_test.py
@@ -185,15 +185,12 @@ class GcsViolationsnotifierTest(ForsetiTestCase):
         self.assertFalse(mock_parser.called)
 
     @mock.patch(
-        'google.cloud.forseti.notifier.notifiers.gcs_violations.LOGGER',
-        autospec=True)
-    @mock.patch(
         'google.cloud.forseti.common.gcp_api.storage.StorageClient',
         autospec=True)
     @mock.patch('google.cloud.forseti.common.util.parser.json_stringify')
     @mock.patch('google.cloud.forseti.common.data_access.csv_writer.write_csv')
     def test_run_with_invalid_data_format(self, mock_write_csv,
-        mock_json_stringify, mock_storage, mock_logger):
+        mock_json_stringify, mock_storage):
         """Test run() with json file format."""
         notifier_config = (
             fake_violations.NOTIFIER_CONFIGS_GCS_INVALID_DATA_FORMAT)
@@ -217,10 +214,6 @@ class GcsViolationsnotifierTest(ForsetiTestCase):
         self.assertFalse(gvp._get_output_filename.called)
         self.assertFalse(mock_write_csv.called)
         self.assertFalse(mock_json_stringify.called)
-        self.assertTrue(mock_logger.error.called)
-        self.assertEquals(
-            ('GCS upload: invalid data format: %s', 'xxx-invalid'),
-            mock_logger.error.call_args[0])
 
 
 if __name__ == '__main__':

--- a/tests/notifier/notifiers/test_data/expected_attachment.csv
+++ b/tests/notifier/notifiers/test_data/expected_attachment.csv
@@ -1,3 +1,3 @@
 resource_id,resource_type,full_name,rule_index,rule_name,violation_type,violation_data
-be-1-ext,bucket,o/5/f/4/f/9/p/be-p1-196611/bucket/be-1-ext/,1,Allow only service accounts to have access,ADDED,{'member': u'user:abc@example.com'\, 'role': u'roles/storage.objectAdmin'\, 'full_name': 'o/5/f/4/f/9/p/be-p1-196611/bucket/be-1-ext/'}
-be-1-int,bucket,o/5/f/4/f/9/p/be-p1-196611/bucket/be-1-int/,1,Allow only service accounts to have access,ADDED,{'member': u'user:ab.cd@example.com'\, 'role': u'roles/storage.objectViewer'\, 'full_name': 'o/5/f/4/f/9/p/be-p1-196611/bucket/be-1-int/'}
+be-1-ext,bucket,o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/,1,Allow only service accounts to have access,ADDED,{'member': 'user:ghi@example.com'\, 'role': 'roles/storage.objectAdmin'\, 'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/'}
+be-1-ext,bucket,o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/,1,Allow only service accounts to have access,ADDED,{'member': 'user:jkl@example.com'\, 'role': 'roles/storage.admin'\, 'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/'}

--- a/tests/notifier/notifiers/test_data/fake_violations.py
+++ b/tests/notifier/notifiers/test_data/fake_violations.py
@@ -18,8 +18,8 @@ NOTIFIER_CONFIGS_GCS_JSON = {
         {'notifiers': [
             {'configuration': {
                 'gcs_path': 'gs://fs-violations/scanner_violations'},
-                'name': 'gcs_violations',
-                'data_format': 'json'}],
+             'name': 'gcs_violations',
+             'data_format': 'json'}],
          'should_notify': True,
          'resource': 'policy_violations'}]}
 
@@ -28,7 +28,7 @@ NOTIFIER_CONFIGS_GCS_DEFAULT = {
         {'notifiers': [
             {'configuration': {
                 'gcs_path': 'gs://fs-violations/scanner_violations'},
-                'name': 'gcs_violations'}],
+             'name': 'gcs_violations'}],
          'should_notify': True,
          'resource': 'policy_violations'}]}
 
@@ -39,8 +39,8 @@ NOTIFIER_CONFIGS_EMAIL_JSON = {
                 'sendgrid_api_key': 'SG.HmvWMOd_QKm',
                 'recipient': 'ab@cloud.cc',
                 'sender': 'cd@ex.com'},
-                 'name': 'email_violations',
-                 'data_format': 'json'}],
+             'name': 'email_violations',
+             'data_format': 'json'}],
          'should_notify': True,
          'resource': 'policy_violations'}]}
 
@@ -51,26 +51,26 @@ NOTIFIER_CONFIGS_EMAIL_DEFAULT = {
                 'sendgrid_api_key': 'SG.HmvWMOd_QKm',
                 'recipient': 'ab@cloud.cc',
                 'sender': 'cd@ex.com'},
-                 'name': 'email_violations'}],
+             'name': 'email_violations'}],
          'should_notify': True,
          'resource': 'policy_violations'}]}
 
 GLOBAL_CONFIGS = {
-        'max_bigquery_api_calls_per_100_seconds': 17000,
-        'max_cloudbilling_api_calls_per_60_seconds': 300,
-        'max_compute_api_calls_per_second': 20,
-        'max_results_admin_api': 500,
-        'max_sqladmin_api_calls_per_100_seconds': 100,
-        'max_container_api_calls_per_100_seconds': 1000,
-        'max_crm_api_calls_per_100_seconds': 400,
-        'domain_super_admin_email': 'chsl@vkvd.com',
-        'db_name': 'forseti-inventory',
-        'db_user': 'forseti_user',
-        'max_admin_api_calls_per_100_seconds': 1500,
-        'db_host': '127.0.0.1',
-        'groups_service_account_key_file': '/tmp/forseti-gsuite-reader.json',
-        'max_appengine_api_calls_per_second': 20,
-        'max_iam_api_calls_per_second': 20}
+    'max_bigquery_api_calls_per_100_seconds': 17000,
+    'max_cloudbilling_api_calls_per_60_seconds': 300,
+    'max_compute_api_calls_per_second': 20,
+    'max_results_admin_api': 500,
+    'max_sqladmin_api_calls_per_100_seconds': 100,
+    'max_container_api_calls_per_100_seconds': 1000,
+    'max_crm_api_calls_per_100_seconds': 400,
+    'domain_super_admin_email': 'chsl@vkvd.com',
+    'db_name': 'forseti-inventory',
+    'db_user': 'forseti_user',
+    'max_admin_api_calls_per_100_seconds': 1500,
+    'db_host': '127.0.0.1',
+    'groups_service_account_key_file': '/tmp/forseti-gsuite-reader.json',
+    'max_appengine_api_calls_per_second': 20,
+    'max_iam_api_calls_per_second': 20}
 
 VIOLATIONS = {
     'iap_violations': [
@@ -142,8 +142,8 @@ VIOLATIONS = {
              'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
              'member': 'user:ghi@example.com',
              'role': 'roles/storage.objectAdmin'},
-             'violation_hash': '15fda93a6fdd32d867064677cf07686f79b',
-             'violation_type': 'ADDED'},
+         'violation_hash': '15fda93a6fdd32d867064677cf07686f79b',
+         'violation_type': 'ADDED'},
         {'created_at_datetime': '2018-03-16T09:29:52Z',
          'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
          'id': 2L,
@@ -165,5 +165,5 @@ VIOLATIONS = {
              'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
              'member': 'user:jkl@example.com',
              'role': 'roles/storage.admin'},
-             'violation_hash': 'f93745f39163060ceee17385b4677b91746',
-             'violation_type': 'ADDED'}]}
+         'violation_hash': 'f93745f39163060ceee17385b4677b91746',
+         'violation_type': 'ADDED'}]}

--- a/tests/notifier/notifiers/test_data/fake_violations.py
+++ b/tests/notifier/notifiers/test_data/fake_violations.py
@@ -32,6 +32,16 @@ NOTIFIER_CONFIGS_GCS_DEFAULT = {
          'should_notify': True,
          'resource': 'policy_violations'}]}
 
+NOTIFIER_CONFIGS_GCS_INVALID_DATA_FORMAT = {
+    'resources': [
+        {'notifiers': [
+            {'configuration': {
+                'gcs_path': 'gs://fs-violations/scanner_violations',
+                'data_format': 'xxx-invalid'},
+             'name': 'gcs_violations'}],
+         'should_notify': True,
+         'resource': 'policy_violations'}]}
+
 NOTIFIER_CONFIGS_EMAIL_JSON = {
     'resources': [
         {'notifiers': [

--- a/tests/notifier/notifiers/test_data/fake_violations.py
+++ b/tests/notifier/notifiers/test_data/fake_violations.py
@@ -1,0 +1,169 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fake violation data."""
+
+NOTIFIER_CONFIGS_GCS_JSON = {
+    'resources': [
+        {'notifiers': [
+            {'configuration': {
+                'gcs_path': 'gs://fs-violations/scanner_violations'},
+                'name': 'gcs_violations',
+                'data_format': 'json'}],
+         'should_notify': True,
+         'resource': 'policy_violations'}]}
+
+NOTIFIER_CONFIGS_GCS_DEFAULT = {
+    'resources': [
+        {'notifiers': [
+            {'configuration': {
+                'gcs_path': 'gs://fs-violations/scanner_violations'},
+                'name': 'gcs_violations'}],
+         'should_notify': True,
+         'resource': 'policy_violations'}]}
+
+NOTIFIER_CONFIGS_EMAIL_JSON = {
+    'resources': [
+        {'notifiers': [
+            {'configuration': {
+                'sendgrid_api_key': 'SG.HmvWMOd_QKm',
+                'recipient': 'ab@cloud.cc',
+                'sender': 'cd@ex.com'},
+                 'name': 'email_violations',
+                 'data_format': 'json'}],
+         'should_notify': True,
+         'resource': 'policy_violations'}]}
+
+NOTIFIER_CONFIGS_EMAIL_DEFAULT = {
+    'resources': [
+        {'notifiers': [
+            {'configuration': {
+                'sendgrid_api_key': 'SG.HmvWMOd_QKm',
+                'recipient': 'ab@cloud.cc',
+                'sender': 'cd@ex.com'},
+                 'name': 'email_violations'}],
+         'should_notify': True,
+         'resource': 'policy_violations'}]}
+
+GLOBAL_CONFIGS = {
+        'max_bigquery_api_calls_per_100_seconds': 17000,
+        'max_cloudbilling_api_calls_per_60_seconds': 300,
+        'max_compute_api_calls_per_second': 20,
+        'max_results_admin_api': 500,
+        'max_sqladmin_api_calls_per_100_seconds': 100,
+        'max_container_api_calls_per_100_seconds': 1000,
+        'max_crm_api_calls_per_100_seconds': 400,
+        'domain_super_admin_email': 'chsl@vkvd.com',
+        'db_name': 'forseti-inventory',
+        'db_user': 'forseti_user',
+        'max_admin_api_calls_per_100_seconds': 1500,
+        'db_host': '127.0.0.1',
+        'groups_service_account_key_file': '/tmp/forseti-gsuite-reader.json',
+        'max_appengine_api_calls_per_second': 20,
+        'max_iam_api_calls_per_second': 20}
+
+VIOLATIONS = {
+    'iap_violations': [
+        {'created_at_datetime': '2018-03-16T09:29:52Z',
+         'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
+         'id': 47L,
+         'inventory_data': {
+             'bindings': [
+                 {'members': ['pEditor:be-p1-196611', 'pOwner:be-p1-196611'],
+                  'role': 'roles/storage.legacyBucketOwner'},
+                 {'members': ['pViewer:be-p1-196611'],
+                  'role': 'roles/storage.legacyBucketReader'}],
+             'etag': 'CAE=',
+             'kind': 'storage#policy',
+             'resourceId': 'ps/_/buckets/be-1-ext'},
+         'inventory_index_id': '2018-03-14T14:49:36.101287',
+         'resource_id': 'be-1-ext',
+         'resource_type': 'bucket',
+         'rule_index': 1L,
+         'rule_name': 'Allow only service accounts to have access',
+         'violation_data': {
+             'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
+             'member': 'user:abc@example.com',
+             'role': 'roles/storage.objectAdmin'},
+         'violation_hash': '15fda93a6fdd32d867064677cf07686f79b65d',
+         'violation_type': 'IAP_VIOLATION'},
+        {'created_at_datetime': '2018-03-16T09:29:52Z',
+         'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
+         'id': 48L,
+         'inventory_data': {
+             'bindings': [
+                 {'members': ['pEditor:be-p1-196611', 'pOwner:be-p1-196611'],
+                  'role': 'roles/storage.legacyBucketOwner'},
+                 {'members': ['pViewer:be-p1-196611'],
+                  'role': 'roles/storage.legacyBucketReader'}],
+             'etag': 'CAE=',
+             'kind': 'storage#policy',
+             'resourceId': 'ps/_/buckets/be-1-ext'},
+         'inventory_index_id': '2018-03-14T14:49:36.101287',
+         'resource_id': 'be-1-ext',
+         'resource_type': 'bucket',
+         'rule_index': 1L,
+         'rule_name': 'Allow only service accounts to have access',
+         'violation_data': {
+             'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
+             'member': 'user:def@example.com',
+             'role': 'roles/storage.admin'},
+         'violation_hash': 'f93745f39163060ceee17385b4677b91746382',
+         'violation_type': 'IAP_VIOLATION'}],
+    'policy_violations': [
+        {'created_at_datetime': '2018-03-16T09:29:52Z',
+         'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
+         'id': 1L,
+         'inventory_data': {
+             'bindings': [
+                 {'members': ['pEditor:be-p1-196611', 'pOwner:be-p1-196611'],
+                  'role': 'roles/storage.legacyBucketOwner'},
+                 {'members': ['pViewer:be-p1-196611'],
+                  'role': 'roles/storage.legacyBucketReader'}],
+             'etag': 'CAE=',
+             'kind': 'storage#policy',
+             'resourceId': 'ps/_/buckets/be-1-ext'},
+         'inventory_index_id': '2018-03-14T14:49:36.101287',
+         'resource_id': 'be-1-ext',
+         'resource_type': 'bucket',
+         'rule_index': 1L,
+         'rule_name': 'Allow only service accounts to have access',
+         'violation_data': {
+             'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
+             'member': 'user:ghi@example.com',
+             'role': 'roles/storage.objectAdmin'},
+             'violation_hash': '15fda93a6fdd32d867064677cf07686f79b',
+             'violation_type': 'ADDED'},
+        {'created_at_datetime': '2018-03-16T09:29:52Z',
+         'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
+         'id': 2L,
+         'inventory_data': {
+             'bindings': [
+                 {'members': ['pEditor:be-p1-196611', 'pOwner:be-p1-196611'],
+                  'role': 'roles/storage.legacyBucketOwner'},
+                 {'members': ['pViewer:be-p1-196611'],
+                  'role': 'roles/storage.legacyBucketReader'}],
+             'etag': 'CAE=',
+             'kind': 'storage#policy',
+             'resourceId': 'ps/_/buckets/be-1-ext'},
+         'inventory_index_id': '2018-03-14T14:49:36.101287',
+         'resource_id': 'be-1-ext',
+         'resource_type': 'bucket',
+         'rule_index': 1L,
+         'rule_name': 'Allow only service accounts to have access',
+         'violation_data': {
+             'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
+             'member': 'user:jkl@example.com',
+             'role': 'roles/storage.admin'},
+             'violation_hash': 'f93745f39163060ceee17385b4677b91746',
+             'violation_type': 'ADDED'}]}

--- a/tests/notifier/notifiers/test_data/fake_violations.py
+++ b/tests/notifier/notifiers/test_data/fake_violations.py
@@ -65,6 +65,18 @@ NOTIFIER_CONFIGS_EMAIL_DEFAULT = {
          'should_notify': True,
          'resource': 'policy_violations'}]}
 
+NOTIFIER_CONFIGS_EMAIL_INVALID_DATA_FORMAT = {
+    'resources': [
+        {'notifiers': [
+            {'configuration': {
+                'sendgrid_api_key': 'SG.HmvWMOd_QKm',
+                'recipient': 'ab@cloud.cc',
+                'sender': 'cd@ex.com',
+                'data_format': 'xyz-invalid'},
+             'name': 'email_violations'}],
+         'should_notify': True,
+         'resource': 'policy_violations'}]}
+
 GLOBAL_CONFIGS = {
     'max_bigquery_api_calls_per_100_seconds': 17000,
     'max_cloudbilling_api_calls_per_60_seconds': 300,

--- a/tests/notifier/notifiers/test_data/fake_violations.py
+++ b/tests/notifier/notifiers/test_data/fake_violations.py
@@ -17,9 +17,9 @@ NOTIFIER_CONFIGS_GCS_JSON = {
     'resources': [
         {'notifiers': [
             {'configuration': {
-                'gcs_path': 'gs://fs-violations/scanner_violations'},
-             'name': 'gcs_violations',
-             'data_format': 'json'}],
+                'gcs_path': 'gs://fs-violations/scanner_violations',
+                'data_format': 'json'},
+             'name': 'gcs_violations'}],
          'should_notify': True,
          'resource': 'policy_violations'}]}
 
@@ -38,9 +38,9 @@ NOTIFIER_CONFIGS_EMAIL_JSON = {
             {'configuration': {
                 'sendgrid_api_key': 'SG.HmvWMOd_QKm',
                 'recipient': 'ab@cloud.cc',
-                'sender': 'cd@ex.com'},
-             'name': 'email_violations',
-             'data_format': 'json'}],
+                'sender': 'cd@ex.com',
+                'data_format': 'json'},
+             'name': 'email_violations'}],
          'should_notify': True,
          'resource': 'policy_violations'}]}
 


### PR DESCRIPTION
Fully tested; switching between CSV and JSON works by specifying a `data_format` configuration setting for the notifier in question (with CSV being the default).

Fixes issue #1287.