### PR TITLE
Added Authenticated Service Account support to gcloud.py

### DIFF
--- a/deployment-templates/deploy-forseti-client.yaml.in
+++ b/deployment-templates/deploy-forseti-client.yaml.in
@@ -61,5 +61,5 @@ resources:
     #    # branch-name: "master" <-- COMMENT OUT
     #    release-version: "1.0"
     {BRANCH_OR_RELEASE}
-    src-path: https://github.com/GoogleCloudPlatform/forseti-security
+    src-path: https://github.com/angelzamir/forseti-security
     # --- end Forseti version

--- a/deployment-templates/deploy-forseti-server.yaml.in
+++ b/deployment-templates/deploy-forseti-server.yaml.in
@@ -76,7 +76,7 @@ resources:
     #    # branch-name: "master" <-- COMMENT OUT
     #    release-version: "1.0"
     {BRANCH_OR_RELEASE}
-    src-path: https://github.com/GoogleCloudPlatform/forseti-security
+    src-path: https://github.com/angelzamir/forseti-security
     # --- end Forseti version
 
     # Cloud SQL

--- a/install/gcp/installer/forseti_installer.py
+++ b/install/gcp/installer/forseti_installer.py
@@ -192,7 +192,8 @@ class ForsetiInstaller(object):
         utils.print_banner('Pre-installation checks')
         self.check_run_properties()
         self.branch = utils.infer_version(self.config.advanced_mode)
-        self.project_id, authed_user, is_cloudshell = gcloud.get_gcloud_info()
+        (self.project_id, authed_user, is_cloudshell, is_service_account) = \
+            gcloud.get_gcloud_info()
         gcloud.verify_gcloud_information(self.project_id,
                                          authed_user,
                                          self.config.force_no_cloudshell,
@@ -202,6 +203,8 @@ class ForsetiInstaller(object):
         self.check_if_authed_user_in_domain(
             self.organization_id, authed_user)
         gcloud.check_billing_enabled(self.project_id, self.organization_id)
+        if is_service_account:
+            gcloud.active_service_account(authed_user)
 
     def create_or_reuse_service_accts(self):
         """Create or reuse service accounts."""

--- a/install/gcp/installer/forseti_installer.py
+++ b/install/gcp/installer/forseti_installer.py
@@ -200,11 +200,12 @@ class ForsetiInstaller(object):
                                          is_cloudshell)
         self.organization_id = gcloud.lookup_organization(self.project_id)
         self.config.generate_identifier(self.organization_id)
-        self.check_if_authed_user_in_domain(
-            self.organization_id, authed_user)
-        gcloud.check_billing_enabled(self.project_id, self.organization_id)
-        if is_service_account:
+        if not is_service_account:
+            self.check_if_authed_user_in_domain(
+                self.organization_id, authed_user)
+        else:
             gcloud.active_service_account(authed_user)
+        gcloud.check_billing_enabled(self.project_id, self.organization_id)
 
     def create_or_reuse_service_accts(self):
         """Create or reuse service accounts."""

--- a/install/gcp/installer/util/gcloud.py
+++ b/install/gcp/installer/util/gcloud.py
@@ -86,14 +86,10 @@ def _get_user_from_json(path):
     Returns:
         str: service account email aka client_email
     """
-    try:
-        f = open(path, 'r')
-        service_account_info = json.loads(f.read())
-        return service_account_info.get('client_email')
-    except IOError:
-        return None
-    finally:
-        f.close()
+    if path:
+        with open(path, 'r') as f:
+            service_account_info = json.loads(f.read())
+            return service_account_info.get('client_email')
 
 
 def active_service_account(authed_user):
@@ -101,7 +97,7 @@ def active_service_account(authed_user):
     Args:
         authed_user (str): service account email
     """
-    return_code, err = utils.run_command(
+    return_code, _, err = utils.run_command(
         ['gcloud', 'auth', 'activate-service-account',
          authed_user, '--key-file={}'
          .format(_get_service_account_json_path())])

--- a/install/gcp/installer/util/gcloud.py
+++ b/install/gcp/installer/util/gcloud.py
@@ -56,6 +56,8 @@ def get_gcloud_info():
                     _get_service_account_json_path())
                 if authed_user:
                     is_service_account = True
+            elif 'iam.gserviceaccount.com' in authed_user:
+                is_service_account = True
         except ValueError as verr:
             print(verr)
             sys.exit(1)

--- a/install/gcp/installer/util/gcloud.py
+++ b/install/gcp/installer/util/gcloud.py
@@ -91,6 +91,8 @@ def _get_user_from_json(path):
             service_account_info = json.loads(f.read())
             return service_account_info.get('client_email')
 
+    return None
+
 
 def active_service_account(authed_user):
     """Activate the service account with gcloud


### PR DESCRIPTION
Currently, the Forseti Installer doesn't support running the install script using a Service Account. A similar PR [1] was submitted in the past; however, this PR only accounts for the case where gcloud hasn't yet been authenticated. Meaning, if you authenticate with an SA, then it will still fail the domain check. This PR addresses that case by explicitly checking to see if the authenticated user is an SA. If it is, then it sets the is_service_account flag to true. 

[1] https://github.com/GoogleCloudPlatform/forseti-security/pull/1640