### PR TITLE
Updated gce host and docker to use ubuntu image version 18.04, added google cloud sdk installation in the startup script

### DIFF
--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -119,6 +119,7 @@ exec 2>&1
 # Ubuntu update.
 sudo apt-get update -y
 sudo apt-get upgrade -y
+sudo apt-get update && sudo apt-get --assume-yes install google-cloud-sdk
 
 USER_HOME=/home/ubuntu
 

--- a/deployment-templates/deploy-forseti-client.yaml.in
+++ b/deployment-templates/deploy-forseti-client.yaml.in
@@ -36,7 +36,7 @@ resources:
   properties:
     # GCE instance properties
     image-project: ubuntu-os-cloud
-    image-family: ubuntu-1604-lts
+    image-family: ubuntu-1804-lts
     instance-type: n1-standard-2
     zone: {FORSETI_SERVER_ZONE}
 

--- a/deployment-templates/deploy-forseti-client.yaml.sample
+++ b/deployment-templates/deploy-forseti-client.yaml.sample
@@ -36,7 +36,7 @@ resources:
   properties:
 # GCE instance properties
     image-project: ubuntu-os-cloud
-    image-family: ubuntu-1604-lts
+    image-family: ubuntu-1804-lts
     instance-type: n1-standard-2
 
     service-account: SERVICE_ACCOUNT_GCP

--- a/deployment-templates/deploy-forseti-server.yaml.in
+++ b/deployment-templates/deploy-forseti-server.yaml.in
@@ -53,7 +53,7 @@ resources:
   properties:
     # GCE instance properties
     image-project: ubuntu-os-cloud
-    image-family: ubuntu-1604-lts
+    image-family: ubuntu-1804-lts
     instance-type: n1-standard-2
     zone: $(ref.cloudsql-instance.region)-c
 

--- a/deployment-templates/deploy-forseti-server.yaml.sample
+++ b/deployment-templates/deploy-forseti-server.yaml.sample
@@ -54,7 +54,7 @@ resources:
   properties:
     # GCE instance properties
     image-project: ubuntu-os-cloud
-    image-family: ubuntu-1604-lts
+    image-family: ubuntu-1804-lts
     instance-type: n1-standard-2
     zone: $(ref.cloudsql-instance.region)-c
 

--- a/setup/docker/base
+++ b/setup/docker/base
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # Expose our source so we can read in dependencies.
 ADD . /forseti-security/


### PR DESCRIPTION
This is the newest Ubuntu image supported by GCP.
Details about all the supported images: https://cloud.google.com/compute/docs/images

The version of OpenSSH installed 
```
joe@forseti-server-vm-xxxx:~$ ssh -v localhost
OpenSSH_7.6p1 Ubuntu-4, OpenSSL 1.0.2n  7 Dec 2017
```

Reason why we need to install google cloud sdk while running the startup script:
>When the startup script of the VM runs, it doesn't have google cloud sdk library installed (e.g. gsutil is not available) that's why we need to add this line here to install the google cloud sdk library before the rest of the installation beings.

Resolves #1474 