### PR TITLE
Fix docstring formatting issues

### DIFF
--- a/google/cloud/forseti/common/gcp_api/api_helpers.py
+++ b/google/cloud/forseti/common/gcp_api/api_helpers.py
@@ -31,7 +31,7 @@ def get_delegated_credential(delegated_account, scopes):
 
     Returns:
         service_account.Credentials: Credentials as built by
-            google.oauth2.service_account.
+        google.oauth2.service_account.
     """
     request = requests.Request()
 

--- a/google/cloud/forseti/common/gcp_api/appengine.py
+++ b/google/cloud/forseti/common/gcp_api/appengine.py
@@ -292,7 +292,7 @@ class AppEngineClient(object):
 
         Returns:
             dict: A Service resource dict for a given project_id and
-                service_id.
+            service_id.
         """
         try:
             results = self.repository.app_services.get(
@@ -338,7 +338,7 @@ class AppEngineClient(object):
 
         Returns:
             dict: A Version resource dict for a given project_id and
-                service_id.
+            service_id.
         """
         try:
             results = self.repository.service_versions.get(
@@ -388,7 +388,7 @@ class AppEngineClient(object):
 
         Returns:
             dict: An Instance resource dict for a given project_id,
-                service_id and version_id.
+            service_id and version_id.
         """
         try:
             results = self.repository.version_instances.get(

--- a/google/cloud/forseti/common/gcp_api/bigquery.py
+++ b/google/cloud/forseti/common/gcp_api/bigquery.py
@@ -182,16 +182,16 @@ class BigQueryClient(object):
 
     def get_dataset_access(self, project_id, dataset_id):
         """Return the access portion of the dataset resource object.
-        
+
         Args:
             project_id (str): String representing the project id.
             dataset_id (str): String representing the dataset id.
-        
+
         Returns:
             list: A list of access lists for a given project_id and dataset_id.
 
         An example return value:
-          
+
             [
                 {'role': 'WRITER', 'specialGroup': 'projectWriters'},
                 {'role': 'OWNER', 'specialGroup': 'projectOwners'},

--- a/google/cloud/forseti/common/gcp_api/bigquery.py
+++ b/google/cloud/forseti/common/gcp_api/bigquery.py
@@ -129,12 +129,14 @@ class BigQueryClient(object):
         Returns:
             list: A list of project_ids enabled for bigquery.
 
+            If there are no project_ids enabled for bigquery an empty list will
+            be returned.
+
+        An example return value::
+
             ['project-id',
              'project-id',
              '...']
-
-            If there are no project_ids enabled for bigquery an empty list will
-            be returned.
         """
         try:
             results = self.repository.projects.list(
@@ -158,7 +160,9 @@ class BigQueryClient(object):
             project_id (str): String representing the project id.
 
         Returns:
-            list: A list of datasetReference objects for a given project_id.
+            list: A list of datasetReference objects for a given project_id
+
+        An example return value::
 
             [{'datasetId': 'dataset-id',
               'projectId': 'project-id'},
@@ -178,17 +182,22 @@ class BigQueryClient(object):
 
     def get_dataset_access(self, project_id, dataset_id):
         """Return the access portion of the dataset resource object.
-
+        
         Args:
             project_id (str): String representing the project id.
             dataset_id (str): String representing the dataset id.
-
+        
         Returns:
             list: A list of access lists for a given project_id and dataset_id.
-            [{'role': 'WRITER', 'specialGroup': 'projectWriters'},
-             {'role': 'OWNER', 'specialGroup': 'projectOwners'},
-             {'role': 'OWNER', 'userByEmail': 'user@domain.com'},
-             {'role': 'READER', 'specialGroup': 'projectReaders'}]
+
+        An example return value::
+          
+            [
+                {'role': 'WRITER', 'specialGroup': 'projectWriters'},
+                {'role': 'OWNER', 'specialGroup': 'projectOwners'},
+                {'role': 'OWNER', 'userByEmail': 'user@domain.com'},
+                {'role': 'READER', 'specialGroup': 'projectReaders'}
+            ]
         """
         try:
             results = self.repository.datasets.get(resource=project_id,

--- a/google/cloud/forseti/common/gcp_api/bigquery.py
+++ b/google/cloud/forseti/common/gcp_api/bigquery.py
@@ -132,7 +132,7 @@ class BigQueryClient(object):
             If there are no project_ids enabled for bigquery an empty list will
             be returned.
 
-        An example return value::
+        An example return value:
 
             ['project-id',
              'project-id',
@@ -162,7 +162,7 @@ class BigQueryClient(object):
         Returns:
             list: A list of datasetReference objects for a given project_id
 
-        An example return value::
+        An example return value:
 
             [{'datasetId': 'dataset-id',
               'projectId': 'project-id'},
@@ -190,7 +190,7 @@ class BigQueryClient(object):
         Returns:
             list: A list of access lists for a given project_id and dataset_id.
 
-        An example return value::
+        An example return value:
           
             [
                 {'role': 'WRITER', 'specialGroup': 'projectWriters'},

--- a/google/cloud/forseti/common/gcp_api/compute.py
+++ b/google/cloud/forseti/common/gcp_api/compute.py
@@ -1013,9 +1013,9 @@ class ComputeClient(object):
 
         Returns:
             dict: The quota of a requested metric in a dict.
-            
+
         An example return value:
-        
+
                 {
                   "metric": "FIREWALLS",
                   "limit": 100.0,

--- a/google/cloud/forseti/common/gcp_api/compute.py
+++ b/google/cloud/forseti/common/gcp_api/compute.py
@@ -981,12 +981,14 @@ class ComputeClient(object):
 
         Returns:
             dict: The quota of a requested metric in a dict.
-                Example:
-                {
-                  "metric": "FIREWALLS",
-                  "limit": 100.0,
-                  "usage": 9.0
-                }
+
+        An example return value::
+
+            {
+              "metric": "FIREWALLS",
+              "limit": 100.0,
+              "usage": 9.0
+            }
 
         Raises:
             KeyError: Metric was not found in the project.
@@ -1011,7 +1013,7 @@ class ComputeClient(object):
 
         Returns:
             dict: The quota of a requested metric in a dict.
-                Example:
+            
                 {
                   "metric": "FIREWALLS",
                   "limit": 100.0,

--- a/google/cloud/forseti/common/gcp_api/compute.py
+++ b/google/cloud/forseti/common/gcp_api/compute.py
@@ -982,7 +982,7 @@ class ComputeClient(object):
         Returns:
             dict: The quota of a requested metric in a dict.
 
-        An example return value::
+        An example return value:
 
             {
               "metric": "FIREWALLS",
@@ -1014,6 +1014,8 @@ class ComputeClient(object):
         Returns:
             dict: The quota of a requested metric in a dict.
             
+        An example return value:
+        
                 {
                   "metric": "FIREWALLS",
                   "limit": 100.0,

--- a/google/cloud/forseti/common/gcp_api/container.py
+++ b/google/cloud/forseti/common/gcp_api/container.py
@@ -218,7 +218,7 @@ class ContainerClient(object):
             dict: A serverconfig for a given Compute Engine zone.
             https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/ServerConfig
 
-        An example return value::
+        An example return value:
 
             {
               "defaultClusterVersion": string,
@@ -268,7 +268,7 @@ class ContainerClient(object):
             list: A list of Cluster dicts.
             https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.zones.clusters#Cluster
 
-        An example return value::
+        An example return value:
 
             [
                 {"name": "cluster-1", ...}

--- a/google/cloud/forseti/common/gcp_api/container.py
+++ b/google/cloud/forseti/common/gcp_api/container.py
@@ -218,6 +218,8 @@ class ContainerClient(object):
             dict: A serverconfig for a given Compute Engine zone.
             https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/ServerConfig
 
+        An example return value::
+
             {
               "defaultClusterVersion": string,
               "validNodeVersions": [
@@ -266,9 +268,13 @@ class ContainerClient(object):
             list: A list of Cluster dicts.
             https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.zones.clusters#Cluster
 
-            [{"name": "cluster-1", ...}
-             {"name": "cluster-2", ...},
-             {...}]
+        An example return value::
+
+            [
+                {"name": "cluster-1", ...}
+                {"name": "cluster-2", ...},
+                {...}
+            ]
 
         Raises:
             ApiExecutionError: ApiExecutionError is raised if the call to the

--- a/google/cloud/forseti/common/gcp_type/resource_util.py
+++ b/google/cloud/forseti/common/gcp_type/resource_util.py
@@ -61,7 +61,7 @@ def create_resource(resource_id, resource_type, **kwargs):
 
     Returns:
         Resource: The new Resource based on the type, if supported,
-            otherwise None.
+        otherwise None.
     """
     if resource_type not in _RESOURCE_TYPE_MAP:
         return None

--- a/google/cloud/forseti/common/util/regular_exp.py
+++ b/google/cloud/forseti/common/util/regular_exp.py
@@ -21,8 +21,8 @@ def escape_and_globify(pattern_string):
     """Given a pattern string with a glob, create actual regex pattern.
 
     To require > 0 length glob, change the "*" to ".+". This is to handle
-    strings like "*@company.com". (The actual regex would probably be
-    ".*@company.com", except that we don't want to match zero-length
+    strings like "\*@company.com". (The actual regex would probably be
+    ".\*@company.com", except that we don't want to match zero-length
     usernames before the "@".)
 
     Special case the pattern '*' to match 0 or more characters.

--- a/google/cloud/forseti/common/util/regular_exp.py
+++ b/google/cloud/forseti/common/util/regular_exp.py
@@ -16,7 +16,7 @@
 
 import re
 
-
+# pylint: disable=anomalous-backslash-in-string
 def escape_and_globify(pattern_string):
     """Given a pattern string with a glob, create actual regex pattern.
 
@@ -34,6 +34,7 @@ def escape_and_globify(pattern_string):
         str: The pattern string, escaped except for the "*", which is
             transformed into ".+" (match on one or more characters).
     """
+    # pylint: enable=anomalous-backslash-in-string
     if pattern_string == '*':
         return '^.*$'
     return '^{}$'.format(re.escape(pattern_string).replace('\\*', '.+?'))

--- a/google/cloud/forseti/common/util/relationship.py
+++ b/google/cloud/forseti/common/util/relationship.py
@@ -37,7 +37,7 @@ def find_ancestors(starting_resource, full_name):
 
     Returns:
         list: A list of GCP resources in ascending order in the resource
-            hierarchy.
+        hierarchy.
     """
     ancestor_resources = [starting_resource]
 

--- a/google/cloud/forseti/enforcer/batch_enforcer.py
+++ b/google/cloud/forseti/enforcer/batch_enforcer.py
@@ -111,8 +111,8 @@ class BatchFirewallEnforcer(object):
 
         Returns:
           enforcer_log_pb2.EnforcerLog: The EnforcerLog proto for the last run,
-              including individual results for each project, and a summary of
-              all results.
+          including individual results for each project, and a summary of all
+          results.
         """
         if self._dry_run:
             LOGGER.info('Simulating changes')

--- a/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
+++ b/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
@@ -119,8 +119,7 @@ def get_network_name_from_url(network_url):
 
     Args:
       network_url: str - the fully qualified network url, such as
-        (https://www.googleapis.com/compute/v1/projects/'
-        'my-proj/global/networks/my-network')
+        ('<root>/compute/v1/projects/my-proj/global/networks/my-network')
 
     Returns:
       str - the network name, my-network in the previous example
@@ -221,9 +220,10 @@ class ComputeFirewallAPI(object):
           A dictionary with three keys, metric, limit and usage.
 
           Example:
-          {"metric": "FIREWALLS",
-           "limit": 100,
-           "usage": 9}
+          
+              {"metric": "FIREWALLS",
+               "limit": 100,
+               "usage": 9}
         """
         request = self.gce_service.projects().get(
             project=project, fields='quotas')

--- a/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
+++ b/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
@@ -219,7 +219,7 @@ class ComputeFirewallAPI(object):
         Returns:
           A dictionary with three keys, metric, limit and usage.
 
-          Example:
+          An example return value:
           
               {"metric": "FIREWALLS",
                "limit": 100,

--- a/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
+++ b/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
@@ -220,7 +220,7 @@ class ComputeFirewallAPI(object):
           A dictionary with three keys, metric, limit and usage.
 
           An example return value:
-          
+
               {"metric": "FIREWALLS",
                "limit": 100,
                "usage": 9}

--- a/google/cloud/forseti/enforcer/project_enforcer.py
+++ b/google/cloud/forseti/enforcer/project_enforcer.py
@@ -124,7 +124,7 @@ class ProjectEnforcer(object):
 
         Returns:
             enforcer_log_pb2.ProjectResult: A proto with details on the status
-                of the enforcement and an audit log with any changes made.
+            of the enforcement and an audit log with any changes made.
         """
         if networks:
             networks = sorted(networks)

--- a/google/cloud/forseti/scanner/audit/forwarding_rule_rules_engine.py
+++ b/google/cloud/forseti/scanner/audit/forwarding_rule_rules_engine.py
@@ -67,7 +67,7 @@ class ForwardingRuleRulesEngine(bre.BaseRulesEngine):
 
         Returns:
             RuleViolation: A rule violation tuple with all data about the
-                forwarding rule that didnt pass a white list
+            forwarding rule that didnt pass a white list
         """
         if self.rule_book is None or force_rebuild:
             self.build_rule_book()

--- a/google/cloud/forseti/scanner/audit/iam_rules_engine.py
+++ b/google/cloud/forseti/scanner/audit/iam_rules_engine.py
@@ -171,7 +171,7 @@ class IamRuleBook(bre.BaseRuleBook):
     Sample rules (simplified):
 
     mode: whitelist
-    Org 1234, bindings: roles/*, members: user:*@company.com
+    Org 1234, bindings: roles/\*, members: user:\*@company.com
     Project p-a, bindings: roles/owner, members: user:pa-owner@company.com
     Project p-b, bindings: roles/owner, members: user:pb-owner@company.com
 

--- a/google/cloud/forseti/scanner/audit/iam_rules_engine.py
+++ b/google/cloud/forseti/scanner/audit/iam_rules_engine.py
@@ -160,7 +160,7 @@ class IamRulesEngine(bre.BaseRulesEngine):
         if self.rule_book is not None:
             self.rule_book.add_rules(rules)
 
-
+# pylint: disable=anomalous-backslash-in-string
 class IamRuleBook(bre.BaseRuleBook):
     """The RuleBook for organization resources.
 
@@ -192,7 +192,7 @@ class IamRuleBook(bre.BaseRuleBook):
     }
 
     """
-
+    # pylint: enable=anomalous-backslash-in-string
     def __init__(self,
                  # TODO: To remove the unused global-configs here, it will be
                  # necessary to also update the base rules engine.

--- a/google/cloud/forseti/services/explain/explainer.py
+++ b/google/cloud/forseti/services/explain/explainer.py
@@ -138,7 +138,7 @@ class Explainer(object):
 
         Returns:
             list: list of tuples,
-                  (overgranting,[(role_name,member_name,resource_name)])
+            (overgranting,[(role_name,member_name,resource_name)])
         """
 
         LOGGER.debug('Explaining how to grant access to a member,'
@@ -167,9 +167,9 @@ class Explainer(object):
 
         Returns:
             tuples: (bindings, member_graph, resource_type_names)
-                bindings, the bindings to grant the access
-                member_graph, the graph to have member included in the binding
-                resource_type_names, the resource tree
+            bindings, the bindings to grant the access
+            member_graph, the graph to have member included in the binding
+            resource_type_names, the resource tree
         """
 
         LOGGER.debug('Explaining why the member has access to a resource,'

--- a/google/cloud/forseti/services/inventory/storage.py
+++ b/google/cloud/forseti/services/inventory/storage.py
@@ -451,7 +451,7 @@ class DataAccess(object):
 
         Returns:
             InventoryIndex: An expunged entry corresponding the
-                inventory_index_id.
+            inventory_index_id.
 
         Raises:
             Exception: Reraises any exception.


### PR DESCRIPTION
To be merged before #1409. This takes care of all docstring formatting issues, bringing them into compliance with Google's Pydoc style guide.

It should be noted for future reference that the `Returns:` block does not support multi-line indentation like the `Params:` block does:
```python
# WRONG
"""
Returns:
    bool: True if successful,
        False otherwise
"""
# RIGHT
"""
Returns:
    bool: True if successful,
    False otherwise
"""
```

The first example will render improperly and cause errors to be thrown.

Furthermore, we must break example return values out into their own blocks. They cannot be included in the `Returns:` block without rendering improperly:
```python
"""
Returns:
    list: A list of project_ids enabled for bigquery.
 
    If there are no project_ids enabled for bigquery an empty list will
    be returned.

An example return value::

    ['project-id',
     'project-id',
     '...']
"""
```