### PR TITLE
Shorten the violation id hash.

### DIFF
--- a/google/cloud/forseti/notifier/notifiers/cscc_notifier.py
+++ b/google/cloud/forseti/notifier/notifiers/cscc_notifier.py
@@ -118,7 +118,8 @@ class CsccNotifier(object):
         findings = []
         for violation in violations:
             finding = {
-                'id': violation.get('violation_hash'),
+                # CSCC can't accept the full hash, so this must be shortened.
+                'id': violation.get('violation_hash')[:64],
                 'assetIds': [
                     violation.get('full_name')
                 ],

--- a/google/cloud/forseti/services/scanner/dao.py
+++ b/google/cloud/forseti/services/scanner/dao.py
@@ -368,8 +368,7 @@ def _create_violation_hash(violation_full_name, resource_data, violation_data):
                      violation_full_name, e)
         return ''
 
-    # CSCC can't accept the full hash, so this must be shortened.
-    return violation_hash.hexdigest()[:64]
+    return violation_hash.hexdigest()
 
 
 def initialize(engine):

--- a/google/cloud/forseti/services/scanner/dao.py
+++ b/google/cloud/forseti/services/scanner/dao.py
@@ -368,7 +368,8 @@ def _create_violation_hash(violation_full_name, resource_data, violation_data):
                      violation_full_name, e)
         return ''
 
-    return violation_hash.hexdigest()
+    # CSCC can't accept the full hash, so this must be shortened.
+    return violation_hash.hexdigest()[:64]
 
 
 def initialize(engine):

--- a/tests/notifier/notifiers/cscc_notifier_test.py
+++ b/tests/notifier/notifiers/cscc_notifier_test.py
@@ -60,7 +60,7 @@ class CsccNotifierTest(ScannerBaseDbTestCase):
             {'assetIds': ['full_name_111'],
              'category': 'UNKNOWN_RISK',
              'eventTime': '2010-08-28T10:20:30Z',
-             'id': '539cfbdb1113a74ec18edf583eada77ab1a60542c6edcb4120b50f34629b6b69041c13f0447ab7b2526d4c944c88670b6f151fa88444c30771f47a3b813552ff',
+             'id': '539cfbdb1113a74ec18edf583eada77ab1a60542c6edcb4120b50f34629b6b69',
              'properties': {
                  'inventory_index_id': 'iii',
                  'resource_data': 'inventory_data_111',
@@ -73,7 +73,7 @@ class CsccNotifierTest(ScannerBaseDbTestCase):
             {'assetIds': ['full_name_222'],
              'category': 'UNKNOWN_RISK',
              'eventTime': '2010-08-28T10:20:30Z',
-             'id': '3eff279ccb96799d9eb18e6b76055b2242d1f2e6f14c1fb3bb48f7c8c03b4ce4db577d67c0b91c5914902d906bf1703d5bbba0ceaf29809ac90fef3bf6aa5417',
+             'id': '3eff279ccb96799d9eb18e6b76055b2242d1f2e6f14c1fb3bb48f7c8c03b4ce4',
              'properties': {
                  'inventory_index_id': 'iii',
                  'resource_data': 'inventory_data_222',


### PR DESCRIPTION
The full hash is 100 something odd characters.  Is there any issues you can see on collision if this is down to 64 characters?