### PR TITLE
Adding working changes for CSCC API integration

### DIFF
--- a/google/cloud/forseti/common/gcp_api/_base_repository.py
+++ b/google/cloud/forseti/common/gcp_api/_base_repository.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Base GCP client which uses the discovery API."""
+import json
 import logging
 import threading
 import google_auth_httplib2
@@ -53,6 +54,11 @@ SUPPORT_DISCOVERY_CACHE = (googleapiclient.__version__ >= '1.4.2')
 REQUEST_RECORDER = dict()
 REQUEST_REPLAYER = dict()
 
+# Used for private APIs that need to be created from local discovery documents
+BASE_DIR = "google/cloud/forseti/common/gcp_api/discovery_documents/"
+PRIVATE_APIS = {
+    "securitycenter": BASE_DIR + "securitycenter.json"
+}
 
 @retry(retry_on_exception=retryable_exceptions.is_retryable_exception,
        wait_exponential_multiplier=1000, wait_exponential_max=10000,
@@ -60,7 +66,6 @@ REQUEST_REPLAYER = dict()
 def _create_service_api(credentials, service_name, version, developer_key=None,
                         cache_discovery=False):
     """Builds and returns a cloud API service object.
-
     Args:
         credentials (OAuth2Credentials): Credentials that will be used to
             authenticate the API calls.
@@ -70,7 +75,6 @@ def _create_service_api(credentials, service_name, version, developer_key=None,
             associated with the API call, most API services do not require
             this to be set.
         cache_discovery (bool): Whether or not to cache the discovery doc.
-
     Returns:
         object: A Resource object with methods for interacting with the service.
     """
@@ -87,16 +91,37 @@ def _create_service_api(credentials, service_name, version, developer_key=None,
         'credentials': credentials}
     if SUPPORT_DISCOVERY_CACHE:
         discovery_kwargs['cache_discovery'] = cache_discovery
+
+    # Used for private APIs that are built from a local discovery file
+    if service_name in PRIVATE_APIS:
+        return _build_from_document(
+            credentials,
+            PRIVATE_APIS[service_name]
+        )
+
     return discovery.build(**discovery_kwargs)
+
+def _build_from_document(credentials, document_path):
+    """Builds an API client from a local discovery document
+    
+    Args:
+        credentials (OAuth2Credentials): Credentials that will be used to
+            authenticate the API calls.
+        document_path (str): The local path of the discovery document
+    """
+    with open(document_path, 'r') as f:
+        discovery_data = json.load(f)
+    return discovery.build_from_document(
+        service=discovery_data,
+        credentials=credentials
+    )
 
 
 def _build_http(http=None):
     """Set custom Forseti user agent and timeouts on a new http object.
-
     Args:
         http (object): An instance of httplib2.Http, or compatible, used for
             testing.
-
     Returns:
         httplib2.Http: An http object with the forseti user agent set.
     """
@@ -122,7 +147,6 @@ class BaseRepositoryClient(object):
                  use_rate_limiter=False,
                  **kwargs):
         """Constructor.
-
         Args:
             api_name (str): The API name to wrap. More details here:
                   https://developers.google.com/api-client-library/python/apis/
@@ -184,7 +208,6 @@ class BaseRepositoryClient(object):
 
     def __repr__(self):
         """The object representation.
-
         Returns:
             str: The object representation.
         """
@@ -192,11 +215,9 @@ class BaseRepositoryClient(object):
 
     def _init_repository(self, repository_class, version=None):
         """Safely initialize a repository class to a property.
-
         Args:
             repository_class (class): The class to initialize.
             version (str): The gcp service version for the repository.
-
         Returns:
             object: An instance of repository_class.
         """
@@ -226,7 +247,6 @@ class GCPRepository(object):
                  max_results_field='maxResults', search_query_field='query',
                  rate_limiter=None, use_cached_http=True):
         """Constructor.
-
         Args:
             gcp_service (object): A Resource object with methods for interacting
                 with the service.
@@ -281,7 +301,6 @@ class GCPRepository(object):
     @property
     def http(self):
         """A thread local instance of httplib2.Http.
-
         Returns:
             google_auth_httplib2.AuthorizedHttp: An Http instance authorized by
                 the credentials.
@@ -298,11 +317,9 @@ class GCPRepository(object):
 
     def _build_request(self, verb, verb_arguments):
         """Builds HttpRequest object.
-
         Args:
             verb (str): Request verb (ex. insert, update, delete).
             verb_arguments (dict): Arguments to be passed with the request.
-
         Returns:
             httplib2.HttpRequest: HttpRequest to be sent to the API.
         """
