### PR TITLE
Updated default cron to run every 2 hours

### DIFF
--- a/deployment-templates/deploy-forseti-server.yaml.in
+++ b/deployment-templates/deploy-forseti-server.yaml.in
@@ -92,4 +92,4 @@ resources:
     # This is the Forseti crontab schedule.
     # The default is "run at some random minute 0-59 (configured in
     # forseti-instance-server.py), every 12 hour".
-    run-frequency: "{RAND_MINUTE} */12 * * *"
+    run-frequency: "{RAND_MINUTE} */2 * * *"

--- a/setup/gcp/installer/util/constants.py
+++ b/setup/gcp/installer/util/constants.py
@@ -289,7 +289,8 @@ MESSAGE_NO_ORGANIZATION = (
     'creating-managing-organization')
 
 MESSAGE_RUN_FREQUENCY = (
-    'Forseti will run once every 12 hours, you can configure the run '
+    'Forseti will run once every 2 hours, a new run will not start until '
+    'the previous run is completed. You can configure the run '
     'frequency in the server deployment template field "run-frequency" '
     'and update the deployment using the deployment manager.')
 


### PR DESCRIPTION
Resolves #1505 

Since the cron job has been updated to not overlap with each others, there shouldn't be any problem having it run every 2 hours even if a full run might take longer than that since the new run will not start until the previous one is completed.