### PR TITLE
Fix full_res_name value when the root_resource is a project or a folder

### DIFF
--- a/google/cloud/forseti/services/model/importer/importer.py
+++ b/google/cloud/forseti/services/model/importer/importer.py
@@ -1137,7 +1137,7 @@ class InventoryImporter(object):
         data = folder.get_resource_data()
         if self._is_root(folder):
             parent, type_name = None, self._type_name(folder)
-            full_res_name = type_name
+            full_res_name = to_full_resource_name('', type_name)
         else:
             parent, full_res_name, type_name = self._full_resource_name(
                 folder)
@@ -1162,7 +1162,7 @@ class InventoryImporter(object):
         data = project.get_resource_data()
         if self._is_root(project):
             parent, type_name = None, self._type_name(project)
-            full_res_name = type_name
+            full_res_name = to_full_resource_name('', type_name)
         else:
             parent, full_res_name, type_name = self._full_resource_name(
                 project)


### PR DESCRIPTION
When running inventory with a project or a folder as the root_resource_id (in the server config), the full_res_name is generated incorrectly. This ensures that in both cases the full_res_name has a trailing `/` as is expected when to_full_resource_name is called on any child resources. Please see #1703 for additional information.