### PR TITLE
Unset default gcs path in server config for inventory summary.

### DIFF
--- a/configs/server/forseti_conf_server.yaml.in
+++ b/configs/server/forseti_conf_server.yaml.in
@@ -278,4 +278,4 @@ notifier:
         # gcs_path should begin with "gs://"
         # data_format may be one of: csv (the default) or json
         data_format: csv
-        gcs_path: gs://{INV_SUMMARY_BUCKET}/inv_summary
+        gcs_path:

--- a/configs/server/forseti_conf_server.yaml.sample
+++ b/configs/server/forseti_conf_server.yaml.sample
@@ -118,4 +118,4 @@ notifier:
         # gcs_path should begin with "gs://"
         # data_format may be one of: csv (the default) or json
         data_format: csv
-        gcs_path: gs://{INV_SUMMARY_BUCKET}/inv_summary
+        gcs_path:


### PR DESCRIPTION
This will be sufficient to be checked in the notifier, so the inventory summary will not run if this gcs path is not set.  We can add the appropriate placeholder when updating the installer.