### PR TITLE
Run cloudsqlproxy service as root

### DIFF
--- a/install/gcp/scripts/initialize_forseti_services.sh
+++ b/install/gcp/scripts/initialize_forseti_services.sh
@@ -66,7 +66,6 @@ SQL_PROXY_SERVICE="$(cat << EOF
 [Unit]
 Description=Cloud SQL Proxy
 [Service]
-User=ubuntu
 Restart=always
 RestartSec=3
 ExecStart=$SQL_PROXY_COMMAND

--- a/install/gcp/scripts/initialize_forseti_services.sh
+++ b/install/gcp/scripts/initialize_forseti_services.sh
@@ -61,7 +61,8 @@ EOF
 echo "$API_SERVICE" > /tmp/forseti.service
 sudo mv /tmp/forseti.service /lib/systemd/system/forseti.service
 
-
+# By default, Systemd starts the executable stated in ExecStart= as root.
+# See github issue #1761 for why this neds to be run as root.
 SQL_PROXY_SERVICE="$(cat << EOF
 [Unit]
 Description=Cloud SQL Proxy


### PR DESCRIPTION
Removed User= from cloudsqlproxy service.

By default, Systemd starts the executable stated in ExecStart= as root so it will contain the permissions required to run the cloudsqlproxy script.

Resolves #1761 