### PR TITLE
Workaround for Stackdriver dropping newlines.

### DIFF
--- a/google/cloud/forseti/common/data_access/errors.py
+++ b/google/cloud/forseti/common/data_access/errors.py
@@ -23,7 +23,7 @@ class Error(Exception):
 class MySQLError(Error):
     """Error for mysql exceptions."""
 
-    CUSTOM_ERROR_MESSAGE = 'Error with MySQL for {0}:\n{1}'
+    CUSTOM_ERROR_MESSAGE = 'Error with MySQL for {0}:\t{1}'
 
     def __init__(self, resource_name, e):
         """Initialize.
@@ -44,7 +44,7 @@ class NoResultsError(Error):
 class CSVFileError(Exception):
     """Error for csv file."""
 
-    CUSTOM_ERROR_MESSAGE = 'Unable to create csv file for {0}:\n{1}'
+    CUSTOM_ERROR_MESSAGE = 'Unable to create csv file for {0}:\t{1}'
 
     def __init__(self, resource_name, e):
         """Initialize.

--- a/google/cloud/forseti/common/gcp_api/errors.py
+++ b/google/cloud/forseti/common/gcp_api/errors.py
@@ -32,7 +32,7 @@ class ApiExecutionError(Error):
     """Error for API executions."""
 
     CUSTOM_ERROR_MESSAGE = (
-        'GCP API Error: unable to get {0} from GCP:\n{1}\n{2}')
+        'GCP API Error: unable to get {0} from GCP:\t{1}\t{2}')
 
     def __init__(self, resource_name, e,
                  resource_key=None, resource_value=None):
@@ -57,7 +57,7 @@ class ApiNotEnabledError(Error):
     """The requested API is not enabled on this project."""
 
     CUSTOM_ERROR_MESSAGE = ('GCP API Error; API not enabled, turn it on at '
-                            '{0}:\n{1}')
+                            '{0}:\t{1}')
 
     def __init__(self, error_url, e):
         """Initialize.

--- a/google/cloud/forseti/common/gcp_type/firewall_rule.py
+++ b/google/cloud/forseti/common/gcp_type/firewall_rule.py
@@ -107,13 +107,14 @@ class FirewallRule(object):
         Returns:
           str: A string representation of FirewallRule.
         """
+        # Using \t separator so stackdriver won't drop newlines.
         string = ('FirewallRule('
-                  'project_id=%s\n'
-                  'name=%s\n'
-                  'network=%s\n'
-                  'priority=%s\n'
-                  'direction=%s\n'
-                  'action=%s\n') % (self.project_id,
+                  'project_id=%s\t'
+                  'name=%s\t'
+                  'network=%s\t'
+                  'priority=%s\t'
+                  'direction=%s\t'
+                  'action=%s\t') % (self.project_id,
                                     self.name,
                                     self.network,
                                     self._priority,
@@ -129,7 +130,7 @@ class FirewallRule(object):
                 ('targetServiceAccounts', self._target_service_accounts),
         ]:
             if value:
-                string += '%s=%s\n' % (field_name, value)
+                string += '%s=%s\t' % (field_name, value)
         return string.strip()
 
     @staticmethod

--- a/google/cloud/forseti/common/util/date_time.py
+++ b/google/cloud/forseti/common/util/date_time.py
@@ -54,12 +54,12 @@ def get_datetime_from_string(string, string_format):
         result = datetime.strptime(string, string_format)
     except TypeError as e:
         LOGGER.error('Unable to create a datetime with %s in format '
-                     '%s\nError: %s',
+                     '%s\tError: %s',
                      string, string_format, e)
         raise DateTimeTypeConversionError
     except ValueError as e:
         LOGGER.error('Unable to create a datetime with %s in format '
-                     '%s\nError: %s',
+                     '%s\tError: %s',
                      string, string_format, e)
         raise DateTimeValueConversionError
 

--- a/google/cloud/forseti/common/util/email.py
+++ b/google/cloud/forseti/common/util/email.py
@@ -127,10 +127,10 @@ class EmailUtil(object):
             raise util_errors.EmailSendError
 
         if response.status_code == 202:
