### PR TITLE
Fix all broken doc links

### DIFF
--- a/_docs/_latest/concepts/architecture.md
+++ b/_docs/_latest/concepts/architecture.md
@@ -1,0 +1,8 @@
+---
+title: Architecture
+order: 100
+---
+
+# {{ page.title }}
+
+TODO

--- a/_docs/_latest/concepts/index.md
+++ b/_docs/_latest/concepts/index.md
@@ -9,18 +9,18 @@ architecture, and best practices.
 
 ---
 
-| **[Forseti Architecture]({% link _docs/concepts/architecture.md %})** |
+| **[Forseti Architecture]({% link _docs/latest/concepts/architecture.md %})** |
 | :---------------------------------------------------------------------------- |
 | Learn about how information flows through Forseti. |
 
-| **[Best Practices]({% link _docs/concepts/best-practices.md %})** |
+| **[Best Practices]({% link _docs/latest/concepts/best-practices.md %})** |
 | :---------------------------------------------------------------------------- |
 | Learn about best practices for using Forseti with specific resources like Cloud Identity and Access Management (Cloud IAM) policies and service accounts. |
 
-| **[Models]({% link _docs/concepts/models.md %})** |
+| **[Models]({% link _docs/latest/concepts/models.md %})** |
 | :---------------------------------------------------------------------------- |
 | TBD |
 
-| **[Service Accounts]({% link _docs/concepts/service-accounts.md %})** |
+| **[Service Accounts]({% link _docs/latest/concepts/service-accounts.md %})** |
 | :---------------------------------------------------------------------------- |
 | Learn about the types of service accounts you can use with Forseti and the roles associated with using them. |

--- a/_docs/_latest/concepts/models.md
+++ b/_docs/_latest/concepts/models.md
@@ -1,0 +1,8 @@
+---
+title: Models
+order: 100
+---
+
+# {{ page.title }}
+
+TODO

--- a/_docs/_latest/concepts/service-accounts.md
+++ b/_docs/_latest/concepts/service-accounts.md
@@ -1,0 +1,8 @@
+---
+title: Service Accounts
+order: 100
+---
+
+# {{ page.title }}
+
+TODO

--- a/_docs/_latest/configure/gsuite-group-collection.md
+++ b/_docs/_latest/configure/gsuite-group-collection.md
@@ -76,13 +76,13 @@ in your `forseti_conf.yaml`.
 
 If you are running Forseti on GCP and made any changes to the above values, 
 you will need to copy the conf file to the GCS bucket. See 
-["Move Configuration to GCS"]({% link _docs/latest/setup/gcp-deployment.md %}) 
+["Move Configuration to GCS"]({% link _docs/latest/configure/configuring-forseti.md %}) 
 for details on how to do this.
 
 ## Deploying to GCP with G Suite Google Groups collection
 
 If you
