### PR TITLE
Add News collection and pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 group :jekyll_plugins do
   gem 'rouge'
   gem 'jekyll-github-metadata'
+  gem 'jekyll-paginate-v2'
   gem 'jekyll-sitemap'
   gem 'jekyll-redirect-from'
   gem 'jekyll-responsive-image'

--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,7 @@ exclude_from_watch: ["_docs/latest/",
 plugins:
   - jekyll-sitemap
   - jekyll-github-metadata
+  - jekyll-paginate-v2
   - jekyll-redirect-from
   - jekyll-responsive-image
 google_analytics: UA-98416450-1
@@ -49,6 +50,14 @@ collections:
     output: true
   faq:
     output: false
+  news:
+    output: true
+
+pagination:
+  enabled: true
+  collection: news
+  permalink: /page/:num/
+  per_page: 10
 
 # Responsive image templates and resizing configuration
 responsive_image:
@@ -69,6 +78,12 @@ responsive_image:
 # Custom site directives.
 # The order of document categories is defined in _data/doc_categories.yml.
 defaults:
+  - scope:
+      path: _news
+    values:
+      author: Forseti Security Team
+      layout: news
+      permalink: /news/:year/:month/:day/:title:output_ext
   - scope:
       path: _docs/latest
     values:

--- a/_includes/site/layout/base/nav.html
+++ b/_includes/site/layout/base/nav.html
@@ -27,6 +27,7 @@
         <li><a href="{{ site.baseurl }}/docs/latest/">Docs</a></li>
         <li><a href="{{ site.baseurl }}/community/">Community</a></li>
         <li><a href="{{ site.baseurl }}/releases/">Releases</a></li>
+        <li><a href="{{ site.baseurl }}/news/">News</a></li>
       </ul>
     </div>
   </div>

--- a/_includes/site/news/news_item.html
+++ b/_includes/site/news/news_item.html
@@ -1,0 +1,6 @@
+<div class="news-item">
+  <p class="published-date">{{ post.date | date_to_long_string }}</p>
+  <h2 class="title">{{ post.title }}</h2>
+  <div class="excerpt">{{ post.excerpt }}</div>
+  <a class="read-more" href="{{ post.url }}">Read more...</a>
+</div>

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -1,0 +1,17 @@
+---
+layout: default
+---
+<h1 class="news-title">{{ page.title }}</h1>
+<div class="news-post row">
+  <div class="content col-md-9">
+    {{ content }}
+  </div>
+  <div class="meta-information col-md-2">
+    <dl>
+      <dt>Written By</dt>
+      <dd>{{ page.author }}</dd>
+      <dt>Published On</dt>
+      <dd>{{ page.date | date_to_long_string }}</dd>
+    </dl>
+  </div>
+</div>

--- a/_news/2018-05-09-test-post.md
+++ b/_news/2018-05-09-test-post.md
@@ -1,0 +1,8 @@
+---
+title: This is a Test Post
+author: Denzel Morris
+excerpt: <img src='/images/docs/configuration/create-service-account.png' />
+---
+# Example Header
+
+Checkout this example post to see some cool news stuff.

--- a/_sass/layouts/_news.scss
+++ b/_sass/layouts/_news.scss
@@ -1,0 +1,42 @@
+.news-title {
+  border-bottom: 1px solid $grey-300;
+  font-weight: bold;
+  margin-bottom: 0;
+  padding-bottom: 20px;
+}
+
+.news-post {
+  margin-top: 24px;
+
+  .meta-information {
+    dt {
+      color: $grey-400;
+      font-size: 80%;
+    }
+
+    dd {
+      margin-bottom: 12px;
+    }
+  }
+
+  .content > *:first-child {
+    margin-top: 0;
+  }
+}
+
+.news-item {
+  padding: 12px 0;
+
+  .published-date {
+    color: $grey-400;
+    margin-bottom: 6px;
+  }
+
+  .title {
+    margin-top: 0;
+  }
+
+  .excerpt {
+    margin-bottom: 24px;
+  }
+}

--- a/css/all.scss
+++ b/css/all.scss
@@ -16,6 +16,7 @@ $baseurl: '{{ site.baseurl }}';
 @import "components/footer";
 @import "layouts/homepage";
 @import "layouts/docs";
+@import "layouts/news";
 @import "layouts/releases";
 @import "layouts/404";
 @import "apidocs/base";

--- a/news/index.html
+++ b/news/index.html
@@ -1,0 +1,25 @@
+---
+layout: default
+title: News
+pagination:
+  enabled: true
+---
+<h1>News</h1>
+{% for post in paginator.posts %}
+  <hr />
+  {% include site/news/news_item.html post=post %}
+{% endfor %}
+<hr />
+{% if paginator.total_pages > 1 %}
+  {% if paginator.previous_page %}
+    <a class="pull-left" href="{{ paginator.previous_page_path | prepend: site.baseurl }}">
+      <button class="btn"><i class="material-icons">navigate_before</i>Newer</button>
+    </a>
+  {% endif %}
+
+  {% if paginator.next_page %}
+    <a class="pull-right" href="{{ paginator.next_page_path | prepend: site.baseurl }}">
+      <button class="btn">Older<i class="material-icons">navigate_next</i></button>
+    </a>
+  {% endif %}
+{% endif %}


### PR DESCRIPTION
With this we add:

1. A paginated news collection that renders at `/news` and `/news/page/:num`
2. Single news item view

The paginated collection includes:

- Title
- Published Date
- Brief excerpt
- Link

For every news item. The excerpt can either be produced with Jekyll's [excerpt functionality](https://jekyllrb.com/docs/posts/#post-excerpts) or you can specify an `excerpt` explicitly in the news item's front-matter like the example item shows:
```yaml
---
excerpt: <img src='/images/example/overview-image.png' />
---
```

The excerpt can contain a brief textual summary, or any custom HTML necessary like above.

Finally, the actual single news item view renders out the title, content, and metainformation in a right side-panel. A piece of this metainformation is the `author`; if the author is not specified in the front-matter for a given news item, then it defaults to "Forseti Security Team". This default author name can be changed in the `_config.yml`.

I welcome comments on layout and design. I've tried to keep it as simple as possible, with the expectation that the team may expand upon this base functionality later.