### PR TITLE
Fix scanner_iter() db session out of sync when used by multiple simultaneous queries.

### DIFF
--- a/google/cloud/forseti/scanner/scanners/ke_version_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/ke_version_scanner.py
@@ -129,7 +129,7 @@ class KeVersionScanner(base_scanner.BaseScanner):
                                         ke_cluster.full_name))
 
         # Retrieve the service config via a separate query because session
-        # in the middle of yield_per() can not support multiple queries.
+        # in the middle of yield_per() can not support simultaneous queries.
         with scoped_session as session:
             for ke_cluster in ke_clusters:
                 position = (

--- a/google/cloud/forseti/scanner/scanners/ke_version_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/ke_version_scanner.py
@@ -136,10 +136,10 @@ class KeVersionScanner(base_scanner.BaseScanner):
                     ke_cluster.resource_full_name.find('kubernetes_cluster'))
                 ke_cluster_type_name = (
                     ke_cluster.resource_full_name[position:][:-1])
+
                 service_config = list(data_access.scanner_iter(
                     session, 'kubernetes_service_config',
                     parent_type_name=ke_cluster_type_name))[0]
-
                 ke_cluster.server_config = json.loads(service_config.data)
 
         return ke_clusters

--- a/google/cloud/forseti/services/dao.py
+++ b/google/cloud/forseti/services/dao.py
@@ -39,10 +39,11 @@ from sqlalchemy import DateTime
 from sqlalchemy import or_
 from sqlalchemy import and_
 from sqlalchemy import not_
-from sqlalchemy.orm import relationship
 from sqlalchemy.orm import aliased
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import reconstructor
+from sqlalchemy.orm import relationship
+from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql import select
 from sqlalchemy.sql import union
 from sqlalchemy.ext.declarative import declarative_base
@@ -661,14 +662,16 @@ def define_model(model_name, dbengine, model_seed):
             """
 
             qry = (
-                session.query(Resource).filter(
-                    Resource.type == resource_type)
-            )
+                session.query(Resource)
+                .filter(Resource.type == resource_type)
+                .options(joinedload(Resource.parent))
+                .enable_eagerloads(True))
 
             if parent_type_name:
                 qry = qry.filter(Resource.parent_type_name == parent_type_name)
 
-            for resource in qry.yield_per(PER_YIELD):
+#            for resource in qry.yield_per(PER_YIELD):
+            for resource in qry.yield_per(5):
                 yield resource
 
         @classmethod

--- a/google/cloud/forseti/services/dao.py
+++ b/google/cloud/forseti/services/dao.py
@@ -670,8 +670,7 @@ def define_model(model_name, dbengine, model_seed):
             if parent_type_name:
                 qry = qry.filter(Resource.parent_type_name == parent_type_name)
 
-#            for resource in qry.yield_per(PER_YIELD):
-            for resource in qry.yield_per(5):
+            for resource in qry.yield_per(PER_YIELD):
                 yield resource
 
         @classmethod


### PR DESCRIPTION
Fixes #1711, by enabling eager loading.

The KE scanner needs a different fix because it uses 2 explicit nested queries.  So, breaking them up into separate sequential queries.