### PR TITLE
Fix header layout issues on mobile

### DIFF
--- a/_includes/site/layout/docs/tabs.html
+++ b/_includes/site/layout/docs/tabs.html
@@ -1,5 +1,5 @@
 <div class="row docs-nav">
-  <div class="col-md-8">
+  <div class="col-sm-8">
     <ul class="nav nav-tabs visible-md-block visible-lg-block">
       {% assign release_version = page.path | split:"/" | slice:1 | first %}
       {% for tab in site.data.doc_categories[release_version] %}
@@ -16,7 +16,7 @@
       <li class="active">{{ page.category }}</li>
     </ol>
   </div>
-  <div class="col-md-4 text-right">
+  <div class="col-sm-4 version-dropdown">
     <div class="btn-group" id="version-dropdown" style="margin-top: 1px; margin-bottom: 0; margin-right: 30px">
       <a data-target="#version-dropdown" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
         {{ release_version }}

--- a/_sass/layouts/_docs.scss
+++ b/_sass/layouts/_docs.scss
@@ -1,4 +1,9 @@
 .docs-nav {
+  @media (min-width: $screen-md-min) {
+    /* Specify only margin-bottom to prevent overriding Bootstrap row margins */
+    margin-bottom: 20px;
+  }
+
   .breadcrumb {
     background: none;
     border-radius: 0;
@@ -11,11 +16,23 @@
       color: $grey-400;
       content: ">\00a0";
     }
+
+    @media (max-width: $screen-xs-max) {
+      margin-bottom: 0;
+    }
   }
 
-  @media (min-width: $screen-sm-min) {
-    /* Specify only margin-bottom to prevent overriding Bootstrap row margins */
-    margin-bottom: 20px;
+  .version-dropdown {
+    text-align: right;
+
+    @media (max-width: $screen-xs-max) {
+      text-align: left;
+      margin-bottom: 10px;
+
+      #version-dropdown > .btn {
+        padding-left: 15px;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Addresses the visually unappealing way the version dropdown was being rendered in a mobile layout. Version dropdown has now been brought inline and with the navigation breadcrumbs, and the vertical spacing has been adjusted to make the mobile layout more pleasing while responsively maintaining the two-column layout on larger screens.