@@ -317,16 +334,13 @@ class GCPRepository(object):
 
     def _build_next_request(self, verb, prior_request, prior_response):
         """Builds pagination-aware request object.
-
         More details:
           https://developers.google.com/api-client-library/python/guide/pagination
-
         Args:
             verb (str): Request verb (ex. insert, update, delete).
             prior_request (httplib2.HttpRequest): Request that may trigger
                 paging.
             prior_response (dict): Potentially partial response.
-
         Returns:
             httplib2.HttpRequest: HttpRequest or None. None is returned when
                 there is nothing more to fetch - request completed.
@@ -336,10 +350,8 @@ class GCPRepository(object):
 
     def _request_supports_pagination(self, verb):
         """Determines if the API action supports pagination.
-
         Args:
             verb (str): Request verb (ex. insert, update, delete).
-
         Returns:
             bool: True when API supports pagination, False otherwise.
         """
@@ -347,16 +359,13 @@ class GCPRepository(object):
 
     def execute_command(self, verb, verb_arguments):
         """Executes command (ex. add) via a dedicated http object.
-
         Async APIs may take minutes to complete. Therefore, callers are
         encouraged to leverage concurrent.futures (or similar) to place long
         running commands on a separate threads.
-
         Args:
             verb (str): Method to execute on the component (ex. get, list).
             verb_arguments (dict): key-value pairs to be passed to
                 _build_request.
-
         Returns:
             dict: An async operation Service Response.
         """
@@ -366,15 +375,12 @@ class GCPRepository(object):
 
     def execute_paged_query(self, verb, verb_arguments):
         """Executes query (ex. list) via a dedicated http object.
-
         Args:
             verb (str): Method to execute on the component (ex. get, list).
             verb_arguments (dict): key-value pairs to be passed to
                 _BuildRequest.
-
         Yields:
             dict: Service Response.
-
         Raises:
             PaginationNotSupportedError: When an API does not support paging.
         """
@@ -395,12 +401,10 @@ class GCPRepository(object):
 
     def execute_search_query(self, verb, verb_arguments):
         """Executes query (ex. search) via a dedicated http object.
-
         Args:
             verb (str): Method to execute on the component (ex. search).
             verb_arguments (dict): key-value pairs to be passed to
                 _BuildRequest.
-
         Yields:
             dict: Service Response.
         """
@@ -425,12 +429,10 @@ class GCPRepository(object):
 
     def execute_query(self, verb, verb_arguments):
         """Executes query (ex. get) via a dedicated http object.
-
         Args:
             verb (str): Method to execute on the component (ex. get, list).
             verb_arguments (dict): key-value pairs to be passed to
                 _BuildRequest.
-
         Returns:
             dict: Service Response.
         """
@@ -444,10 +446,8 @@ class GCPRepository(object):
            stop_max_attempt_number=5)
     def _execute(self, request):
         """Run execute with retries and rate limiting.
-
         Args:
             request (object): The HttpRequest object to execute.
