### PR TITLE
Update the storage API client to handler Requester Pays buckets.

### DIFF
--- a/google/cloud/forseti/common/util/metadata_server.py
+++ b/google/cloud/forseti/common/util/metadata_server.py
@@ -103,11 +103,25 @@ def get_value_for_attribute(attribute):
     try:
         http_response = _issue_http_request(
             path, HTTP_GET, REQUIRED_METADATA_HEADER)
-        read_response = http_response.read()
-
-        return read_response
+        return http_response.read()
     except (TypeError, ValueError,
             errors.MetadataServerHttpError) as e:
         LOGGER.error('Unable to read value for attribute key %s '
                      'from metadata server: %s', attribute, e)
+        return None
+
+
+def get_project_id():
+    """Get the project id from the metadata server.
+
+    Returns:
+        str: The of the project id, on error, returns None.
+    """
+    path = '/computeMetadata/v1/project/project-id'
+    try:
+        http_response = _issue_http_request(
+            path, HTTP_GET, REQUIRED_METADATA_HEADER)
+        return http_response.read()
+    except errors.MetadataServerHttpError as e:
+        LOGGER.error('Unable to read project id from metadata server: %s', e)
         return None

--- a/google/cloud/forseti/common/util/metadata_server.py
+++ b/google/cloud/forseti/common/util/metadata_server.py
@@ -62,7 +62,7 @@ def _issue_http_request(path, method, headers):
     http_client = _obtain_http_client()
 
     try:
-        return http_client.request(path, method, headers)
+        return http_client.request(path, method, headers=headers)
     except socket.error:
         raise errors.MetadataServerHttpError
     finally:

--- a/setup/gcp/installer/util/constants.py
+++ b/setup/gcp/installer/util/constants.py
@@ -91,6 +91,7 @@ GCP_READ_IAM_ROLES = [
     'roles/appengine.appViewer',
     'roles/bigquery.dataViewer',
     'roles/servicemanagement.quotaViewer',
+    'serviceusage.serviceUsageConsumer',
     'roles/cloudsql.viewer'
 ]
 

--- a/tests/common/gcp_api/storage_test.py
+++ b/tests/common/gcp_api/storage_test.py
@@ -22,6 +22,7 @@ from tests.common.gcp_api.test_data import fake_storage_responses as fake_storag
 from tests.common.gcp_api.test_data import http_mocks
 from google.cloud.forseti.common.gcp_api import errors as api_errors
 from google.cloud.forseti.common.gcp_api import storage
+from google.cloud.forseti.common.util import metadata_server
 
 
 class StorageTest(unittest_utils.ForsetiTestCase):
@@ -29,8 +30,13 @@ class StorageTest(unittest_utils.ForsetiTestCase):
 
     @classmethod
     @mock.patch.object(client, 'GoogleCredentials', spec=True)
-    def setUpClass(cls, mock_google_credential):
+    @mock.patch.object(metadata_server, 'get_project_id', spec=True)
+    @mock.patch.object(metadata_server, 'can_reach_metadata_server', spec=True)
+    def setUpClass(cls, mock_reach_metadata, mock_get_project_id,
+                   mock_google_credential):
         """Set up."""
+        mock_reach_metadata.return_value = True
+        mock_get_project_id.return_value = 'test-project'
         cls.gcs_api_client = storage.StorageClient({})
 
     def test_get_bucket_and_path_from(self):
@@ -87,6 +93,20 @@ class StorageTest(unittest_utils.ForsetiTestCase):
         with self.assertRaises(api_errors.ApiExecutionError):
             self.gcs_api_client.get_bucket_acls(fake_storage.FAKE_BUCKET_NAME)
 
