### PR TITLE
Writetosyslog

### DIFF
--- a/configs/logging/fluentd/forseti.conf
+++ b/configs/logging/fluentd/forseti.conf
@@ -3,8 +3,8 @@
 
     <parse>
         @type multiline
-        format_firstline /^\[forseti\-security\]/
-        format1 /^(?<message>.*)/
+        format_firstline /^\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2},\d{1,3}/
+        format1 /^(?<time>\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2},\d{1,3}) (?<message>.*)/
     </parse>
 
     # Format 'none' indicates the log is unstructured (text).
@@ -20,5 +20,6 @@
     read_from_head true
 
     # The log tag for this log input.
+    # This will show up 
     tag forseti
 </source>

--- a/configs/logging/fluentd/forseti.conf
+++ b/configs/logging/fluentd/forseti.conf
@@ -4,7 +4,7 @@
     <parse>
         @type multiline
         format_firstline /^\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2},\d{1,3}/
-        format1 /^(?<time>\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2},\d{1,3}) (?<message>.*)/
+        format1 /^(?<time>\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2},\d{1,3}) (?<severity>[^\s]+) (?<message>.*)/
     </parse>
 
     # Format 'none' indicates the log is unstructured (text).

--- a/configs/logging/fluentd/forseti.conf
+++ b/configs/logging/fluentd/forseti.conf
@@ -1,0 +1,24 @@
+<source>
+    @type tail
+
+    <parse>
+        @type multiline
+        format_firstline /^\[forseti\-security\]/
+        format1 /^(?<message>.*)/
+    </parse>
+
+    # Format 'none' indicates the log is unstructured (text).
+    format none
+
+    # The path of the log file.
+    path /var/log/forseti.log
+
+    # The path of the position file that records where in the log file
+    # we have processed already. This is useful when the agent
+    # restarts.
+    pos_file /var/lib/google-fluentd/pos/forseti.pos
+    read_from_head true
+
+    # The log tag for this log input.
+    tag forseti
+</source>

--- a/configs/logging/fluentd/forseti.conf
+++ b/configs/logging/fluentd/forseti.conf
@@ -20,6 +20,6 @@
     read_from_head true
 
     # The log tag for this log input.
-    # This will show up 
+    # This makes it sortable from the pull-down menu on stackdriver.
     tag forseti
 </source>

--- a/configs/logging/fluentd/forseti.conf
+++ b/configs/logging/fluentd/forseti.conf
@@ -20,6 +20,5 @@
     read_from_head true
 
     # The log tag for this log input.
-    # This makes it sortable from the pull-down menu on stackdriver.
     tag forseti
 </source>

--- a/configs/logging/logrotate/forseti
+++ b/configs/logging/logrotate/forseti
@@ -3,5 +3,5 @@
   rotate 30
   missingok
   notifempty
-  create 640 root root
+  create 640 ubuntu root
 }

--- a/configs/logging/logrotate/forseti
+++ b/configs/logging/logrotate/forseti
@@ -1,0 +1,7 @@
+/var/log/forseti.log {
+  daily
+  rotate 30
+  missingok
+  notifempty
+  create 640 root root
+}

--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -159,6 +159,13 @@ pip install --upgrade pip==9.0.3
 pip install -q --upgrade setuptools wheel
 pip install -q --upgrade -r requirements.txt
 
+# Setup Forseti logging
+touch /var/log/forseti.log
+mv {forseti_home}/configs/logging/fluentd/forseti.conf /etc/google-fluentd/config.d/forseti.conf
+mv {forseti_home}/configs/logrotate/forseti /etc/logrotate.d/forseti
+# TODO: see what the actual permissions are on testing, and dial it down
+# target: -rw-r--r-- 1 root root
+
 # Change the access level of configs/ rules/ and run_forseti.sh
 chmod -R ug+rwx {forseti_home}/configs {forseti_home}/rules {forseti_home}/setup/gcp/scripts/run_forseti.sh
 

--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -164,8 +164,6 @@ touch /var/log/forseti.log
 chown ubuntu:root /var/log/forseti.log 
 mv {forseti_home}/configs/logging/fluentd/forseti.conf /etc/google-fluentd/config.d/forseti.conf
 mv {forseti_home}/configs/logrotate/forseti /etc/logrotate.d/forseti