-
         Returns:
             dict: The response from the API.
         """

--- a/google/cloud/forseti/common/gcp_api/_supported_apis.py
+++ b/google/cloud/forseti/common/gcp_api/_supported_apis.py
@@ -55,6 +55,10 @@ SUPPORTED_APIS = {
         'default_version': 'v2',
         'supported_versions': ['v2']
     },
+    'securitycenter': {
+        'default_version': 'v1alpha3',
+        'supported_versions': ['v1alpha3']
+    },
     'servicemanagement': {
         'default_version': 'v1',
         'supported_versions': ['v1']

--- a/google/cloud/forseti/common/gcp_api/discovery_documents/securitycenter.json
+++ b/google/cloud/forseti/common/gcp_api/discovery_documents/securitycenter.json
@@ -1,0 +1,621 @@
+{
+  "batchPath": "batch",
+  "title": "Cloud Security Command Center API",
+  "ownerName": "Google",
+  "resources": {
+    "organizations": {
+      "resources": {
+        "assets": {
+          "methods": {
+            "search": {
+              "description": "Search assets within an organization.",
+              "request": {
+                "$ref": "SearchAssetsRequest"
+              },
+              "response": {
+                "$ref": "SearchAssetsResponse"
+              },
+              "parameterOrder": [
+                "orgName"
+              ],
+              "httpMethod": "POST",
+              "parameters": {
+                "orgName": {
+                  "pattern": "^organizations/[^/]+$",
+                  "location": "path",
+                  "description": "Name of the organization to search for assets. Its format is\n\"organizations/[organization_id]\". For example, \"organizations/1234\".",
+                  "required": true,
+                  "type": "string"
+                }
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ],
+              "flatPath": "v1alpha3/organizations/{organizationsId}/assets:search",
+              "path": "v1alpha3/{+orgName}/assets:search",
+              "id": "securitycenter.organizations.assets.search"
+            },
+            "modify": {
+              "description": "Modifies the marks on the specified asset.",
+              "request": {
+                "$ref": "ModifyAssetRequest"
+              },
+              "response": {
+                "$ref": "Asset"
+              },
+              "parameterOrder": [
+                "orgName",
+                "id"
+              ],
+              "httpMethod": "POST",
+              "parameters": {
+                "orgName": {
+                  "description": "Organization name.",
+                  "required": true,
+                  "type": "string",
+                  "pattern": "^organizations/[^/]+$",
+                  "location": "path"
+                },
+                "id": {
+                  "description": "Unique identifier for the asset to be modified.",
+                  "required": true,
+                  "type": "string",
+                  "location": "path"
+                }
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ],
+              "flatPath": "v1alpha3/organizations/{organizationsId}/assets/{id}:modify",
+              "path": "v1alpha3/{+orgName}/assets/{id}:modify",
+              "id": "securitycenter.organizations.assets.modify"
+            }
+          }
+        },
+        "findings": {
+          "methods": {
+            "create": {
+              "response": {
+                "$ref": "Finding"
+              },
+              "parameterOrder": [
+                "orgName"
+              ],
+              "httpMethod": "POST",
+              "parameters": {
+                "orgName": {
+                  "description": "Name of the organization to search for assets. Its format is\n\"organizations/[organization_id]\". For example, \"organizations/1234\".",
+                  "required": true,
+                  "type": "string",
+                  "pattern": "^organizations/[^/]+$",
+                  "location": "path"
+                }
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ],
+              "flatPath": "v1alpha3/organizations/{organizationsId}/findings",
+              "path": "v1alpha3/{+orgName}/findings",
+              "id": "securitycenter.organizations.findings.create",
+              "description": "Creates a finding. Creating the same finding with a later event_time will\nupdate the existing one. Cloud SCC provides the capability for users to\nsearch findings based on timestamps.",
+              "request": {
+                "$ref": "CreateFindingRequest"
+              }
+            },
+            "search": {
+              "description": "Search findings within an organization.",
+              "request": {
+                "$ref": "SearchFindingsRequest"
+              },
+              "httpMethod": "POST",
+              "parameterOrder": [
+                "orgName"
+              ],
+              "response": {
+                "$ref": "SearchFindingsResponse"
+              },
+              "parameters": {
+                "orgName": {
+                  "location": "path",
+                  "description": "The name of the organization to which the findings belong. Its format is\n\"organizations/[organization_id]\". For example, \"organizations/1234\".",
+                  "required": true,
+                  "type": "string",
+                  "pattern": "^organizations/[^/]+$"
+                }
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ],
+              "flatPath": "v1alpha3/organizations/{organizationsId}/findings:search",
+              "id": "securitycenter.organizations.findings.search",
+              "path": "v1alpha3/{+orgName}/findings:search"
+            },
+            "modify": {
+              "description": "Modifies the changeable parts of the specified finding.",
+              "request": {
+                "$ref": "ModifyFindingRequest"
+              },
+              "response": {
+                "$ref": "Finding"
+              },
+              "parameterOrder": [
+                "orgName",
+                "id"
+              ],
+              "httpMethod": "POST",
+              "parameters": {
+                "id": {
+                  "location": "path",
+                  "description": "ID of the finding.",
+                  "required": true,
+                  "type": "string"
+                },
+                "orgName": {
+                  "description": "Organization name.",
+                  "required": true,
+                  "type": "string",
+                  "pattern": "^organizations/[^/]+$",
+                  "location": "path"
+                }
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ],
+              "flatPath": "v1alpha3/organizations/{organizationsId}/findings/{id}:modify",
+              "path": "v1alpha3/{+orgName}/findings/{id}:modify",
+              "id": "securitycenter.organizations.findings.modify"
+            }
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "key": {
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "type": "string",
+      "location": "query"
+    },
+    "access_token": {
+      "location": "query",
+      "description": "OAuth access token.",
+      "type": "string"
+    },
+    "upload_protocol": {
+      "location": "query",
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "location": "query",
+      "description": "Returns response with indentations and line breaks.",
+      "type": "boolean",
+      "default": "true"
+    },
+    "quotaUser": {
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+      "type": "string",
+      "location": "query"
+    },
+    "uploadType": {
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+      "type": "string",
+      "location": "query"
+    },
+    "fields": {
+      "location": "query",
+      "description": "Selector specifying which fields to include in a partial response.",
+      "type": "string"
+    },
+    "$.xgafv": {
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "location": "query",
+      "enum": [
+        "1",
+        "2"
+      ],
+      "description": "V1 error format.",
+      "type": "string"
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
+      "type": "string",
+      "location": "query"
+    },
+    "callback": {
+      "description": "JSONP",
+      "type": "string",
+      "location": "query"
+    },
+    "alt": {
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "type": "string",
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "location": "query",
+      "description": "Data format for response.",
+      "default": "json"
+    }
+  },
+  "version": "v1alpha3",
+  "baseUrl": "https://securitycenter.googleapis.com/",
+  "kind": "discovery#restDescription",
+  "description": "The public Cloud Security Command Center API.",
+  "servicePath": "",
+  "basePath": "",
+  "id": "securitycenter:v1alpha3",
+  "revision": "20180625",
+  "documentationLink": "https://console.cloud.google.com/apis/api/securitycenter.googleapis.com/overview",
+  "discoveryVersion": "v1",
+  "version_module": true,
+  "schemas": {
+    "SourceFinding": {
+      "description": "Representation of a source's finding.",
+      "type": "object",
+      "properties": {
+        "properties": {
+          "description": "`Key: value` pairs provided by the source. Indexing will be provided\nfor each key.",
+          "type": "object",
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          }
+        },
+        "url": {
+          "description": "An https url provided by the source for users to click on to see more\ninformation, used for UI navigation.",
+          "type": "string"
+        },
+        "marks": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "User specified marks placed on the finding.\nNote: This field is used in responses only. Any value specified here in a\nrequest is ignored.",
+          "type": "object"
+        },
+        "attributes": {
+          "description": "Dynamically calculated attributes provided by Google.\nFor example, first_discovered, create_time.\nNote: This field is used in responses only. Any value specified here in a\nrequest is ignored.",
+          "type": "object",
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          }
+        },
+        "id": {
+          "description": "Required field, an organization & source unique immutable identifier\nprovided by the sources.",
+          "type": "string"
+        },
+        "category": {
+          "description": "Required field, category of a finding, this is a custom string field. In\ngeneral, sources have logical groupings for their findings. For example,\nthe Data Loss Prevention Scanner has the following types: \"SSN\",\n\"US passport\", \"credit card number\", and so on. This field is indexed and\nused by Cloud SCC frontend for data visualization. It's also useful for\nreporting and analysis. It's recommended to populate this field\nconsistently.",
+          "type": "string"
+        },
+        "sourceId": {
+          "description": "Required field, ID of the finding source. A source is a producer of\nsecurity findings and source IDs are namespaced under each organization.\nFor Google integrated sources, please use their official source IDs for\nbetter frontend integration. For custom sources, choose an ID that doesn't\nconflict with any existing IDs.",
+          "type": "string"
+        },
+        "eventTime": {
+          "description": "Time when the finding was generated by the source.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "assetIds": {
+          "description": "Required field, list of IDs of affected assets. These IDs should strictly\nmap to one of the existing asset IDs in the asset inventory for the\norganization, which is populated by Cloud SCC backend. If the ID doesn't\nmap to one of the existing asset IDs, the result is a NOT_FOUND error.\nAsset types must be supported by Cloud SCC. It's best to pick the most\ngranular asset type. For example, if a file in a VM instance is affected,\npick the asset ID of the VM instance. This works best because file isn't a\nsupported asset type in Cloud SCC, and project ID is too broad.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "SourceFinding"
+    },
+    "ModifyAssetRequest": {
+      "description": "Request message for modifying the marks on an asset.",
+      "type": "object",
+      "properties": {
+        "removeMarksWithKeys": {
+          "description": "A list of keys defining the marks to remove from the asset. There can be no\noverlaps between keys to remove and keys to add or update.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "addOrUpdateMarks": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Keys and values to add/update on the asset.\n\nIf a mark with the same key already exists, its value will be replaced by\nthe updated value.",
+          "type": "object"
+        }
+      },
+      "id": "ModifyAssetRequest"
+    },
+    "SearchFindingsRequest": {
+      "properties": {
+        "pageSize": {
+          "description": "The maximum number of results to return.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "referenceTime": {
+          "description": "The reference point used to determine the findings at a specific\npoint in time.\nQueries with the timestamp in the future are rounded down to the\ncurrent time on the server. If the value is not given, \"now\" is going to\nbe used implicitly.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "query": {
+          "description": "Expression that defines the query to apply across findings.\nThe expression is a list of one or more restrictions combined via logical\noperators `AND` and `OR`.\nParentheses are supported, and in absence of parentheses `OR` has higher\nprecedence than `AND`.\n\nRestrictions have the form `\u003cfield\u003e \u003coperator\u003e \u003cvalue\u003e` and may have a `-`\ncharacter in front of them to indicate negation. The fields can be of the\nfollowing types:\n\n* Attribute - optional `attribute.` prefix or no prefix and name.\n* Property - mandatory `property.` prefix and name.\n* Mark - mandatory `mark` prefix and name.\n\nThe supported operators are:\n\n* `=` for all value types.\n* `\u003e`, `\u003c`, `\u003e=`, `\u003c=` for integer values.\n* `:`, meaning substring matching, for strings.\n\nThe supported value types are:\n\n* string literals in quotes.\n* integer literals without quotes.\n* boolean literals `true` and `false` without quotes.\n\nFor example, `property.count = 100` is a valid query string.",
+          "type": "string"
+        },
+        "orderBy": {
+          "description": "Expression that defines what fields and order to use for sorting.",
+          "type": "string"
+        },
+        "pageToken": {
+          "description": "Optional pagination token returned in an earlier call.",
+          "type": "string"
+        }
+      },
+      "id": "SearchFindingsRequest",
+      "description": "Request message for SearchFindings.",
+      "type": "object"
+    },
+    "SearchFindingsResponse": {
+      "description": "Response message for SearchFindings.",
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "description": "Token to retrieve the next page of results, or empty if there are no more\nresults.",
+          "type": "string"
+        },
+        "totalSize": {
+          "description": "The total number of findings irrespective of pagination.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "findings": {
+          "description": "Findings returned by the request.",
+          "type": "array",
+          "items": {
+            "$ref": "Finding"
+          }
+        },
+        "referenceTime": {
+          "description": "Time provided for reference_time in the request.",
+          "format": "google-datetime",
+          "type": "string"
+        }
+      },
+      "id": "SearchFindingsResponse"
+    },
+    "SearchAssetsResponse": {
+      "description": "Response message for SearchAssets.",
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "description": "Token to retrieve the next page of results, or empty if there are no more\nresults.",
+          "type": "string"
+        },
+        "assets": {
+          "description": "Assets returned by the request.",
+          "type": "array",
+          "items": {
+            "$ref": "Asset"
+          }
+        },
+        "totalSize": {
+          "description": "The total number of results available.",
+          "format": "uint64",
+          "type": "string"
+        },
+        "referenceTime": {
+          "description": "Time provided for reference_time in the request.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "compareDuration": {
+          "description": "Time provided for compare_duration in the request.",
+          "format": "google-duration",
+          "type": "string"
+        }
+      },
+      "id": "SearchAssetsResponse"
+    },
+    "CreateFindingRequest": {
+      "description": "Request message for CreatingFinding.",
+      "type": "object",
+      "properties": {
+        "sourceFinding": {
+          "description": "The source finding to be created.",
+          "$ref": "SourceFinding"
+        }
+      },
+      "id": "CreateFindingRequest"
+    },
+    "Finding": {
+      "properties": {
+        "properties": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "Properties associated with the finding.",
+          "type": "object"
+        },
+        "marks": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "User specified marks placed on the finding.",
+          "type": "object"
+        },
+        "scannerId": {
+          "description": "Unique identifier for the scanner that produced the finding.",
+          "type": "string"
+        },
+        "updateTime": {
+          "description": "Time at which this finding was last updated. This does not include updates\non user specified marks.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "assetId": {
+          "description": "Unique identifier for the asset the finding relates to.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Unique identifier for this finding. The same finding and identifier can\nappear at multiple points in time.",
+          "type": "string"
+        }
+      },
+      "id": "Finding",
+      "description": "Representation of a scanner's finding.",
+      "type": "object"
+    },
+    "ModifyFindingRequest": {
+      "description": "Request message for ModifyFinding.",
+      "type": "object",
+      "properties": {
+        "addOrUpdateMarks": {
+          "description": "Keys and values to add or update on the finding.\nIf a mark with the same key already exists, its value will be replaced by\nthe updated value.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "removeMarksWithKeys": {
+          "description": "A list of keys defining the marks to remove from the finding. There can be\nno overlaps between keys to remove and keys to add or update.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "ModifyFindingRequest"
+    },
+    "SearchAssetsRequest": {
+      "description": "Request message for SearchAssets.",
+      "type": "object",
+      "properties": {
+        "orderBy": {
+          "description": "Expression that defines what fields and order to use for sorting.",
+          "type": "string"
+        },
+        "compareDuration": {
+          "description": "When compare_duration is set, the Asset's \"state\" attribute is updated to\nindicate whether the asset was added, removed, or remained present during\nthe compare_duration period of time that precedes the reference_time. This\nis the time between (reference_time - compare_duration) and reference_time.\n\nThe state value is derived based on the presence of the asset at the two\npoints in time. Intermediate state changes between the two times don't\naffect the result. For example, the results aren't affected if the asset is\nremoved and re-created again.\n\nPossible \"state\" values when compare_duration is specified:\n\n* \"ADDED\": indicates that the asset was not present before\n             compare_duration, but present at reference_time.\n* \"REMOVED\": indicates that the asset was present at the start of\n             compare_duration, but not present at reference_time.\n* \"ACTIVE_AT_BOTH\": indicates that the asset was present at both the\n             start and the end of the time period defined by\n             compare_duration and reference_time.\n\nIf compare_duration is not specified, then the only possible state is\n\"ACTIVE\", which indicates that the asset is present at reference_time.",
+          "format": "google-duration",
+          "type": "string"
+        },
+        "pageToken": {
+          "description": "Optional pagination token returned in an earlier call.",
+          "type": "string"
+        },
+        "pageSize": {
+          "description": "The maximum number of results to return in a single response.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "referenceTime": {
+          "description": "Time at which to search for assets. The search will capture the state of\nassets at this point in time.\n\nNot providing a value or providing one in the future is treated as current.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "query": {
+          "description": "Expression that defines the query to apply across assets.\nThe expression is a list of one or more restrictions combined via logical\noperators `AND` and `OR`.\nParentheses are not supported, and `OR` has higher precedence than `AND`.\n\nRestrictions have the form `\u003cfield\u003e \u003coperator\u003e \u003cvalue\u003e` and may have a `-`\ncharacter in front of them to indicate negation. The fields can be of the\nfollowing types:\n\n* Attribute: optional `attribute.` prefix or no prefix and name.\n* Property: mandatory `property.` prefix and name.\n* Mark: mandatory `mark` prefix and name.\n\nThe supported operators are:\n\n* `=` for all value types.\n* `\u003e`, `\u003c`, `\u003e=`, `\u003c=` for integer values.\n* `:`, meaning substring matching, for strings.\n\nThe supported value types are:\n\n* string literals in quotes.\n* integer literals without quotes.\n* boolean literals `true` and `false` without quotes.\n\nFor example, `property.count = 100` is a valid query string.",
+          "type": "string"
+        }
+      },
+      "id": "SearchAssetsRequest"
+    },
+    "Asset": {
+      "description": "Representation of a Google Cloud Platform asset. Examples of assets include:\nApp Engine Application, Project, Bucket, and so on.",
+      "type": "object",
+      "properties": {
+        "properties": {
+          "description": "Properties associated with the asset.",
+          "type": "object",
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          }
+        },
+        "parentId": {
+          "description": "Unique identifier for this asset's parent. For example, a Project's parent\nwould be either the organization it belongs to OR the folder it resides in.",
+          "type": "string"
+        },
+        "marks": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "User specified marks placed on the asset.",
+          "type": "object"
+        },
+        "state": {
+          "enumDescriptions": [
+            "Invalid state.",
+            "Asset was active for the point in time.",
+            "Asset was not found for the point(s) in time.",
+            "Asset was added between the points in time.",
+            "Asset was removed between the points in time.",
+            "Asset was active at both point(s) in time."
+          ],
+          "enum": [
+            "STATE_UNSPECIFIED",
+            "ACTIVE",
+            "NOT_FOUND",
+            "ADDED",
+            "REMOVED",
+            "ACTIVE_AT_BOTH"
+          ],
+          "description": "State of the asset.",
+          "type": "string"
+        },
+        "updateTime": {
+          "description": "The time at which the asset was last updated, added, or deleted in\nCloud SCC.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "type": {
+          "description": "The type of asset. Examples include: APPLICATION, PROJECT, and\nORGANIZATION.",
+          "type": "string"
+        },
+        "owners": {
+          "description": "Owners of the asset. Commonly represented as email addresses.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "description": "Unique identifier for this asset. This identifier persists following\nmodification, deletion, or recreation.",
+          "type": "string"
+        }
+      },
+      "id": "Asset"
+    }
+  },
+  "icons": {
+    "x16": "http://www.google.com/images/icons/product/search-16.gif",
+    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  },
+  "protocol": "rest",
+  "canonicalName": "Security Command Center",
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/cloud-platform": {
+          "description": "View and manage your data across Google Cloud Platform services"
+        }
+      }
+    }
+  },
+  "rootUrl": "https://securitycenter.googleapis.com/",
+  "ownerDomain": "google.com",
+  "name": "securitycenter"
+}

--- a/google/cloud/forseti/common/gcp_api/repository_mixins.py
+++ b/google/cloud/forseti/common/gcp_api/repository_mixins.py
@@ -283,3 +283,31 @@ class SearchQueryMixin(object):
                 verb=verb,
                 verb_arguments={'body': req_body, 'fields': fields}):
             yield resp
+
+
+class CreateQueryMixin(object):
+    """Mixin that implements a Create query."""
+
+    def create(self, organization_id, query=None, fields=None, max_results=500, verb='create'):
+        """Create a resource.
+
+        Args:
+            self (GCPRespository): An instance of a GCPRespository class.
+            fields (str): Fields to include in the response - partial response.
+            verb (str): The method to call on the API.
+
+        Yields:
+            dict: An API response containing one page of results.
+        """
+        req_body = {}
+        arguments = {'body': req_body,
+                     'orgName': 'organizations/' + str(organization_id)}
+        if query:
+            req_body['sourceFinding'] = query
+
+#        req_body[self._max_results_field] = max_results
+
+        for resp in self.execute_query(
+                verb=verb,
+                verb_arguments=arguments):
+            yield resp

--- a/google/cloud/forseti/common/gcp_api/securitycenter.py
+++ b/google/cloud/forseti/common/gcp_api/securitycenter.py
@@ -1,0 +1,106 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wrapper for Cloud Security Command Center API client."""
+import json
+from googleapiclient import errors
+from httplib2 import HttpLib2Error
+
+from google.cloud.forseti.common.gcp_api import _base_repository
+from google.cloud.forseti.common.gcp_api import api_helpers
+from google.cloud.forseti.common.gcp_api import errors as api_errors
+from google.cloud.forseti.common.gcp_api import repository_mixins
+from google.cloud.forseti.common.util import logger
+
+LOGGER = logger.get_logger(__name__)
+
+class SecurityCenterRepositoryClient(_base_repository.BaseRepositoryClient):
+    """SecurityCenter API Respository."""
+
+    def __init__(self,
+                 quota_max_calls=None,
+                 quota_period=1.0,
+                 use_rate_limiter=True):
+        """Constructor.
+        Args:
+            quota_max_calls (int): Allowed requests per <quota_period> for the
+                API.
+            quota_period (float): The time period to track requests over.
+            use_rate_limiter (bool): Set to false to disable the use of a rate
+                limiter for this service.
+        """
+        if not quota_max_calls:
+            use_rate_limiter = False
+
+        self._findings = None
+
+        super(SecurityCenterRepositoryClient, self).__init__(
+            'securitycenter', versions=['v1alpha3'],
+            quota_max_calls=quota_max_calls,
+            quota_period=quota_period,
+            use_rate_limiter=use_rate_limiter)
+
+    # Turn off docstrings for properties.
+    # pylint: disable=missing-return-doc, missing-return-type-doc
+    @property
+    def findings(self):
+        """Returns an _SecurityCenterOrganizationsFindingsRepository instance."""
+        if not self._findings:
+            self._findings = self._init_repository(
+                _SecurityCenterOrganizationsFindingsRepository)
+        return self._findings
+    # pylint: enable=missing-return-doc, missing-return-type-doc
+
+
+class _SecurityCenterOrganizationsFindingsRepository(
+        repository_mixins.CreateQueryMixin,
+        _base_repository.GCPRepository):
+    """Implementation of CSCC Organizations Findings repository."""
+
+    def __init__(self, **kwargs):
+        """Constructor.
+        """
+        super(_SecurityCenterOrganizationsFindingsRepository, self).__init__(
+#            component='securitycenter.organizations.findings', **kwargs)
+            component='organizations.findings', **kwargs)
+
+
+class SecurityCenterClient(object):
+    """Cloud Security Command Center Client.
+    https://cloud.google.com/security-command-center/docs/reference/rest
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize.
+        Args:
+            global_configs (dict): Forseti config.
+            **kwargs (dict): The kwargs.
+        """
+        self.repository = SecurityCenterRepositoryClient()
+
+    def create_finding(self, organization_id, finding):
+        """Creates a finding in CSCC.
+        Args:
+            organization_id (str): The id of the organization.
+        """
+        try:
+            response = self.repository.findings.create(organization_id, finding)
+            LOGGER.debug('Created finding in CSCC: %s', list(response))
+            return
+        except (errors.HttpError, HttpLib2Error) as e:
+            LOGGER.info('>>>>> %s', e)
+            #if _is_status_not_found(e):
+            #    return []
+            #raise api_errors.ApiExecutionError(project_id, e)
+            raise api_errors.ApiExecutionError(e)

