### PR TITLE
Include data_format explicitly in notifier config.

### DIFF
--- a/configs/server/forseti_conf_server.yaml.in
+++ b/configs/server/forseti_conf_server.yaml.in
@@ -87,12 +87,14 @@ notifier:
             # Email violations
             - name: email_violations
               configuration:
+                data_format: csv
                 sendgrid_api_key: {SENDGRID_API_KEY}
                 sender: {EMAIL_SENDER}
                 recipient: {EMAIL_RECIPIENT}
             # Upload violations to GCS.
             - name: gcs_violations
               configuration:
+                data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
             # Slack webhook pipeline.
@@ -101,6 +103,7 @@ notifier:
             # Add the provided URL in the configuration below in `webhook_url`.
             - name: slack_webhook
               configuration:
+                data_format: json  # slack only supports json
                 webhook_url: ''
 
         - resource: blacklist_violations
@@ -109,6 +112,7 @@ notifier:
             # Upload violations to GCS.
             - name: gcs_violations
               configuration:
+                data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
 
@@ -118,6 +122,7 @@ notifier:
             # Upload violations to GCS.
             - name: gcs_violations
               configuration:
+                data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
 
@@ -127,6 +132,7 @@ notifier:
             # Upload violations to GCS.
             - name: gcs_violations
               configuration:
+                data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
 
@@ -136,6 +142,7 @@ notifier:
             # Upload violations to GCS.
             - name: gcs_violations
               configuration:
+                data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
 
@@ -145,6 +152,7 @@ notifier:
             # Upload violations to GCS.
             - name: gcs_violations
               configuration:
+                data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
 
@@ -154,6 +162,7 @@ notifier:
             # Upload violations to GCS.
             - name: gcs_violations
               configuration:
+                data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
 
@@ -163,6 +172,7 @@ notifier:
             # Upload violations to GCS.
             - name: gcs_violations
               configuration:
+                data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
 
@@ -172,6 +182,7 @@ notifier:
             # Upload violations to GCS.
             - name: gcs_violations
               configuration:
+                data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
 
@@ -181,6 +192,7 @@ notifier:
             # Upload violations to GCS.
             - name: gcs_violations
               configuration:
+                data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
 
@@ -190,6 +202,7 @@ notifier:
             # Upload violations to GCS.
             - name: gcs_violations_pipeline
               configuration:
+                data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: gs://{SCANNER_BUCKET}/scanner_violations
 

--- a/configs/server/forseti_conf_server.yaml.sample
+++ b/configs/server/forseti_conf_server.yaml.sample
@@ -86,6 +86,7 @@ notifier:
             # Email violations
             - name: email_violations
               configuration:
+                data_format: csv
                 sendgrid_api_key: ''
                 sender: ''
                 # Multiple recipients can be specified as comma-separated text.
@@ -93,6 +94,7 @@ notifier:
             # Upload violations to GCS.
             - name: gcs_violations
               configuration:
+                data_format: csv
                 # gcs_path should begin with "gs://"
                 gcs_path: ''
             # Slack webhook pipeline
@@ -101,6 +103,7 @@ notifier:
             # Add the provided URL in the configuration below in `webhook_url`.
             - name: slack_webhook
               configuration:
+                data_format: json  # slack only supports json
                 webhook_url: ''
 
     violation:


### PR DESCRIPTION
So, users don't have to do this themselves, which can be easy to screw up.