### PR TITLE
Add flag to enable debug mode and suppress crawler's errors & warnings with it.

### DIFF
--- a/google/cloud/forseti/services/cli.py
+++ b/google/cloud/forseti/services/cli.py
@@ -67,6 +67,11 @@ def define_inventory_parser(parent):
         action='store_true',
         help='Execute inventory in background',
     )
+    create_inventory_parser.add_argument(
+        '--enable_debug',
+        action='store_true',
+        help='Emit additional information for debugging.',
+    )
 
     delete_inventory_parser = action_subparser.add_parser(
         'delete',
@@ -703,7 +708,8 @@ def run_inventory(client, config, output, _):
     def do_create_inventory():
         """Create an inventory."""
         for progress in client.create(config.background,
-                                      config.import_as):
+                                      config.import_as,
+                                      config.enable_debug):
             output.write(progress)
 
     def do_list_inventory():

--- a/google/cloud/forseti/services/client.py
+++ b/google/cloud/forseti/services/client.py
@@ -286,13 +286,15 @@ class InventoryClient(ForsetiClient):
         echo = self.stub.Ping(inventory_pb2.PingRequest(data=data)).data
         return echo == data
 
-    def create(self, background=False, import_as=None):
+    def create(self, background=False, import_as=None, enable_debug=False):
         """Creates a new inventory, with an optional import.
 
         Args:
             background (bool): whether to run in background
             import_as (str): the name of the data model to create after
                 inventory is created
+            enable_debug (bool): whether to emit additional information
+                for debugging
 
         Returns:
             proto: the returned proto message of create inventory
@@ -300,7 +302,8 @@ class InventoryClient(ForsetiClient):
 
         request = inventory_pb2.CreateRequest(
             background=background,
-            model_name=import_as)
+            model_name=import_as,
+            enable_debug=enable_debug)
         return self.stub.Create(request)
 
     def get(self, inventory_index_id):

--- a/google/cloud/forseti/services/inventory/inventory.proto
+++ b/google/cloud/forseti/services/inventory/inventory.proto
@@ -52,6 +52,7 @@ message Progress {
 message CreateRequest {
   bool background = 1;
   string model_name = 2;
+  bool enable_debug = 3;
 }
 
 message ListRequest {

--- a/google/cloud/forseti/services/inventory/service.py
+++ b/google/cloud/forseti/services/inventory/service.py
@@ -86,14 +86,22 @@ class GrpcInventory(inventory_pb2_grpc.InventoryServicer):
 
         for progress in self.inventory.create(request.background,
                                               request.model_name):
+
+            if self.inventory.config.enable_debug_mode:
+                last_warning = repr(progress.last_warning)
+                last_error = repr(progress.last_error)
+            else:
+                last_warning = None
+                last_error = None
+
             yield inventory_pb2.Progress(
                 id=progress.inventory_index_id,
                 final_message=progress.final_message,
                 step=progress.step,
                 warnings=progress.warnings,
                 errors=progress.errors,
-                last_warning=repr(progress.last_warning),
-                last_error=repr(progress.last_error))
+                last_warning=last_warning,
+                last_error=last_error)
 
     @autoclose_stream
     def List(self, request, _):

--- a/google/cloud/forseti/services/inventory/service.py
+++ b/google/cloud/forseti/services/inventory/service.py
@@ -87,7 +87,7 @@ class GrpcInventory(inventory_pb2_grpc.InventoryServicer):
         for progress in self.inventory.create(request.background,
                                               request.model_name):
 
-            if self.inventory.config.enable_debug_mode:
+            if request.enable_debug:
                 last_warning = repr(progress.last_warning)
                 last_error = repr(progress.last_error)
             else:

--- a/google/cloud/forseti/services/server.py
+++ b/google/cloud/forseti/services/server.py
@@ -264,7 +264,7 @@ class ServiceConfig(AbstractServiceConfig):
             global_config (dict): Global configurations
             forseti_db_connect_string (str): Forseti database string
             endpoint (str): server endpoint
-            enable_debug_mode (bool): Enable console logging.
+            enable_debug_mode (bool): Enable debug mode.
         """
 
         super(ServiceConfig, self).__init__()
@@ -386,7 +386,7 @@ def serve(endpoint,
         forseti_config_file_path (str): Path to Forseti configuration file.
         log_level (str): Sets the threshold for Forseti's logger.
         enable_console_log (bool): Enable console logging.
-        enable_debug_mode (bool): Enable console logging.
+        enable_debug_mode (bool): Enable debug mode.
         max_workers (int): maximum number of workers for the crawler
         wait_shutdown_secs (int): seconds to wait before shutdown
 

--- a/google/cloud/forseti/services/server.py
+++ b/google/cloud/forseti/services/server.py
@@ -253,7 +253,8 @@ class ServiceConfig(AbstractServiceConfig):
                  notifier_config,
                  global_config,
                  forseti_db_connect_string,
-                 endpoint):
+                 endpoint,
+                 enable_debug_mode):
         """Initialize
 
         Args:
@@ -263,6 +264,7 @@ class ServiceConfig(AbstractServiceConfig):
             global_config (dict): Global configurations
             forseti_db_connect_string (str): Forseti database string
             endpoint (str): server endpoint
+            enable_debug_mode (bool): Enable console logging.
         """
 
         super(ServiceConfig, self).__init__()