--- a/google/cloud/forseti/notifier/notifier.py
+++ b/google/cloud/forseti/notifier/notifier.py
@@ -150,7 +150,9 @@ def run(inventory_index_id, progress_queue, service_config=None):
                     notifier_configs.get('violation').get('cscc').get('enabled')):
                 cscc_notifier.CsccNotifier(inventory_index_id).run(
                     violations_as_dict,
-                    notifier_configs.get('violation').get('cscc').get('gcs_path'))
+                    notifier_configs.get('violation').get('cscc').get('gcs_path'),
+                    notifier_configs.get('violation').get('cscc').get('mode'),
+                    notifier_configs.get('violation').get('cscc').get('organization_id'))
             # pylint: enable=line-too-long
 
         InventorySummary(service_config, inventory_index_id).run()

--- a/google/cloud/forseti/notifier/notifiers/cscc_notifier.py
+++ b/google/cloud/forseti/notifier/notifiers/cscc_notifier.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 """Upload violations to GCS bucket as Findings."""
-
 import tempfile
 
 from googleapiclient.errors import HttpError
 
 from google.cloud.forseti.common.gcp_api import storage
+from google.cloud.forseti.common.gcp_api import securitycenter
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.common.util import parser
 from google.cloud.forseti.common.util import date_time
