### PR TITLE
Fix build script for Travis CI

### DIFF
--- a/travis/jekyll_build.sh
+++ b/travis/jekyll_build.sh
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e
+trap 'return_code=$?' ERR
 
 if  [ -z ${JGT+x} ]; then
     # We don't have access to the encrypted vars.
@@ -24,3 +26,5 @@ fi
 bundle exec htmlproofer --check-img-http --check-opengraph --check-html \
 --check-favicon --report-missing-names --report-script-embeds \
 --url-ignore "/GoogleCloudPlatform/forseti-security/edit/" ./_www/www
+
+exit ${return_code}


### PR DESCRIPTION
Travis has been erroneously passing builds that should fail because the docs don't build due
to broken links.

However, the script is not returning a non-zero exit code in the case that the `jekyll build`
failed; it is returning a zero exit code because the HTML proofer found nothing wrong
with an empty site.

We fix this error by trapping any non-zero exit codes from intermediate steps and returning
that exit code to the calling process. Therefore, Travis will be properly notified when the
Jekyll build fails **and** when the HTML proofer fails.