-# TODO: see what the actual permissions are on testing, and dial it down
-# target: -rw-r--r-- 1 root root
 
 # Change the access level of configs/ rules/ and run_forseti.sh
 chmod -R ug+rwx {forseti_home}/configs {forseti_home}/rules {forseti_home}/setup/gcp/scripts/run_forseti.sh

--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -166,6 +166,7 @@ cp {forseti_home}/configs/logging/fluentd/forseti.conf /etc/google-fluentd/confi
 cp {forseti_home}/configs/logging/logrotate/forseti /etc/logrotate.d/forseti
 chmod 644 /etc/logrotate.d/forseti
 service google-fluentd restart
+logrotate /etc/logrotate.conf
 
 # Change the access level of configs/ rules/ and run_forseti.sh
 chmod -R ug+rwx {forseti_home}/configs {forseti_home}/rules {forseti_home}/setup/gcp/scripts/run_forseti.sh

--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -161,6 +161,7 @@ pip install -q --upgrade -r requirements.txt
 
 # Setup Forseti logging
 touch /var/log/forseti.log
+chown ubuntu:root /var/log/forseti.log 
 mv {forseti_home}/configs/logging/fluentd/forseti.conf /etc/google-fluentd/config.d/forseti.conf
 mv {forseti_home}/configs/logrotate/forseti /etc/logrotate.d/forseti
 # TODO: see what the actual permissions are on testing, and dial it down

--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -163,7 +163,9 @@ pip install -q --upgrade -r requirements.txt
 touch /var/log/forseti.log
 chown ubuntu:root /var/log/forseti.log 
 cp {forseti_home}/configs/logging/fluentd/forseti.conf /etc/google-fluentd/config.d/forseti.conf
-cp {forseti_home}/configs/logrotate/forseti /etc/logrotate.d/forseti
+cp {forseti_home}/configs/logging/logrotate/forseti /etc/logrotate.d/forseti
+chmod 644 /etc/logrotate.d/forseti
+service google-fluentd restart
 
 # Change the access level of configs/ rules/ and run_forseti.sh
 chmod -R ug+rwx {forseti_home}/configs {forseti_home}/rules {forseti_home}/setup/gcp/scripts/run_forseti.sh

--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -162,8 +162,8 @@ pip install -q --upgrade -r requirements.txt
 # Setup Forseti logging
 touch /var/log/forseti.log
 chown ubuntu:root /var/log/forseti.log 
-mv {forseti_home}/configs/logging/fluentd/forseti.conf /etc/google-fluentd/config.d/forseti.conf
-mv {forseti_home}/configs/logrotate/forseti /etc/logrotate.d/forseti
+cp {forseti_home}/configs/logging/fluentd/forseti.conf /etc/google-fluentd/config.d/forseti.conf
+cp {forseti_home}/configs/logrotate/forseti /etc/logrotate.d/forseti
 
 # Change the access level of configs/ rules/ and run_forseti.sh
 chmod -R ug+rwx {forseti_home}/configs {forseti_home}/rules {forseti_home}/setup/gcp/scripts/run_forseti.sh

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -53,7 +53,13 @@ def get_logger(module_name):
     # in stackdriver.
     # Next step is to figure out fluentd's multiline parser to handle the
     # newline correctly in syslog, for proper display in stackdriver.
-    syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
+    if os.path.exists('/dev/log'):
+        syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
+    elif os.path.exists('/var/run/syslog'):
+        syslog_handler = logging.handlers.SysLogHandler(
+            address='/var/run/syslog')
+    else:
+        syslog_handler = logging.handlers.SysLogHandler()
     syslog_handler.setFormatter(logging.Formatter(SYSLOG_LOG_FMT))
 
     logger_instance = logging.getLogger(module_name)

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -53,15 +53,7 @@ def get_logger(module_name):
     # in stackdriver.
     # Next step is to figure out fluentd's multiline parser to handle the
     # newline correctly in syslog, for proper display in stackdriver.