@@ -272,6 +274,7 @@ class ServiceConfig(AbstractServiceConfig):
         self.model_manager = ModelManager(self.engine)
         self.sessionmaker = db.create_scoped_sessionmaker(self.engine)
         self.endpoint = endpoint
+        self.enable_debug_mode = enable_debug_mode
 
         self.inventory_config = inventory_config
         self.inventory_config.set_service_config(self)
@@ -371,6 +374,7 @@ def serve(endpoint,
           forseti_config_file_path,
           log_level,
           enable_console_log,
+          enable_debug_mode,
           max_workers=32,
           wait_shutdown_secs=3):
     """Instantiate the services and serves them via gRPC.
@@ -382,6 +386,7 @@ def serve(endpoint,
         forseti_config_file_path (str): Path to Forseti configuration file.
         log_level (str): Sets the threshold for Forseti's logger.
         enable_console_log (bool): Enable console logging.
+        enable_debug_mode (bool): Enable console logging.
         max_workers (int): maximum number of workers for the crawler
         wait_shutdown_secs (int): seconds to wait before shutdown
 
@@ -430,7 +435,8 @@ def serve(endpoint,
                            notifier_config=forseti_notifier_config,
                            global_config=forseti_global_config,
                            forseti_db_connect_string=forseti_db_connect_string,
-                           endpoint=endpoint)
+                           endpoint=endpoint,
+                           enable_debug_mode=enable_debug_mode)
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers))
     for factory in factories:
@@ -479,11 +485,19 @@ def main():
         '--enable_console_log',
         action='store_true',
         help='Print log to console.')
+    parser.add_argument(
+        '--enable_debug_mode',
+        action='store_true',
+        help='Emit additional details for debugging.')
     args = vars(parser.parse_args())
 
-    serve(args['endpoint'], args['services'], args['forseti_db'],
-          args['forseti_config_file_path'], args['log_level'],
-          args['enable_console_log'])
+    serve(args['endpoint'],
+          args['services'],
+          args['forseti_db'],
+          args['forseti_config_file_path'],
+          args['log_level'],
+          args['enable_console_log'],
+          args['enable_debug_mode'])
 
 
 if __name__ == '__main__':

--- a/google/cloud/forseti/services/server.py
+++ b/google/cloud/forseti/services/server.py
@@ -253,8 +253,7 @@ class ServiceConfig(AbstractServiceConfig):
                  notifier_config,
                  global_config,
                  forseti_db_connect_string,
-                 endpoint,
-                 enable_debug_mode):
+                 endpoint):
         """Initialize
 
         Args:
@@ -264,7 +263,6 @@ class ServiceConfig(AbstractServiceConfig):
             global_config (dict): Global configurations
             forseti_db_connect_string (str): Forseti database string
             endpoint (str): server endpoint
-            enable_debug_mode (bool): Enable debug mode.
         """
 
         super(ServiceConfig, self).__init__()
@@ -274,7 +272,6 @@ class ServiceConfig(AbstractServiceConfig):
         self.model_manager = ModelManager(self.engine)
         self.sessionmaker = db.create_scoped_sessionmaker(self.engine)
         self.endpoint = endpoint
-        self.enable_debug_mode = enable_debug_mode
 
         self.inventory_config = inventory_config
         self.inventory_config.set_service_config(self)
@@ -374,7 +371,6 @@ def serve(endpoint,
           forseti_config_file_path,
           log_level,
           enable_console_log,
-          enable_debug_mode,
           max_workers=32,
           wait_shutdown_secs=3):
     """Instantiate the services and serves them via gRPC.
@@ -386,7 +382,6 @@ def serve(endpoint,
         forseti_config_file_path (str): Path to Forseti configuration file.
         log_level (str): Sets the threshold for Forseti's logger.
         enable_console_log (bool): Enable console logging.
-        enable_debug_mode (bool): Enable debug mode.
         max_workers (int): maximum number of workers for the crawler
         wait_shutdown_secs (int): seconds to wait before shutdown
 
@@ -435,8 +430,7 @@ def serve(endpoint,
                            notifier_config=forseti_notifier_config,
                            global_config=forseti_global_config,
                            forseti_db_connect_string=forseti_db_connect_string,
-                           endpoint=endpoint,
-                           enable_debug_mode=enable_debug_mode)
+                           endpoint=endpoint)
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers))
     for factory in factories:
@@ -485,10 +479,6 @@ def main():
         '--enable_console_log',
         action='store_true',
         help='Print log to console.')
-    parser.add_argument(
-        '--enable_debug_mode',
-        action='store_true',
-        help='Emit additional details for debugging.')
     args = vars(parser.parse_args())
 
     serve(args['endpoint'],
@@ -496,8 +486,7 @@ def main():
           args['forseti_db'],
           args['forseti_config_file_path'],
           args['log_level'],
-          args['enable_console_log'],
-          args['enable_debug_mode'])
+          args['enable_console_log'])
 
 
 if __name__ == '__main__':

--- a/tests/services/cli_test.py
+++ b/tests/services/cli_test.py
@@ -110,7 +110,7 @@ class ImporterTest(ForsetiTestCase):
     @test_cmds([
         ('inventory create --background --import_as "bar"',
          CLIENT.inventory.create,
-         [True, 'bar'],
+         [True, 'bar', False],
          {},
          '{}',
          {}),


### PR DESCRIPTION
Fixes #1349 

I have tested this functionally.  Inventory is the same.  But unable to verify if errors are saved correctly as there are no errors in our environment.