### PR TITLE
Add better visual separation for left nav items

### DIFF
--- a/_sass/components/_left_sidebar.scss
+++ b/_sass/components/_left_sidebar.scss
@@ -8,10 +8,12 @@
     padding: 0;
 
     li {
+      margin-bottom: 8px;
+
       & > a {
         color: $grey-800;
         font-size: 14px;
-        line-height: 24px;
+        line-height: 20px;
       }
 
       &.active > a {


### PR DESCRIPTION
A straightforward style change to improve the visual readability of multiline titles in the left navbar.

Addresses issue #533 