### PR TITLE
Make server command line arg processing more robust

### DIFF
--- a/google/cloud/forseti/services/server.py
+++ b/google/cloud/forseti/services/server.py
@@ -450,7 +450,6 @@ def serve(endpoint,
             return
 
 
-
 def check_args(args):
     """Make sure the required args are present and valid.
 

--- a/google/cloud/forseti/services/server.py
+++ b/google/cloud/forseti/services/server.py
@@ -22,10 +22,11 @@ from concurrent import futures
 from multiprocessing.pool import ThreadPool
 
 import argparse
-import grpc
 import os
 import sys
 import time
+
+import grpc
 
 from google.cloud.forseti.common.util import file_loader
 from google.cloud.forseti.common.util import logger

--- a/tests/services/server_test.py
+++ b/tests/services/server_test.py
@@ -17,8 +17,6 @@ import unittest
 import mock
 from tests.unittest_utils import ForsetiTestCase
 from google.cloud.forseti.services import server
-import pdb
-
 
 
 class NameSpace(object):

--- a/tests/services/server_test.py
+++ b/tests/services/server_test.py
@@ -1,0 +1,96 @@
+# Copyright 2018 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit Tests: Forseti Server."""
+
+import unittest
+import mock
+from tests.unittest_utils import ForsetiTestCase
+from google.cloud.forseti.services import server
+
+
+class NameSpace(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class ServerTest(ForsetiTestCase):
+    """Test Forseti Server."""
+
+    @mock.patch('google.cloud.forseti.services.server.argparse', autospec=True)
+    def test_services_not_specified(self, mock_argparse):
+        """Test main() with no service specified."""
+        expected_exit_code = 1
+        mock_arg_parser = mock.MagicMock()
+        mock_argparse.ArgumentParser.return_value = mock_arg_parser
+        mock_arg_parser.parse_args.return_value = NameSpace(
+            endpoint='[::]:50051',
+            services=None,
+            forseti_db=None,
+            config_file_path=None,
+            log_level='info',
+            enable_console_log=False)
+
+        try:
+            server.main()
+        except SystemExit as e:
+            self.assertEquals(expected_exit_code, e.code)
+        else:
+            self.assertFalse('SystemExit not raised')
+
+    @mock.patch('google.cloud.forseti.services.server.argparse', autospec=True)
+    def test_config_file_path_not_specified(self, mock_argparse):
+        """Test main() with no config_file_path specified."""
+        expected_exit_code = 2
+        mock_arg_parser = mock.MagicMock()
+        mock_argparse.ArgumentParser.return_value = mock_arg_parser
+        mock_arg_parser.parse_args.return_value = NameSpace(
+            endpoint='[::]:50051',
+            services=['scanner'],
+            forseti_db=None,
+            config_file_path=None,
+            log_level='info',
+            enable_console_log=False)
+
+        try:
+            server.main()
+        except SystemExit as e:
+            self.assertEquals(expected_exit_code, e.code)
+        else:
+            self.assertFalse('SystemExit not raised')
+
+    @mock.patch('google.cloud.forseti.services.server.argparse', autospec=True)
+    def test_config_file_path_non_existent_file(self, mock_argparse):
+        """Test main() with non-existent config file."""
+        expected_exit_code = 3
+        mock_arg_parser = mock.MagicMock()
+        mock_argparse.ArgumentParser.return_value = mock_arg_parser
+        mock_arg_parser.parse_args.return_value = NameSpace(
+            endpoint='[::]:50051',
+            services=['scanner'],
+            forseti_db=None,
+            config_file_path='/this/does/not/exist',
+            log_level='info',
+            enable_console_log=False)
+
+        try:
+            server.main()
+        except SystemExit as e:
+            self.assertEquals(expected_exit_code, e.code)
+        else:
+            self.assertFalse('SystemExit not raised')
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/services/server_test.py
+++ b/tests/services/server_test.py
@@ -41,12 +41,9 @@ class ServerTest(ForsetiTestCase):
             log_level='info',
             enable_console_log=False)
 
-        try:
+        with self.assertRaises(SystemExit) as e:
             server.main()
-        except SystemExit as e:
             self.assertEquals(expected_exit_code, e.code)
-        else:
-            self.assertFalse('SystemExit not raised')
 
     @mock.patch('google.cloud.forseti.services.server.argparse', autospec=True)
     def test_config_file_path_not_specified(self, mock_argparse):
@@ -62,12 +59,27 @@ class ServerTest(ForsetiTestCase):
             log_level='info',
             enable_console_log=False)
 
-        try:
+        with self.assertRaises(SystemExit) as e:
             server.main()
-        except SystemExit as e:
             self.assertEquals(expected_exit_code, e.code)
-        else:
-            self.assertFalse('SystemExit not raised')
+
+    @mock.patch('google.cloud.forseti.services.server.argparse', autospec=True)
+    def test_config_file_path_non_readable_file(self, mock_argparse):
+        """Test main() with non-readable config file."""
+        expected_exit_code = 3
+        mock_arg_parser = mock.MagicMock()
+        mock_argparse.ArgumentParser.return_value = mock_arg_parser
+        mock_arg_parser.parse_args.return_value = NameSpace(
+            endpoint='[::]:50051',
+            services=['scanner'],
+            forseti_db=None,
+            config_file_path='/this/does/not/exist',
+            log_level='info',
+            enable_console_log=False)
+
+        with self.assertRaises(SystemExit) as e:
+            server.main()
+            self.assertEquals(expected_exit_code, e.code)
 
     @mock.patch('google.cloud.forseti.services.server.argparse', autospec=True)
     def test_config_file_path_non_existent_file(self, mock_argparse):
@@ -83,13 +95,9 @@ class ServerTest(ForsetiTestCase):
             log_level='info',
             enable_console_log=False)
 
-        try:
+        with self.assertRaises(SystemExit) as e:
             server.main()
-        except SystemExit as e:
             self.assertEquals(expected_exit_code, e.code)
-        else:
-            self.assertFalse('SystemExit not raised')
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The server now makes sure that the user supplies
 * at least one service
 * the config file path (also checks that the specified path points to a file and that the latter is readable)
 * the database connection string

on the command line. Fixes issue #1166.
