### PR TITLE
Website build improvements

### DIFF
--- a/scripts/docker/data/conf.py
+++ b/scripts/docker/data/conf.py
@@ -36,9 +36,6 @@ project = google.cloud.forseti.__package_name__.replace('-', ' ').title()
 author = 'The %s Authors' % (project,)
 current_year = datetime.now().year
 copyright = '%s, %s' % (current_year, author,)
-# project = u'Forseti Security'
-# copyright = u'2018, The Forseti Security Authors'
-# author = u'The Forseti Security Authors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -68,10 +65,23 @@ for project_directory, _, _ in os.walk('google'):
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'sphinx.ext.inheritance_diagram',
 ]
 
-# napoleon_google_docstring = False
+# Autodoc configuration.
+# See: http://www.sphinx-doc.org/en/master/ext/autodoc.html#confval-autodoc_default_flags
+autodoc_default_flags = [
+    'members',
+    'private-members',
+    'undoc-members',
+]
+
+# Napoleon configuration.
+# See: http://www.sphinx-doc.org/en/master/ext/napoleon.html#configuration
+napoleon_google_docstring = True
+napoleon_include_private_with_doc = True
+napoleon_include_special_with_doc = True
 # napoleon_use_param = False
 # napoleon_use_ivar = True
 
@@ -104,7 +114,10 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-# exclude_patterns = ['_build']
+exclude_patterns = [
+    '*.eggs*',
+    '*pb2*'
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -238,7 +251,7 @@ def no_namedtuple_attrib_docstring(app, what, name,
     if is_namedtuple_docstring:
         # We don't return, so we need to purge in-place
         del lines[:]
-        
+
 def setup(app):
     app.connect(
         'autodoc-process-docstring',

--- a/scripts/docker/generate_sphinx_docs.Dockerfile
+++ b/scripts/docker/generate_sphinx_docs.Dockerfile
@@ -15,7 +15,7 @@
 FROM forseti/build
 
 RUN pip install git+https://github.com/sphinx-doc/sphinx
-RUN sphinx-apidoc -F -M -e -o . google
+RUN sphinx-apidoc -P -F -M -e -o . google *.eggs/
 COPY data/conf.py data/index.rst ./
 COPY data/*.html _templates/
 RUN python setup.py build_sphinx

--- a/scripts/generate_sphinx_docs.sh
+++ b/scripts/generate_sphinx_docs.sh
@@ -85,41 +85,11 @@ function copy_sphinx_docs_into_jekyll_docs() {
     docker rm "${container_id}"
 }
 
-#######################################
-# Sphinx generates some links to pages
-# that do not exist; the best way to
-# clean them up is after generation.
-#######################################
-function delete_erroneous_generated_links_from_docs() {
-    sed -i '/<li><a href="sqlalchemy/d' \
-      _docs/_latest/develop/reference/_modules/index.html
-    sed -i '/<li><a href="namedtuple_/d' index.html \
-      _docs/_latest/develop/reference/_modules/index.html
-}
-
-#######################################
-# Jinja uses a similar syntax to Jekyll
-# Liquid, therefore we must escape
-# strings like "{{" and "}}" when used
-# in code samples that are meant to be
-# displayed without Liquid expansion.
-#######################################
-function escape_jinja_templating_in_code_samples() {
-    # Escape "{%", "%}", "{{", "}}" with Liquid's raw escaping mechanism, but
-    # DO NOT escape unbalanced sequences such as "{}}" which is present in some
-    # JSON examples.
-    find _docs/_latest/develop/reference/.eggs/ -type f -print0 | \
-    xargs -0 sed -ri \
-        '/\{\}\}/b; s/(\{\%|\%\}|\{\{|\}\})/\{% raw %\}\1\{% endraw %\}/g'
-}
-
 function main() {
     checkout_python_source_to_temp_directory
     build_python_source_in_docker
     generate_sphinx_docs_in_docker
     copy_sphinx_docs_into_jekyll_docs
-    delete_erroneous_generated_links_from_docs
-    escape_jinja_templating_in_code_samples
 }
 
 main "$@"

--- a/travis/jekyll_build.sh
+++ b/travis/jekyll_build.sh
@@ -27,7 +27,7 @@ else
     JEKYLL_GITHUB_TOKEN=$JGT bundle exec jekyll build
 fi
 
-bundle exec htmlproofer --check-img-http --check-opengraph --check-html \
+bundle exec htmlproofer --check-img-http --check-html \
 --check-favicon --report-missing-names --report-script-embeds \
 --url-ignore '/GoogleCloudPlatform/forseti-security/edit/' \
 --file-ignore '/develop/reference/' \


### PR DESCRIPTION
1. Generate private members with sphinx
1. Remove unnecessary bash cleanup
1. Exclude .eggs/ in sphinx build
1. Remove a htmlproofer check