### PR TITLE
Added support for using service account instead of a user

### DIFF
--- a/install/gcp/installer/forseti_installer.py
+++ b/install/gcp/installer/forseti_installer.py
@@ -192,7 +192,8 @@ class ForsetiInstaller(object):
         utils.print_banner('Pre-installation checks')
         self.check_run_properties()
         self.branch = utils.infer_version(self.config.advanced_mode)
-        self.project_id, authed_user, is_cloudshell = gcloud.get_gcloud_info()
+        (self.project_id, authed_user, is_cloudshell, is_service_account) = \
+            gcloud.get_gcloud_info()
         gcloud.verify_gcloud_information(self.project_id,
                                          authed_user,
                                          self.config.force_no_cloudshell,
@@ -202,6 +203,8 @@ class ForsetiInstaller(object):
         self.check_if_authed_user_in_domain(
             self.organization_id, authed_user)
         gcloud.check_billing_enabled(self.project_id, self.organization_id)
+        if is_service_account:
+            gcloud.active_service_account(authed_user)
 
     def create_or_reuse_service_accts(self):
         """Create or reuse service accounts."""

--- a/install/gcp/installer/forseti_installer.py
+++ b/install/gcp/installer/forseti_installer.py
@@ -200,11 +200,12 @@ class ForsetiInstaller(object):
                                          is_cloudshell)
         self.organization_id = gcloud.lookup_organization(self.project_id)
         self.config.generate_identifier(self.organization_id)
-        self.check_if_authed_user_in_domain(
-            self.organization_id, authed_user)
-        gcloud.check_billing_enabled(self.project_id, self.organization_id)
-        if is_service_account:
+        if not is_service_account:
+            self.check_if_authed_user_in_domain(
+                self.organization_id, authed_user)
+        else:
             gcloud.active_service_account(authed_user)
+        gcloud.check_billing_enabled(self.project_id, self.organization_id)
 
     def create_or_reuse_service_accts(self):
         """Create or reuse service accounts."""

--- a/install/gcp/installer/util/gcloud.py
+++ b/install/gcp/installer/util/gcloud.py
@@ -86,14 +86,10 @@ def _get_user_from_json(path):
     Returns:
         str: service account email aka client_email
     """
-    try:
-        f = open(path, 'r')
-        service_account_info = json.loads(f.read())
-        return service_account_info.get('client_email')
-    except IOError:
-        return None
-    finally:
-        f.close()
+    if path:
+        with open(path, 'r') as f:
+            service_account_info = json.loads(f.read())
+            return service_account_info.get('client_email')
 
 
 def active_service_account(authed_user):
@@ -101,7 +97,7 @@ def active_service_account(authed_user):
     Args:
         authed_user (str): service account email
     """
-    return_code, err = utils.run_command(
+    return_code, _, err = utils.run_command(
         ['gcloud', 'auth', 'activate-service-account',
          authed_user, '--key-file={}'
          .format(_get_service_account_json_path())])

--- a/install/gcp/installer/util/gcloud.py
+++ b/install/gcp/installer/util/gcloud.py
@@ -91,6 +91,8 @@ def _get_user_from_json(path):
             service_account_info = json.loads(f.read())
             return service_account_info.get('client_email')
 
+    return None
+
 
 def active_service_account(authed_user):
     """Activate the service account with gcloud


### PR DESCRIPTION
Hello,

In some cases outside of Cloud Shell we can't use a user but a service account. This PR helps detect if there's any credentials file in the environment variables and activate the service account for using it instead of a specific user.