### PR TITLE
Make the forseti.log writeable when user tries to use the client in the server VM.

### DIFF
--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -165,7 +165,7 @@ chown ubuntu:root /var/log/forseti.log
 
 # The forseti.log needs to be writeable by the user who runs the forseti client
 # in the server VM.
-chmod 644 /var/log/forseti.log
+chmod 666 /var/log/forseti.log
 
 cp {forseti_home}/configs/logging/fluentd/forseti.conf /etc/google-fluentd/config.d/forseti.conf
 cp {forseti_home}/configs/logging/logrotate/forseti /etc/logrotate.d/forseti

--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -163,10 +163,6 @@ pip install -q --upgrade -r requirements.txt
 touch /var/log/forseti.log
 chown ubuntu:root /var/log/forseti.log
 
-# The forseti.log needs to be writeable by the user who runs the forseti client
-# in the server VM.
-chmod 666 /var/log/forseti.log
-
 cp {forseti_home}/configs/logging/fluentd/forseti.conf /etc/google-fluentd/config.d/forseti.conf
 cp {forseti_home}/configs/logging/logrotate/forseti /etc/logrotate.d/forseti
 chmod 644 /etc/logrotate.d/forseti

--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -161,7 +161,12 @@ pip install -q --upgrade -r requirements.txt
 
 # Setup Forseti logging
 touch /var/log/forseti.log
-chown ubuntu:root /var/log/forseti.log 
+chown ubuntu:root /var/log/forseti.log
+
+# The forseti.log needs to be writeable by the user who runs the forseti client
+# in the server VM.
+chmod 644 /var/log/forseti.log
+
 cp {forseti_home}/configs/logging/fluentd/forseti.conf /etc/google-fluentd/config.d/forseti.conf
 cp {forseti_home}/configs/logging/logrotate/forseti /etc/logrotate.d/forseti
 chmod 644 /etc/logrotate.d/forseti

--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -162,7 +162,6 @@ pip install -q --upgrade -r requirements.txt
 # Setup Forseti logging
 touch /var/log/forseti.log
 chown ubuntu:root /var/log/forseti.log
-
 cp {forseti_home}/configs/logging/fluentd/forseti.conf /etc/google-fluentd/config.d/forseti.conf
 cp {forseti_home}/configs/logging/logrotate/forseti /etc/logrotate.d/forseti
 chmod 644 /etc/logrotate.d/forseti


### PR DESCRIPTION
More details in #1527 .  @ahoying Is this a good thing to do, from a security point of view?  The assumption here is that anyone who can get into the VM, then he is an admin, and should be able to write to the ```/var/log/forseti.log```.

But please let me know if there is something better.