### PR TITLE
Updated BufferedDbWriter add() method do proper length comparison

### DIFF
--- a/google/cloud/forseti/services/inventory/crawler.py
+++ b/google/cloud/forseti/services/inventory/crawler.py
@@ -305,6 +305,7 @@ def run_crawler(storage,
     else:
         crawler_config = CrawlerConfig(storage, progresser, client)
         crawler_impl = Crawler(crawler_config)
-
     progresser = crawler_impl.run(resource)
+    # flush the buffer at the end to make sure nothing is cached.
+    storage.buffer.flush()
     return progresser

--- a/google/cloud/forseti/services/inventory/crawler.py
+++ b/google/cloud/forseti/services/inventory/crawler.py
@@ -307,5 +307,5 @@ def run_crawler(storage,
         crawler_impl = Crawler(crawler_config)
     progresser = crawler_impl.run(resource)
     # flush the buffer at the end to make sure nothing is cached.
-    storage.buffer.flush()
+    storage.commit()
     return progresser

--- a/google/cloud/forseti/services/inventory/storage.py
+++ b/google/cloud/forseti/services/inventory/storage.py
@@ -432,7 +432,7 @@ class BufferedDbWriter(object):
         """
 
         self.buffer.append(obj)
-        if self.buffer >= self.max_size:
+        if len(self.buffer) >= self.max_size:
             self.flush()
 
     def flush(self):

--- a/tests/services/inventory/storage_test.py
+++ b/tests/services/inventory/storage_test.py
@@ -124,6 +124,7 @@ class StorageTest(ForsetiTestCase):
             _ = storage.open()
             for resource in resources:
                 storage.write(resource)
+            storage.buffer.flush()
             self.assertEqual(3,
                              len(self.reduced_inventory(
                                  storage,


### PR DESCRIPTION
Without the len() method, we are flushing every single time we add an item to the BufferedDbWriter which is very inefficient, this will increase the performance of the crawler.