@@ -29,22 +29,19 @@ LOGGER = logger.get_logger(__name__)
 
 
 class CsccNotifier(object):
-    """Upload violations to GCS bucket as CSCC findings."""
+    """Send violations to CSCC via API or via GCS bucket."""
 
     def __init__(self, inv_index_id):
         """`Findingsnotifier` initializer.
-
         Args:
-            inv_index_id (int64): inventory index ID
+            inv_index_id (str): inventory index ID
         """
         self.inv_index_id = inv_index_id
 
-    def _transform_to_findings(self, violations):
-        """Transform forseti violations to findings format.
-
+    def _transform_for_gcs(self, violations):
+        """Transform forseti violations to GCS findings format. 
         Args:
             violations (dict): Violations to be uploaded as findings.
-
         Returns:
             list: violations in findings format; each violation is a dict.
         """
@@ -82,14 +79,14 @@ class CsccNotifier(object):
             string_formats.TIMESTAMP_TIMEZONE)
         return string_formats.CSCC_FINDINGS_FILENAME.format(output_timestamp)
 
-    def run(self, violations, gcs_path):
-        """Generate the temporary json file and upload to GCS.
+    def _send_findings_to_gcs(self, violations, gcs_path):
+        """Send violations to CSCC via upload to GCS (legacy mode).
         Args:
             violations (dict): Violations to be uploaded as findings.
             gcs_path (str): The GCS bucket to upload the findings.
         """
