### PR TITLE
Updated step to output resourceType/resourceKey

### DIFF
--- a/google/cloud/forseti/services/inventory/inventory.py
+++ b/google/cloud/forseti/services/inventory/inventory.py
@@ -72,7 +72,7 @@ class QueueProgresser(Progress):
             resource (Resource): db row of Resource
         """
 
-        self.step = resource.key()
+        self.step = '{}/{}'.format(resource.type(), resource.key())
         self._notify()
 
     def on_warning(self, warning):


### PR DESCRIPTION
Example step output:
"subnetwork/3316438950644033618" instead of "3316438950644033618"
"firewall/4532033159196977876" instead of "4532033159196977876"
"project/proj-apple" instead of "proj-apple"

Resolves #1330 