-            LOGGER.info('Email accepted for delivery:\n%s',
+            LOGGER.info('Email accepted for delivery:\t%s',
                         email_subject)
         else:
-            LOGGER.error('Unable to send email:\n%s\n%s\n%s\n%s',
+            LOGGER.error('Unable to send email:\t%s\t%s\t%s\t%s',
                          email_subject, response.status_code,
                          response.body, response.headers)
             raise util_errors.EmailSendError

--- a/google/cloud/forseti/common/util/parser.py
+++ b/google/cloud/forseti/common/util/parser.py
@@ -65,8 +65,8 @@ def format_timestamp(timestamp_str, datetime_formatter):
         formatted_timestamp = (
             dateutil_parser.parse(timestamp_str).strftime(datetime_formatter))
     except (TypeError, ValueError) as e:
-        LOGGER.warn('Unable to parse/format timestamp: %s\n,'
-                    ' datetime_formatter: %s\n%s',
+        LOGGER.warn('Unable to parse/format timestamp: %s\t,'
+                    ' datetime_formatter: %s\t%s',
                     timestamp_str, datetime_formatter, e)
         formatted_timestamp = None
     return formatted_timestamp

--- a/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
+++ b/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
@@ -1234,7 +1234,7 @@ class FirewallEnforcer(object):
                 LOGGER.error(
                     'Error changing firewall rule %s for project %s: %s',
                     rule.get('name', ''), self.project, e)
-                error_str = 'Rule: %s\nError: %s' % (rule.get('name', ''), e)
+                error_str = 'Rule: %s\tError: %s' % (rule.get('name', ''), e)
                 change_errors.append(error_str)
                 failed_rules.append(rule)
                 if self.operation_sema:

--- a/google/cloud/forseti/scanner/scanner_builder.py
+++ b/google/cloud/forseti/scanner/scanner_builder.py
@@ -62,7 +62,7 @@ class ScannerBuilder(object):
                 try:
                     module = importlib.import_module(module_name)
                 except (ImportError, TypeError, ValueError) as e:
-                    LOGGER.error('Unable to import %s\n%s', module_name, e)
+                    LOGGER.error('Unable to import %s\t%s', module_name, e)
                     continue
 
                 class_name = (
@@ -72,7 +72,7 @@ class ScannerBuilder(object):
                 try:
                     scanner_class = getattr(module, class_name)
                 except AttributeError:
-                    LOGGER.error('Unable to instantiate %s\n%s',
+                    LOGGER.error('Unable to instantiate %s\t%s',
                                  class_name, sys.exc_info()[0])
                     continue
 
@@ -88,7 +88,7 @@ class ScannerBuilder(object):
                                   .get(scanner.get('name'))
                                   .get('rules_filename'))
                 rules = '{}/{}'.format(rules_path, rules_filename)
-                LOGGER.info('Initializing the rules engine:\nUsing rules: %s',
+                LOGGER.info('Initializing the rules engine:\tUsing rules: %s',
                             rules)
 
                 scanner = scanner_class(self.global_configs,

--- a/google/cloud/forseti/services/scanner/dao.py
+++ b/google/cloud/forseti/services/scanner/dao.py
@@ -362,7 +362,7 @@ def _create_violation_hash(violation_full_name, resource_data, violation_data):
         violation_hash = hashlib.new(algorithm)
     except ValueError as e:
         LOGGER.error('Cannot create hash for a violation with algorithm: '
-                     '%s\n%s', algorithm, e)
+                     '%s\t%s', algorithm, e)
         return ''
 
     try:

--- a/tests/enforcer/gce_firewall_enforcer_test.py
+++ b/tests/enforcer/gce_firewall_enforcer_test.py
@@ -1197,7 +1197,7 @@ class FirewallEnforcerTest(ForsetiTestCase):
             insert_function, test_rules)
         self.assertSameStructure(test_rules, failures)
         self.assertListEqual([], successes)
-        error_str = 'Rule: %s\nError: %s' % (
+        error_str = 'Rule: %s\tError: %s' % (
             test_rules[0].get('name', ''),
             error_409)
         self.assertListEqual([error_str], change_errors)


### PR DESCRIPTION
This is workaround for issue #1406 , notably to fix the problem where log records with newlines `\n` are cut-off after the first line.  For a more long-term fix, we need to discuss & decide if we will continue to use google-fluentd (which means considering the stackdriver client library), or use the more platform neutral fluentd, where configuration efforts can be better justified.

More details in #1406 