### PR TITLE
Disable visual building toc

### DIFF
--- a/_includes/site/layout/base/scripts.html
+++ b/_includes/site/layout/base/scripts.html
@@ -50,7 +50,7 @@
 
 <script type="text/javascript">
   $(document).ready(function() {
-    $("#toc").toc({ title: '', listType: 'ul' });
+    $("#toc").toc({ title: '', listType: 'ul', showSpeed: 0 });
     $.material.init();
 
     populate_search_input();


### PR DESCRIPTION
Straightforward fix for disabling the visual TOC build animation that became enabled by default.