### PR TITLE
Fixes to gcloud.py and Service Account Support

### DIFF
--- a/install/gcp/installer/forseti_installer.py
+++ b/install/gcp/installer/forseti_installer.py
@@ -205,8 +205,7 @@ class ForsetiInstaller(object):
             self.check_if_authed_user_in_domain(
                 self.organization_id, authed_user)
         else:
-            gcloud.activate_service_account(authed_user,
-                                            service_account_key_file)
+            gcloud.activate_service_account(service_account_key_file)
 
         gcloud.check_billing_enabled(self.project_id, self.organization_id)
 

--- a/install/gcp/installer/util/gcloud.py
+++ b/install/gcp/installer/util/gcloud.py
@@ -55,7 +55,6 @@ def activate_service_account(key_file):
     """Activate the service account with gcloud.
 
     Args:
-        service_account (str): Service account email
         key_file (str): Absolute path to service account key file
     """
 

--- a/install/gcp/installer/util/gcloud.py
+++ b/install/gcp/installer/util/gcloud.py
@@ -790,7 +790,7 @@ def check_vm_init_status(vm_name, zone):
         bool: Whether or not the VM has finished initializing.
     """
 
-    check_script_executed = '\"tail -n1 /tmp/deployment.log\"'
+    check_script_executed = 'tail -n1 /tmp/deployment.log'
 
     _, out, _ = utils.run_command(
         ['gcloud', 'compute', 'ssh', vm_name,

--- a/install/gcp/installer/util/gcloud.py
+++ b/install/gcp/installer/util/gcloud.py
@@ -51,7 +51,7 @@ def get_gcloud_info():
             sys.exit(1)
     return project_id, authed_user, is_devshell
 
-def activate_service_account(service_account, key_file):
+def activate_service_account(key_file):
     """Activate the service account with gcloud.
 
     Args:
@@ -61,7 +61,7 @@ def activate_service_account(service_account, key_file):
 
     return_code, _, err = utils.run_command(
         ['gcloud', 'auth', 'activate-service-account',
-         service_account, '--key-file=' + key_file])
+         '--key-file=' + key_file])
 
     if return_code:
         print(err)
@@ -791,7 +791,7 @@ def check_vm_init_status(vm_name, zone):
         bool: Whether or not the VM has finished initializing.
     """
 
-    check_script_executed = 'tail -n1 /tmp/deployment.log'
+    check_script_executed = '\"tail -n1 /tmp/deployment.log\"'
 
     _, out, _ = utils.run_command(
         ['gcloud', 'compute', 'ssh', vm_name,


### PR DESCRIPTION
Currently, gcloud will execute the invalid command, and then spam the log with the following error: 

ERROR: (gcloud.compute.ssh) unrecognized arguments:
  -n1
  /tmp/deployment.log

It turns out that the following command isn't actually valid for gcloud:

gcloud compute ssh forseti-server-vm-[random_hash] --zone us-central1-c --command tail -n1 /tmp/deployment.log --quiet

This is because --command expects a single command string. Thus, this works:

gcloud compute ssh forseti-server-vm-<random_hash> --zone us-central1-c --command "tail -n1 /tmp/deployment.log" --quiet

Additionally, Morgante and I noticed that the current SA support in gcloud.py requires the SA already be activated which is superfluous. Removed the need for the SA name since the credentials file should be a .json file.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [ ] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [ ] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [ ] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [ ] My PR has been functionally tested.
- [ ] All of the [unit-tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) still pass.
- [ ] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
