### PR TITLE
Make the default instance network scanner not throw off violation

### DIFF
--- a/rules/instance_network_interface_rules.yaml
+++ b/rules/instance_network_interface_rules.yaml
@@ -24,10 +24,12 @@ rules:
     is_external_network: True
     # this would be a custom list of your networks/projects.
     whitelist:
-      master: 
-        - master-1
-      network: 
-        - network-1 
-        - network-2
-      default:
-        - default-1
+      # Below are examples that you can reference to create your own custom
+      # whitelist.
+      # project-1:
+      #  - network-1
+      # project-2:
+      #  - network-2
+      #  - network-2-2
+      #project-3:
+      #  - network-3

--- a/rules/instance_network_interface_rules.yaml
+++ b/rules/instance_network_interface_rules.yaml
@@ -12,24 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-rules:
-  # This rule helps with:
-  # #1 Ensure instances with external IPs are only running 
-  # on whitelisted networks
-  # #2 Ensure instances are only running on networks created in allowed 
-  # projects (using XPN)
-  - name: all networks covered in whitelist
-    project: '*'
-    network: '*'
-    is_external_network: True
-    # this would be a custom list of your networks/projects.
-    whitelist:
-      # Below are examples that you can reference to create your own custom
-      # whitelist.
-      # project-1:
-      #  - network-1
-      # project-2:
-      #  - network-2
-      #  - network-2-2
-      #project-3:
-      #  - network-3
+# Below is the example that you can reference to create your own rule.
+# rules:
+#   # This rule helps with:
+#   # #1 Ensure instances with external IPs are only running 
+#   # on whitelisted networks
+#   # #2 Ensure instances are only running on networks created in allowed 
+#   # projects (using XPN)
+#   - name: all networks covered in whitelist
+#     project: '*'
+#     network: '*'
+#     is_external_network: True
+#     # This would be a custom list of your projects/networks.
+#     whitelist:
+#       whitelist.
+#       project-1:
+#        - network-1
+#       project-2:
+#        - network-2
+#        - network-2-2
+#       project-3:
+#        - network-3

--- a/rules/instance_network_interface_rules.yaml
+++ b/rules/instance_network_interface_rules.yaml
@@ -25,7 +25,6 @@
 #     is_external_network: True
 #     # This would be a custom list of your projects/networks.
 #     whitelist:
-#       whitelist.
 #       project-1:
 #        - network-1
 #       project-2:


### PR DESCRIPTION
Also make the rule more accurately reflect the correct syntax.

Fixes #1360 