-    print '----------------------'
-    print os.environ
-    logging.info(os.environ)
-    print '----------------------'
-    is_travis = 'TRAVIS' in os.environ
-    if is_travis:
-        syslog_handler = logging.handlers.SysLogHandler()
-    else:
-        syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
+    syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
     syslog_handler.setFormatter(logging.Formatter(SYSLOG_LOG_FMT))
 
     logger_instance = logging.getLogger(module_name)

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -55,9 +55,9 @@ def get_logger(module_name):
     # newline correctly in syslog, for proper display in stackdriver.
     is_travis = 'TRAVIS' in os.environ
     if is_travis:
-        syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
-    else:
         syslog_handler = logging.handlers.SysLogHandler()
+    else:
+        syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
     syslog_handler.setFormatter(logging.Formatter(SYSLOG_LOG_FMT))
 
     logger_instance = logging.getLogger(module_name)

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -45,7 +45,13 @@ def get_logger(module_name):
         logger: An instance of the configured logger.
     """
     # TODO: Move this into a configuration file.
-    syslog_handler = logging.handlers.SysLogHandler()
+    #
+    # Actually, write to local /var/log/syslog with the address parameter.
+    # rsyslogd will convert \n to #012 in syslog, so log lines are not cut off
+    # in stackdriver.
+    # Next step is to figure out fluentd's multiline parser to handle the
+    # newline correctly in syslog, for proper display in stackdriver.
+    syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
     syslog_handler.setFormatter(logging.Formatter(SYSLOG_LOG_FMT))
 
     logger_instance = logging.getLogger(module_name)

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -25,7 +25,7 @@ import os
 DEFAULT_LOG_FMT = ('%(asctime)s %(levelname)s '
                    '%(name)s(%(funcName)s): %(message).1024s')
 
-SYSLOG_LOG_FMT = ('[forseti-security] %(levelname)s '
+SYSLOG_LOG_FMT = ('%(levelname)s [forseti-security] '
                   '%(name)s(%(funcName)s): %(message).1024s')
 
 # %(asctime)s is used as the marker by multiline parser to determine
@@ -63,6 +63,7 @@ def get_logger(module_name):
         default_log_handler = logging.handlers.SysLogHandler()
         default_log_handler.setFormatter(logging.Formatter(SYSLOG_LOG_FMT))
 
+    logging.addLevelName(logging.INFO, 'Info')
     logger_instance = logging.getLogger(module_name)
     logger_instance.addHandler(default_log_handler)
     logger_instance.setLevel(LOGLEVEL)

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -53,6 +53,8 @@ def get_logger(module_name):
     # in stackdriver.
     # Next step is to figure out fluentd's multiline parser to handle the
     # newline correctly in syslog, for proper display in stackdriver.
+    print os.environ
+    print '----------------------'
     is_travis = 'TRAVIS' in os.environ
     if is_travis:
         syslog_handler = logging.handlers.SysLogHandler()

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -25,10 +25,11 @@ import os
 DEFAULT_LOG_FMT = ('%(asctime)s %(levelname)s '
                    '%(name)s(%(funcName)s): %(message).1024s')
 
-# "[forseti-security]" is the used as the marker by multiline parser
-# to determine the first line of a log record that spans multiple lines.
-# So if this is changed here, update "format_firstline" in the parser config.
-SYSLOG_LOG_FMT = ('[forseti-security] %(levelname)s '
+# %(asctime)s is used as the marker by multiline parser to determine
+# the first line of a log record that spans multiple lines.
+# So if this is moved or changed here, update "format_firstline" in the logging
+# parser config.
+SYSLOG_LOG_FMT = ('%(asctime)s [forseti-security] %(levelname)s '
                   '%(name)s(%(funcName)s): %(message).1024s')
 LOGGERS = {}
 LOGLEVELS = {

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -53,6 +53,7 @@ def get_logger(module_name):
     # in stackdriver.
     # Next step is to figure out fluentd's multiline parser to handle the
     # newline correctly in syslog, for proper display in stackdriver.
+    print '----------------------'
     print os.environ
     print '----------------------'
     is_travis = 'TRAVIS' in os.environ

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -63,7 +63,6 @@ def get_logger(module_name):
         default_log_handler = logging.handlers.SysLogHandler()
         default_log_handler.setFormatter(logging.Formatter(SYSLOG_LOG_FMT))
 
-    logging.addLevelName(logging.INFO, 'Info')
     logger_instance = logging.getLogger(module_name)
     logger_instance.addHandler(default_log_handler)
     logger_instance.setLevel(LOGLEVEL)

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -55,6 +55,7 @@ def get_logger(module_name):
     # newline correctly in syslog, for proper display in stackdriver.
     print '----------------------'
     print os.environ
+    logging.info(os.environ)
     print '----------------------'
     is_travis = 'TRAVIS' in os.environ
     if is_travis:

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -19,6 +19,8 @@ Setup logging for Forseti Security. Logs to console and syslog.
 
 import logging
 import logging.handlers
+import os
+
 
 DEFAULT_LOG_FMT = ('%(asctime)s %(levelname)s '
                    '%(name)s(%(funcName)s): %(message).1024s')
@@ -51,7 +53,11 @@ def get_logger(module_name):
     # in stackdriver.
     # Next step is to figure out fluentd's multiline parser to handle the
     # newline correctly in syslog, for proper display in stackdriver.
-    syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
+    is_travis = 'TRAVIS' in os.environ
+    if is_travis:
+        syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
+    else:
+        syslog_handler = logging.handlers.SysLogHandler()
     syslog_handler.setFormatter(logging.Formatter(SYSLOG_LOG_FMT))
 
     logger_instance = logging.getLogger(module_name)

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -25,12 +25,16 @@ import os
 DEFAULT_LOG_FMT = ('%(asctime)s %(levelname)s '
                    '%(name)s(%(funcName)s): %(message).1024s')
 
+SYSLOG_LOG_FMT = ('[forseti-security] %(levelname)s '
+                  '%(name)s(%(funcName)s): %(message).1024s')
+
 # %(asctime)s is used as the marker by multiline parser to determine
 # the first line of a log record that spans multiple lines.
 # So if this is moved or changed here, update "format_firstline" in the logging
 # parser config.
-SYSLOG_LOG_FMT = ('%(asctime)s [forseti-security] %(levelname)s '
-                  '%(name)s(%(funcName)s): %(message).1024s')
+FORSETI_LOG_FMT = '%(asctime)s ' + SYSLOG_LOG_FMT
+
+
 LOGGERS = {}
 LOGLEVELS = {
     'debug': logging.DEBUG,
@@ -54,10 +58,10 @@ def get_logger(module_name):
 
     if os.path.exists('/var/log/forseti.log'):  # ubuntu on GCE
         default_log_handler = logging.FileHandler('/var/log/forseti.log')
+        default_log_handler.setFormatter(logging.Formatter(FORSETI_LOG_FMT))
     else:
         default_log_handler = logging.handlers.SysLogHandler()
-
-    default_log_handler.setFormatter(logging.Formatter(SYSLOG_LOG_FMT))
+        default_log_handler.setFormatter(logging.Formatter(SYSLOG_LOG_FMT))
 
     logger_instance = logging.getLogger(module_name)
     logger_instance.addHandler(default_log_handler)

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -51,7 +51,7 @@ def get_logger(module_name):
         logger: An instance of the configured logger.
     """
 
-    if os.path.exists('/var/log/forseti.log'):  # deployed to ubuntu on GCE
+    if os.path.exists('/var/log/forseti.log'):  # ubuntu on GCE
         default_log_handler = logging.FileHandler('/var/log/forseti.log')
     else:
         default_log_handler = logging.handlers.SysLogHandler()

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -53,9 +53,10 @@ def get_logger(module_name):
     # in stackdriver.
     # Next step is to figure out fluentd's multiline parser to handle the
     # newline correctly in syslog, for proper display in stackdriver.
-    if os.path.exists('/dev/log'):
+    # Docker on travis does not have syslog path.
+    if os.path.exists('/dev/log'):  # ubuntu
         syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
-    elif os.path.exists('/var/run/syslog'):
+    elif os.path.exists('/var/run/syslog'):  # mac
         syslog_handler = logging.handlers.SysLogHandler(
             address='/var/run/syslog')
     else:


### PR DESCRIPTION
Users of the CLI on the server VM can not write to `/var/log/forseti.log`, so falling back to syslog.

Creating this PR in this branch here for easier testing, since there is a GCP VM that will pull from this branch.  Afterwards, will move to the the original PR #1528 