### PR TITLE
Updated firewall rule to not call the parse function when the time is empty

### DIFF
--- a/google/cloud/forseti/common/gcp_type/firewall_rule.py
+++ b/google/cloud/forseti/common/gcp_type/firewall_rule.py
@@ -145,6 +145,14 @@ class FirewallRule(object):
         Returns:
           FirewallRule: A FirewallRule created from the input dictionary.
         """
+        if firewall_dict.get('creationTimestamp'):
+            creation_time = parser.format_timestamp(
+                parser.json_stringify(
+                    firewall_dict.get('creationTimestamp')),
+                string_formats.TIMESTAMP_MYSQL_DATETIME_FORMAT)
+        else:
+            creation_time = None
+
         in_dict = {
             'firewall_rule_id': firewall_dict.get('id'),
             'firewall_rule_name': firewall_dict.get('name'),
@@ -173,9 +181,7 @@ class FirewallRule(object):
                 firewall_dict.get('denied')),
             'firewall_rule_self_link': parser.json_stringify(
                 firewall_dict.get('selfLink')),
-            'firewall_rule_create_time': parser.format_timestamp(
-                parser.json_stringify(firewall_dict.get('creationTimestamp')),
-                string_formats.TIMESTAMP_MYSQL_DATETIME_FORMAT),
+            'firewall_rule_create_time': creation_time,
         }
         if project_id:
             in_dict['project_id'] = project_id

--- a/google/cloud/forseti/common/gcp_type/firewall_rule.py
+++ b/google/cloud/forseti/common/gcp_type/firewall_rule.py
@@ -146,6 +146,11 @@ class FirewallRule(object):
           FirewallRule: A FirewallRule created from the input dictionary.
         """
         if firewall_dict.get('creationTimestamp'):
+            # When we are creating firewall rule gcp objects from the firewall
+            # rules we defined in the firewall_rules.yaml file, the creation
+            # timestamp is not part of the rule in the yaml file and if the
+            # creation timestamp does not exist, we shouldn't call the parse
+            # function with the empty field.
             creation_time = parser.format_timestamp(
                 parser.json_stringify(
                     firewall_dict.get('creationTimestamp')),


### PR DESCRIPTION
Resolves #1571

When we are creating firewall rule gcp objects from the firewall rules we defined in the firewall_rules.yaml file, the creation time field is not part of the rule in the yaml file and if the creation time does not exist, we shouldn't call the parse function with that empty field.