+    def test_get_buckets_acls_user_project(self):
+        """Test get buckets acls requires user project."""
+        mock_responses = [
+            ({'status': '400', 'content-type': 'application/json'},
+             fake_storage.USER_PROJECT_MISSING),
+            ({'status': '200', 'content-type': 'application/json'},
+             fake_storage.GET_BUCKET_ACL),
+        ]
+        http_mocks.mock_http_response_sequence(mock_responses)
+
+        results = self.gcs_api_client.get_bucket_acls(
+            fake_storage.FAKE_BUCKET_NAME)
+        self.assertEqual(3, len(results))
+
     def test_get_bucket_iam_policy(self):
         """Test get bucket iam policy."""
         http_mocks.mock_http_response(
@@ -104,6 +124,20 @@ class StorageTest(unittest_utils.ForsetiTestCase):
             self.gcs_api_client.get_bucket_iam_policy(
                 fake_storage.FAKE_BUCKET_NAME)
 
+    def test_get_bucket_iam_policy_user_project(self):
+        """Test get bucket iam policy requires user project."""
+        mock_responses = [
+            ({'status': '400', 'content-type': 'application/json'},
+             fake_storage.USER_PROJECT_MISSING),
+            ({'status': '200', 'content-type': 'application/json'},
+             fake_storage.GET_BUCKET_IAM_POLICY_RESPONSE),
+        ]
+        http_mocks.mock_http_response_sequence(mock_responses)
+
+        results = self.gcs_api_client.get_bucket_iam_policy(
+            fake_storage.FAKE_BUCKET_NAME)
+        self.assertTrue('bindings' in results)
+
     def test_get_default_object_acls(self):
         """Test get default object acls."""
         http_mocks.mock_http_response(
@@ -120,6 +154,20 @@ class StorageTest(unittest_utils.ForsetiTestCase):
         with self.assertRaises(api_errors.ApiExecutionError):
             self.gcs_api_client.get_default_object_acls(
                  fake_storage.FAKE_BUCKET_NAME)
+
+    def test_get_default_object_acls_user_project(self):
+        """Test get default object acls requires user project."""
+        mock_responses = [
+            ({'status': '400', 'content-type': 'application/json'},
+             fake_storage.USER_PROJECT_MISSING),
+            ({'status': '200', 'content-type': 'application/json'},
+             fake_storage.DEFAULT_OBJECT_ACL),
+        ]
+        http_mocks.mock_http_response_sequence(mock_responses)
+
+        results = self.gcs_api_client.get_default_object_acls(
+            fake_storage.FAKE_BUCKET_NAME)
+        self.assertEqual(3, len(results))
 
     def test_get_objects(self):
         """Test get objects."""
@@ -142,6 +190,23 @@ class StorageTest(unittest_utils.ForsetiTestCase):
         with self.assertRaises(api_errors.ApiExecutionError):
             self.gcs_api_client.get_objects(fake_storage.FAKE_PROJECT_NUMBER)
 
+    def test_get_objects_user_project(self):
+        """Test get objects requires user project."""
+        mock_responses = [
+            ({'status': '400', 'content-type': 'application/json'},
+             fake_storage.USER_PROJECT_MISSING)]
+
+        for page in fake_storage.LIST_OBJECTS_RESPONSES:
+            mock_responses.append(({'status': '200'}, page))
+        http_mocks.mock_http_response_sequence(mock_responses)
+
+        expected_object_names = fake_storage.EXPECTED_FAKE_OBJECT_NAMES
+
+        results = self.gcs_api_client.get_objects(
+            fake_storage.FAKE_PROJECT_NUMBER)
+        self.assertEquals(expected_object_names,
+                          [r.get('name') for r in results])
+
     def test_get_object_iam_policy(self):
         """Test get object iam policy."""
         http_mocks.mock_http_response(
@@ -159,6 +224,20 @@ class StorageTest(unittest_utils.ForsetiTestCase):
             self.gcs_api_client.get_object_iam_policy(
                 fake_storage.FAKE_BUCKET_NAME, fake_storage.FAKE_OBJECT_NAME)
 
+    def test_get_object_iam_policy_user_project(self):
+        """Test get object iam policy requires user project."""
+        mock_responses = [
+            ({'status': '400', 'content-type': 'application/json'},
+             fake_storage.USER_PROJECT_MISSING),
+            ({'status': '200', 'content-type': 'application/json'},
+             fake_storage.GET_OBJECT_IAM_POLICY_RESPONSE),
+        ]
+        http_mocks.mock_http_response_sequence(mock_responses)
+
+        results = self.gcs_api_client.get_object_iam_policy(
+            fake_storage.FAKE_BUCKET_NAME, fake_storage.FAKE_OBJECT_NAME)
+        self.assertTrue('bindings' in results)
+
     def test_get_object_acls(self):
         """Test get object acls."""
         http_mocks.mock_http_response(
@@ -175,6 +254,20 @@ class StorageTest(unittest_utils.ForsetiTestCase):
         with self.assertRaises(api_errors.ApiExecutionError):
             self.gcs_api_client.get_object_acls(
                 fake_storage.FAKE_BUCKET_NAME, fake_storage.FAKE_OBJECT_NAME)
+
+    def test_get_object_acls_user_project(self):
+        """Test get object acls requires user project."""
+        mock_responses = [
+            ({'status': '400', 'content-type': 'application/json'},
+             fake_storage.USER_PROJECT_MISSING),
+            ({'status': '200', 'content-type': 'application/json'},
+             fake_storage.GET_OBJECT_ACL),
+        ]
+
+        results = self.gcs_api_client.get_object_acls(
+            fake_storage.FAKE_BUCKET_NAME, fake_storage.FAKE_OBJECT_NAME)
+        self.assertEqual(4, len(results))
+
 
     def test_get_text_file(self):
         """Test get test file returns a valid response."""

--- a/tests/common/gcp_api/test_data/fake_storage_responses.py
+++ b/tests/common/gcp_api/test_data/fake_storage_responses.py
@@ -646,3 +646,19 @@ NOT_FOUND = """
  }
 }
 """
+
+USER_PROJECT_MISSING = """
+{
+ "error": {
+  "errors": [
+   {
+    "domain": "global",
+    "reason": "required",
+    "message": "Bucket is requester pays bucket but no user project provided."
+   }
+  ],
+  "code": 400,
+  "message": "Bucket is requester pays bucket but no user project provided."
+ }
+}
+"""

--- a/tests/common/util/file_loader_test.py
+++ b/tests/common/util/file_loader_test.py
@@ -49,8 +49,11 @@ class FileLoaderTest(ForsetiTestCase):
             file_loader._get_filetype_parser('path/to/file.yaml', 'asdf')
 
     @mock.patch.object(client.GoogleCredentials, 'get_application_default')
-    def test_read_file_from_gcs_json(self, mock_default_credential):
+    @mock.patch.object(metadata_server, 'can_reach_metadata_server', spec=True)
+    def test_read_file_from_gcs_json(self, mock_reach_metadata,
+                                     mock_default_credential):
         """Test read_file_from_gcs for json."""
+        mock_reach_metadata.return_value = False
         mock_responses = [
             ({'status': '200',
               'content-range': '0-10/11'}, b'{"test": 1}')
@@ -62,8 +65,11 @@ class FileLoaderTest(ForsetiTestCase):
         self.assertEqual(expected_dict, return_dict)
 
     @mock.patch.object(client.GoogleCredentials, 'get_application_default')
-    def test_read_file_from_gcs_yaml(self, mock_default_credential):
+    @mock.patch.object(metadata_server, 'can_reach_metadata_server', spec=True)
+    def test_read_file_from_gcs_yaml(self, mock_reach_metadata,
+                                     mock_default_credential):
         """Test read_file_from_gcs for yaml."""
+        mock_reach_metadata.return_value = False
         mock_responses = [
             ({'status': '200',
               'content-range': '0-6/7'}, b'test: 1')

--- a/tests/common/util/file_loader_test.py
+++ b/tests/common/util/file_loader_test.py
@@ -49,11 +49,8 @@ class FileLoaderTest(ForsetiTestCase):
             file_loader._get_filetype_parser('path/to/file.yaml', 'asdf')
 
     @mock.patch.object(client.GoogleCredentials, 'get_application_default')
-    @mock.patch.object(metadata_server, 'can_reach_metadata_server', spec=True)
-    def test_read_file_from_gcs_json(self, mock_reach_metadata,
-                                     mock_default_credential):
+    def test_read_file_from_gcs_json(self, mock_default_credential):
         """Test read_file_from_gcs for json."""
-        mock_reach_metadata.return_value = False
         mock_responses = [
             ({'status': '200',
               'content-range': '0-10/11'}, b'{"test": 1}')
@@ -65,11 +62,8 @@ class FileLoaderTest(ForsetiTestCase):
         self.assertEqual(expected_dict, return_dict)
 
     @mock.patch.object(client.GoogleCredentials, 'get_application_default')
-    @mock.patch.object(metadata_server, 'can_reach_metadata_server', spec=True)
-    def test_read_file_from_gcs_yaml(self, mock_reach_metadata,
-                                     mock_default_credential):
+    def test_read_file_from_gcs_yaml(self, mock_default_credential):
         """Test read_file_from_gcs for yaml."""
-        mock_reach_metadata.return_value = False
         mock_responses = [
             ({'status': '200',
               'content-range': '0-6/7'}, b'test: 1')

--- a/tests/common/util/metadata_server_test.py
+++ b/tests/common/util/metadata_server_test.py
@@ -123,8 +123,9 @@ class MetadataServerTest(ForsetiTestCase):
         """
         mock_response = 'expected_response'
 
-        with mock.patch('httplib.HTTPResponse',
-                        mock.mock_open(read_data=mock_response)) as mock_http_resp:
+        with mock.patch(
+                'httplib.HTTPResponse',
+                mock.mock_open(read_data=mock_response)) as mock_http_resp:
             mock_http_resp.return_value.status = httplib.OK
             mock_meta_req.side_effect = mock_http_resp
 
@@ -132,6 +133,41 @@ class MetadataServerTest(ForsetiTestCase):
 
         self.assertEqual(actual_response, mock_response)
 
+    @mock.patch.object(metadata_server, '_issue_http_request', autospec=True)
+    def test_get_project_id_with_exception(self, mock_meta_req):
+        """Test get_project_id returns correctly when exception is raised.
+
+        Setup:
+            * Have _issue_http_request raise errors.MetadataServerHttpError
+
+        Expected results:
+            * A matching string.
+        """
+        mock_meta_req.side_effect = _MockMetadataServerHttpError('Unreachable')
+        actual_response = metadata_server.get_project_id()
+        self.assertIsNone(actual_response)
+
+    @mock.patch.object(metadata_server, '_issue_http_request', autospec=True)
+    def test_get_project_id(self, mock_meta_req):
+        """Test get_project_id returns correctly.
+
+        Setup:
+            * Have _issue_http_request return a project id.
+
+        Expected results:
+            * A matching string.
+        """
+        mock_response = 'test-project'
+
+        with mock.patch(
+                'httplib.HTTPResponse',
+                mock.mock_open(read_data=mock_response)) as mock_http_resp:
+            mock_http_resp.return_value.status = httplib.OK
+            mock_meta_req.side_effect = mock_http_resp
+
+            actual_response = metadata_server.get_project_id()
+
+        self.assertEqual(actual_response, mock_response)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Add 'roles/serviceusage.serviceUsageConsumer' role to service account.
* Add get_project_id to metadata server client.
* Add detection for 400 errors from storage API, and retry the request,
  passing in the current project_id as the user project.

Fixes #1300.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](http://forsetisecurity.org/docs/development/#executing-tests) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