-        LOGGER.info('Running CSCC findings notification.')
-        findings = self._transform_to_findings(violations)
+        LOGGER.info('Legacy mode detected - writing findings to GCS.')
+        findings = self._transform_for_gcs(violations)
 
         with tempfile.NamedTemporaryFile() as tmp_violations:
             tmp_violations.write(parser.json_stringify(findings))
@@ -101,9 +98,73 @@ class CsccNotifier(object):
 
             if gcs_upload_path.startswith('gs://'):
                 storage_client = storage.StorageClient()
-                try:
-                    storage_client.put_text_file(
-                        tmp_violations.name, gcs_upload_path)
-                except HttpError as e:
-                    LOGGER.error('Unable to save CSCC in bucket %s:\n%s',
-                                 gcs_upload_path, e.content)
+                storage_client.put_text_file(
+                    tmp_violations.name, gcs_upload_path)
+        return
+
+    @staticmethod
+    def _unix_time_millis(dt):
+        return int((dt - datetime.utcfromtimestamp(0)).total_seconds())
+
+    def _transform_for_cscc_api(self, violations):
+        """Transform forseti violations to findings for CSCC API. 
+        Args:
+            violations (dict): Violations to be sent to CSCC as findings.
+        Returns:
+            list: violations in findings format; each violation is a dict.
+        """
+        findings = []
+        for violation in violations:
+            finding = {
+                'id': violation.get('violation_hash'),
+                'assetIds': [
+                    violation.get('full_name')
+                ],
+                'eventTime': violation.get('created_at_datetime'),
+                'properties': {
+                    'inventory_index_id': self.inv_index_id,
+                    'resource_data': violation.get('resource_data'),
+                    'resource_id': violation.get('resource_id'),
+                    'resource_type': violation.get('resource_type'),
+                    'rule_index': violation.get('rule_index'),
+                    'scanner_index_id': violation.get('scanner_index_id'),
+                    'violation_data': violation.get('violation_data')
+                },
+                'source_id': 'FORSETI',
+                'category': 'UNKNOWN_RISK'
+            }
+            findings.append(finding)
+        return findings
+
+    def _send_findings_to_cscc(self, violations, organization_id):
+        """Send violations to CSCC directly via the CSCC API.
+        Args:
+            violations (dict): Violations to be uploaded as findings.
+        """
+        LOGGER.info('CSCC API mode detected - sending findings via CSCC API.')
+        findings = self._transform_for_cscc_api(violations)
+
+        client = securitycenter.SecurityCenterClient()
+
+        for finding in findings:
+            client.create_finding(
+                organization_id=organization_id,
+                finding=finding
+            )
+        return
+
+    def run(self, violations, gcs_path, mode, organization_id):
+        """Generate the temporary json file and upload to GCS.
+        Args:
+            violations (dict): Violations to be uploaded as findings.
+            gcs_path (str): The GCS bucket to upload the findings.
+        """
+        LOGGER.info('Running Cloud Security Command Center notification module.')
+
+        if mode == 'gcs':
+            self._send_findings_to_gcs(violations, gcs_path)
+        elif mode == 'cscc-api':
+            self._send_findings_to_cscc(violations, organization_id)
+        else:
+            LOGGER.info('A valid mode for CSCC was not selected. Please use either gcs or cscc-api modes.')
+        return


### PR DESCRIPTION
This is a PR for direct integration between Forseti and Cloud Security Command Center (CSCC). The violations from Scanner can now be written directly into CSCC via its REST API.

@blueandgold I made some small tweaks to the format of the finding, in "_transform_findings_for_cscc()", and tested to ensure this works. I did not add unit tests yet, based on our discussion.