-[created a deployment]({% link _docs/latest/setup/gcp-deployment.md %})
+[created a deployment]({% link _docs/latest/configure/configuring-forseti.md %})
 on GCP, run the following command to copy your G Suite key to your Forseti instance:
 
   ```

--- a/_docs/_latest/configure/index.md
+++ b/_docs/_latest/configure/index.md
@@ -5,39 +5,39 @@ hide:
   right_sidebar: true
 ---
 
-After you **[Set up Forseti]({% link _docs/setup/index.md %})**,
+After you **[Set up Forseti]({% link _docs/latest/setup/index.md %})**,
 use these guides to configure features.
 
 ---
 
-| **[Configuring Forseti]({% link _docs/configure/forseti/index.md %})** |
+| **[Configuring Forseti]({% link _docs/latest/configure/forseti/index.md %})** |
 | :---------------------------------------------------------------------------- |
 | Configure Forseti global and module-specific settings by updating the centrally-maintained configuration file. This includes basic configuration, and configuration for Inventory, Scanner, and Enforcer. |
 
-| **[Configuring Inventory]({% link _docs/configure/inventory/index.md %})** |
+| **[Configuring Inventory]({% link _docs/latest/configure/inventory/index.md %})** |
 | :---------------------------------------------------------------------------- |
 | Configure Inventory to collect and store information about your GCP resources. Inventory helps you undersand your resources and take action to conserve resources, reduce cost, and minimize security exposure. |
 
-| **[Configuring Scanner]({% link _docs/configure/scanner/index.md %})** |
+| **[Configuring Scanner]({% link _docs/latest/configure/scanner/index.md %})** |
 | :---------------------------------------------------------------------------- |
 | Configure Scanner to monitor your GCP resources for rule violations. Scanner uses the information from Inventory to regularly compare role-based access policies for your resources. |
 
-| **[Configuring Enforcer]({% link _docs/configure/enforcer/index.md %})** |
+| **[Configuring Enforcer]({% link _docs/latest/configure/enforcer/index.md %})** |
 | :---------------------------------------------------------------------------- |
 | Configure Enforcer to automatically correct policy discrepancies. Enforcer uses policies you create to compare the current state of your Compute Engine firewall to the desired state and uses Google Cloud APIs to make changes if it finds any differences. |
 
-| **[Configuring Explain]({% link _docs/configure/explain/index.md %})** |
+| **[Configuring Explain]({% link _docs/latest/configure/explain/index.md %})** |
 | :---------------------------------------------------------------------------- |
 | Configure Explain to help you understand, test, and develop Cloud Identity and Access Management (Cloud IAM) policies. |
 
-| **[Enabling Email Notifications]({% link _docs/configure/email-notification.md %})** |
+| **[Enabling Email Notifications]({% link _docs/latest/configure/email-notification.md %})** |
 | :---------------------------------------------------------------------------- |
 | Enable Forseti email notifications using the SendGrid API. SendGrid is the suggested free email service provider for Google Cloud Platform (GCP). |
 
-| **[Enabling G Suite Google Groups Collection]({% link _docs/configure/gsuite-group-collection.md %})** |
+| **[Enabling G Suite Google Groups Collection]({% link _docs/latest/configure/gsuite-group-collection.md %})** |
 | :---------------------------------------------------------------------------- |
 | Enable the data collection of G Suite Google Groups for processing by Forseti Inventory. G Suite Groups Collection helps you make sure the right people are in the right group, and is required for Explain. |
 
-| **[Export Summary Notifications]({% link _docs/configure/export-summary-notifications.md %})** |
+| **[Export Summary Notifications]({% link _docs/latest/configure/export-summary-notifications.md %})** |
 | :---------------------------------------------------------------------------- |
 | Create an AppScript to find, parse, and upload the summary email that's dispatched from Forseti Security to BigQuery. The script runs at the time you select to export details from the Forseti notification email. |

--- a/_docs/_latest/develop/index.md
+++ b/_docs/_latest/develop/index.md
@@ -5,22 +5,22 @@ hide:
   right_sidebar: true
 ---
 
-| **[Contributing to Forseti]({% link _docs/_latest/develop/contributing)** |
+| **[Contributing to Forseti]({% link _docs/latest/develop/contributing.md %})** |
 | :---------------------------------------------------------------------------- |
 | Learn about the process to contribute to Forseti, including how style guidelines and how to submit a pull request. |
 
-| **[Testing Forseti Contributions]({% link _docs/_latest/develop/testing)** |
+| **[Testing Forseti Contributions]({% link _docs/latest/develop/testing.md %})** |
 | :---------------------------------------------------------------------------- |
 | Learn how to build protos and run unit tests for your Forseti contributions. |
 
-| **[Setting up the Development Environment]({% link _docs/_latest/develop/dev-setup)** |
+| **[Setting up the Development Environment]({% link _docs/latest/develop/dev-setup.md %})** |
 | :---------------------------------------------------------------------------- |
 | Set up Forseti for local development from the Google Cloud Platform (GCP) infrastructure to executing commands.  |
 
-| **[Collecting and Storing New Data in Forseti Inventory]({% link _docs/_latest/develop/inventory-new-data)** |
+| **[Collecting and Storing New Data in Forseti Inventory]({% link _docs/latest/develop/inventory-new-data.md %})** |
 | :---------------------------------------------------------------------------- |
 | Modify Forseti Inventory to collect and store new data so you can inventory new products and resources. |
 
-| **[Creating a Rules Engine]({% link _docs/_latest/develop/rules_engine)** |
+| **[Creating a Rules Engine]({% link _docs/latest/develop/rules_engine.md %})** |
 | :---------------------------------------------------------------------------- |
 | Create your own Forseti Scanner rules to check different types of data to make sure it's securely configured. |

--- a/_docs/_latest/develop/testing.md
+++ b/_docs/_latest/develop/testing.md
@@ -7,7 +7,7 @@ order: 003
 This page describes how to run tests on your Forseti contributions. You need to
 install Forseti before you run the unit tests, either by following the
 [Developer Setup]({% link _docs/latest/develop/dev-setup.md %}) (local installation) 
-or the [GCP setup]({% link _docs/latest/setup/gcp-deployment.md %}) 
+or the [GCP setup]({% link _docs/latest/configure/configuring-forseti.md %}) 
 (install on a GCE instance; you will need to connect to that instance to run the unit tests).
 
 ## Executing tests

--- a/_docs/_latest/setup/index.md
+++ b/_docs/_latest/setup/index.md
@@ -17,18 +17,18 @@ Platform (GCP) environments.
 | :---------------------------------------------------------------------------- |
 | Get new features and update your GCP deployment by upgrading your Forseti Security installation to the latest version. |
 
-| **[Inventory]({% link _docs/latest/quickstarts/inventory/index.md %})** |
+| **[Inventory]({% link _docs/latest/configure/inventory/index.md %})** |
 | :---------------------------------------------------------------------------- |
 | Set up Inventory to collect and store information about your GCP resources. Inventory helps you undersand your resources and take action to conserve resources, reduce cost, and minimize security exposure. |
 
-| **[Scanner]({% link _docs/latest/quickstarts/scanner/index.md %})** |
+| **[Scanner]({% link _docs/latest/configure/scanner/index.md %})** |
 | :---------------------------------------------------------------------------- |
 | Set up Scanner to monitor your GCP resources for rule violations. Scanner uses the information from Inventory to regularly compare role-based access policies for your resources. |
 
-| **[Enforcer]({% link _docs/latest/quickstarts/enforcer/index.md %})** |
+| **[Enforcer]({% link _docs/latest/configure/enforcer/index.md %})** |
 | :---------------------------------------------------------------------------- |
 | Set up Enforcer to automatically correct policy discrepancies. Enforcer uses policies you create to compare the current state of your Compute Engine firewall to the desired state and uses Google Cloud APIs to make changes if it finds any differences. |
 
-| **[IAM Explain]({% link _docs/latest/quickstarts/explain/index.md %})** |
+| **[IAM Explain]({% link _docs/latest/configure/explain/index.md %})** |
 | :---------------------------------------------------------------------------- |
 | Set up IAM Explain to help you understand, test, and develop Cloud Identity and Access Management (Cloud IAM) policies. |

--- a/_docs/_latest/setup/index.md
+++ b/_docs/_latest/setup/index.md
@@ -9,26 +9,26 @@ Platform (GCP) environments.
 
 ---
 
-| **[Installing Forseti Security]({% link _docs/setup/install.md %})** |
+| **[Installing Forseti Security]({% link _docs/latest/setup/install.md %})** |
 | :---------------------------------------------------------------------------- |
 | Install Forseti Security to help protect your GCP environments by monitoring your GCP resources to ensure that role-based access controls are set as you intended. The setup wizard automatically determines setup information, generates a deployment template, and creates a Forseti deployment. |
 
-| **[Upgrading Forseti]({% link _docs/setup/upgrade.md %})** |
+| **[Upgrading Forseti]({% link _docs/latest/setup/upgrade.md %})** |
 | :---------------------------------------------------------------------------- |
 | Get new features and update your GCP deployment by upgrading your Forseti Security installation to the latest version. |
 
-| **[Inventory]({% link _docs/quickstarts/inventory/index.md %})** |
+| **[Inventory]({% link _docs/latest/quickstarts/inventory/index.md %})** |
 | :---------------------------------------------------------------------------- |
 | Set up Inventory to collect and store information about your GCP resources. Inventory helps you undersand your resources and take action to conserve resources, reduce cost, and minimize security exposure. |
 
-| **[Scanner]({% link _docs/quickstarts/scanner/index.md %})** |
+| **[Scanner]({% link _docs/latest/quickstarts/scanner/index.md %})** |
 | :---------------------------------------------------------------------------- |
 | Set up Scanner to monitor your GCP resources for rule violations. Scanner uses the information from Inventory to regularly compare role-based access policies for your resources. |
 
-| **[Enforcer]({% link _docs/quickstarts/enforcer/index.md %})** |
+| **[Enforcer]({% link _docs/latest/quickstarts/enforcer/index.md %})** |
 | :---------------------------------------------------------------------------- |
 | Set up Enforcer to automatically correct policy discrepancies. Enforcer uses policies you create to compare the current state of your Compute Engine firewall to the desired state and uses Google Cloud APIs to make changes if it finds any differences. |
 
-| **[IAM Explain]({% link _docs/quickstarts/explain/index.md %})** |
+| **[IAM Explain]({% link _docs/latest/quickstarts/explain/index.md %})** |
 | :---------------------------------------------------------------------------- |
 | Set up IAM Explain to help you understand, test, and develop Cloud Identity and Access Management (Cloud IAM) policies. |

--- a/_docs/_latest/setup/install.md
+++ b/_docs/_latest/setup/install.md
@@ -71,11 +71,11 @@ steps below:
 
      * SendGrid API key \[Optional\]: Used for sending email via SendGrid. For
        more information, see
-       [Enabling email notifications]({% link _docs/configure/email-notification.md %}).
+       [Enabling email notifications]({% link _docs/latest/configure/email-notification.md %}).
      * Email recipient \[Optional\]: If you provide a SendGrid API key, you will
        also be asked to whom Forseti should send the email notifications.
      * G Suite super admin email \[Not optional\]: This is part of the
-       [G Suite Google Groups collection]({% link _docs/configure/gsuite-group-collection.md %})
+       [G Suite Google Groups collection]({% link _docs/latest/configure/gsuite-group-collection.md %})
        and is necessary. Ask your G Suite Admin if you don't know the super
        admin email.
 
@@ -93,10 +93,10 @@ steps below:
 ## What's next
 
   - Learn how to customize
-    [Inventory]({% link _docs/configure/inventory/index.md %}) and 
-    [Scanner]({% link _docs/configure/scanner/index.md %}).
+    [Inventory]({% link _docs/latest/configure/inventory/index.md %}) and 
+    [Scanner]({% link _docs/latest/configure/scanner/index.md %}).
   - Configure Forseti to send
-    [email notifications]({% link _docs/configure/email-notification.md %}).
+    [email notifications]({% link _docs/latest/configure/email-notification.md %}).
   - Enable
-    [G Suite Google Groups collection]({% link _docs/configure/gsuite-group-collection.md %})
+    [G Suite Google Groups collection]({% link _docs/latest/configure/gsuite-group-collection.md %})
     for processing by Forseti.

--- a/_docs/_latest/setup/upgrade.md
+++ b/_docs/_latest/setup/upgrade.md
@@ -1,0 +1,8 @@
+---
+title: Forseti Upgrade
+order: 002
+---
+
+# {{ page.title }}
+
+TODO

--- a/_docs/_latest/use/cli.md
+++ b/_docs/_latest/use/cli.md
@@ -1,0 +1,7 @@
+---
+title: Using Forseti CLI
+order: 001
+---
+# { page.title }
+
+TODO

--- a/_docs/_latest/use/index.md
+++ b/_docs/_latest/use/index.md
@@ -9,10 +9,10 @@ access Forseti Security.
 
 ---
 
-| **[Command Line]({% link _docs/use/cli.md %})** |
+| **[Command Line]({% link _docs/latest/use/cli.md %})** |
 | :---------------------------------------------------------------------------- |
 | Using the command line to access Forseti data. |
 
-**[Inventory]({% link _docs/use/inventory.md %})**
+**[Inventory]({% link _docs/latest/use/inventory.md %})**
 | :---------------------------------------------------------------------------- |
 | Using third party tools to query raw Forseti Inventory data. |

--- a/_docs/_latest/use/inventory.md
+++ b/_docs/_latest/use/inventory.md
@@ -1,0 +1,7 @@
+---
+title: Using Forseti Inventory
+order: 002
+---
+# { page.title }
+
+TODO

--- a/_faq/installation_and_deployment/change-setup.md
+++ b/_faq/installation_and_deployment/change-setup.md
@@ -5,6 +5,6 @@ order: 3
 {::options auto_ids="false" /}
 
 You can edit your Forseti deployment script (refer to 
-["Updating Forseti"]({% link _docs/latest/setup/change-gcp-deployment.md %})) 
+["Updating Forseti"]({% link _docs/latest/configure/configuring-forseti.md %})) 
 or your Forseti configuration file (refer to 
 ["Configuring Forseti"]({% link _docs/latest/configure/configuring-forseti.md %}#move-configuration-to-gcs)).

--- a/_faq/installation_and_deployment/update-forseti.md
+++ b/_faq/installation_and_deployment/update-forseti.md
@@ -5,4 +5,4 @@ order: 2
 {::options auto_ids="false" /}
 
 Please refer to 
-["Updating Forseti"]({% link _docs/latest/setup/change-gcp-deployment.md %}).
+["Updating Forseti"]({% link _docs/latest/configure/configuring-forseti.md %}).

--- a/_faq/installation_and_deployment/which-deployment.md
+++ b/_faq/installation_and_deployment/which-deployment.md
@@ -5,8 +5,8 @@ order: 1
 {::options auto_ids="false" /}
 
 * "I want to setup Forseti in GCP with sane defaults" - Use the 
-[setup wizard]({% link _docs/latest/setup/gcp-deployment.md %}).
+[setup wizard]({% link _docs/latest/configure/configuring-forseti.md %}).
 * "I want to setup Forseti for development/local use" - Refer to 
 ["Development Environment Setup"]({% link _docs/latest/develop/dev-setup.md %}).
 * "I want to setup Forseti in GCP but want more flexibility in configuration" - 
-Refer to ["GCP Deployment"]({% link _docs/latest/setup/install-forseti-security.md %}).
+Refer to ["GCP Deployment"]({% link _docs/latest/setup/install.md %}).

--- a/about/index.md
+++ b/about/index.md
@@ -14,7 +14,7 @@ provide their respective features, and provide a foundation that addons can
 build upon.
 
 Get started with
-[Forseti Security]({% link _docs/latest/setup/gcp-deployment.md %}).
+[Forseti Security]({% link _docs/latest/configure/configuring-forseti.md %}).
 
 ## When to use Forseti Security
 

--- a/travis/jekyll_build.sh
+++ b/travis/jekyll_build.sh
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e
+trap 'return_code=$?' ERR
 
 if  [ -z ${JGT+x} ]; then
     # We don't have access to the encrypted vars.
@@ -24,3 +26,5 @@ fi
 bundle exec htmlproofer --check-img-http --check-opengraph --check-html \
 --check-favicon --report-missing-names --report-script-embeds \
 --url-ignore "/GoogleCloudPlatform/forseti-security/edit/" ./_www/www
+
+exit ${return_code}


### PR DESCRIPTION
Merge this PR after:

1. #1331 

Fixes broken link issues in build for #1306.

Please review these changes as a team to verify that the links are pointing to the appropriate pages. I've used context clues in places where there was no direct file correlation. In other places, I simply added _TODO_ placeholders for pages I believe are in the pipeline (yet to be merged).

