### PR TITLE
Added retry and fall back when google.auth.default() fails

### DIFF
--- a/google/cloud/forseti/common/gcp_api/_base_repository.py
+++ b/google/cloud/forseti/common/gcp_api/_base_repository.py
@@ -28,6 +28,7 @@ import google.auth
 from google.auth.credentials import with_scopes_if_required
 
 from google.cloud import forseti as forseti_security
+from google.cloud.forseti.common.gcp_api import api_helpers
 from google.cloud.forseti.common.gcp_api import _supported_apis
 from google.cloud.forseti.common.gcp_api import errors as api_errors
 from google.cloud.forseti.common.util import logger
@@ -175,7 +176,7 @@ class BaseRepositoryClient(object):
         if not credentials:
             # Only share the http object when using the default credentials.
             self._use_cached_http = True
-            credentials, _ = google.auth.default()
+            credentials, _ = api_helpers.get_google_default_credentials()
         self._credentials = with_scopes_if_required(credentials,
                                                     list(CLOUD_SCOPES))
 

--- a/google/cloud/forseti/common/gcp_api/_base_repository.py
+++ b/google/cloud/forseti/common/gcp_api/_base_repository.py
@@ -495,14 +495,14 @@ class GCPRepository(object):
             dict: The response from the API.
         """
         try:
-            self._execute_request(request)
+            return self._execute_request(request)
         except exceptions.RefreshError as e:
             # If there is problem refreshing the token, we will recreate a new
             # Credential object and use that to refresh the request.
             LOGGER.exception(e)
             self._credentials, _ = api_helpers.get_google_default_credentials()
             self._credentials.refresh(request)
-            self._execute_request(request)
+            return self._execute_request(request)
 
     def _execute_request(self, request):
         """Execute the request.

--- a/google/cloud/forseti/common/gcp_api/_base_repository.py
+++ b/google/cloud/forseti/common/gcp_api/_base_repository.py
@@ -173,6 +173,7 @@ class BaseRepositoryClient(object):
         if not credentials:
             # Only share the http object when using the default credentials.
             credentials, _ = api_helpers.get_google_default_credentials()
+        self._credentials = credentials
 
         # Lock may be acquired multiple times in the same thread.
         self._repository_lock = threading.RLock()

--- a/google/cloud/forseti/common/gcp_api/_base_repository.py
+++ b/google/cloud/forseti/common/gcp_api/_base_repository.py
@@ -319,9 +319,9 @@ class GCPRepository(object):
             google_auth_httplib2.AuthorizedHttp: An Http instance authorized by
                 the credentials.
         """
-
+        new_cred = api_helpers.get_google_default_credentials()
         authorized_http = google_auth_httplib2.AuthorizedHttp(
-            self._credentials, http=_build_http())
+            new_cred, http=_build_http())
 
         return authorized_http
 

--- a/google/cloud/forseti/common/gcp_api/_base_repository.py
+++ b/google/cloud/forseti/common/gcp_api/_base_repository.py
@@ -24,7 +24,6 @@ from googleapiclient import discovery
 import httplib2
 from ratelimiter import RateLimiter
 from retrying import retry
-import google.auth
 from google.auth.credentials import with_scopes_if_required
 
 from google.cloud import forseti as forseti_security
@@ -34,9 +33,7 @@ from google.cloud.forseti.common.gcp_api import errors as api_errors
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.common.util import replay
 from google.cloud.forseti.common.util import retryable_exceptions
-import google.oauth2.credentials
 
-CLOUD_SCOPES = frozenset(['https://www.googleapis.com/auth/cloud-platform'])
 
 # Per request max wait timeout.
 HTTP_REQUEST_TIMEOUT = 30.0
@@ -177,8 +174,9 @@ class BaseRepositoryClient(object):
             # Only share the http object when using the default credentials.
             self._use_cached_http = True
             credentials, _ = api_helpers.get_google_default_credentials()
-        self._credentials = with_scopes_if_required(credentials,
-                                                    list(CLOUD_SCOPES))
+        self._credentials = with_scopes_if_required(
+            credentials,
+            list(api_helpers.CLOUD_SCOPES))
 
         # Lock may be acquired multiple times in the same thread.
         self._repository_lock = threading.RLock()

--- a/google/cloud/forseti/common/gcp_api/_base_repository.py
+++ b/google/cloud/forseti/common/gcp_api/_base_repository.py
@@ -175,9 +175,6 @@ class BaseRepositoryClient(object):
             # Only share the http object when using the default credentials.
             self._use_cached_http = True
             credentials, _ = api_helpers.get_google_default_credentials()
-        self._credentials = with_scopes_if_required(
-            credentials,
-            list(api_helpers.CLOUD_SCOPES))
 
         # Lock may be acquired multiple times in the same thread.
         self._repository_lock = threading.RLock()
@@ -500,7 +497,7 @@ class GCPRepository(object):
             # If there is problem refreshing the token, we will recreate a new
             # Credential object and use that to refresh the request.
             LOGGER.exception(e)
-            self._credentials, _ = api_helpers.get_google_default_credentials()
+            self._credentials = api_helpers.get_google_default_credentials()
             self._credentials.refresh(request)
             return self._execute_request(request)
 
@@ -522,6 +519,5 @@ class GCPRepository(object):
                                        num_retries=self._num_retries)
         return request.execute(http=self.http,
                                num_retries=self._num_retries)
-
 
 # pylint: enable=too-many-instance-attributes, too-many-arguments

--- a/google/cloud/forseti/common/gcp_api/api_helpers.py
+++ b/google/cloud/forseti/common/gcp_api/api_helpers.py
@@ -79,7 +79,7 @@ def get_delegated_credential(delegated_account, scopes):
 def get_google_default_credentials():
     """Get Google default credentials.
 
-    Returns
+    Returns:
         google.auth.credentials.Credentials: Credentials object.
     """
     return google.auth.default()

--- a/google/cloud/forseti/common/gcp_api/api_helpers.py
+++ b/google/cloud/forseti/common/gcp_api/api_helpers.py
@@ -79,10 +79,10 @@ def get_google_default_credentials():
         google.auth.credentials.Credentials:
             google auth credentials object.
     """
-    credentials, _ =  google.auth.default()
+    credentials, project_id = google.auth.default()
     credentials = with_scopes_if_required(
         credentials, list(CLOUD_SCOPES))
-    return credentials
+    return credentials, project_id
 
 
 

--- a/google/cloud/forseti/common/gcp_api/api_helpers.py
+++ b/google/cloud/forseti/common/gcp_api/api_helpers.py
@@ -49,7 +49,7 @@ def get_delegated_credential(delegated_account, scopes):
 
     # Get the "bootstrap" credentials that will be used to talk to the IAM
     # API to sign blobs.
-    bootstrap_credentials = get_google_default_credentials()
+    bootstrap_credentials, _ = get_google_default_credentials()
 
     # Refresh the boostrap credentials. This ensures that the information about
     # this account, notably the email, is populated.

--- a/google/cloud/forseti/common/gcp_api/api_helpers.py
+++ b/google/cloud/forseti/common/gcp_api/api_helpers.py
@@ -15,7 +15,7 @@
 """Helper functions for API clients."""
 
 import google.auth
-from google.auth import iam
+from google.auth import exceptions, iam
 from google.auth.credentials import with_scopes_if_required
 from google.auth.transport import requests
 from google.oauth2 import service_account
@@ -47,7 +47,7 @@ def get_delegated_credential(delegated_account, scopes, retry=5):
 
     try:
         return _get_delegated_credential(delegated_account, scopes)
-    except Exception as e:
+    except exceptions.DefaultCredentialsError as e:
         LOGGER.error(e, exc_info=True)
         return get_delegated_credential(delegated_account, scopes, retry-1)
 

--- a/google/cloud/forseti/common/gcp_api/api_helpers.py
+++ b/google/cloud/forseti/common/gcp_api/api_helpers.py
@@ -22,11 +22,12 @@ from google.auth.credentials import with_scopes_if_required
 from google.auth.transport import requests
 from google.oauth2 import service_account
 
-from google.cloud.forseti.common.gcp_api._base_repository import CLOUD_SCOPES
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.common.util import retryable_exceptions
 
 LOGGER = logger.get_logger(__name__)
+
+CLOUD_SCOPES = frozenset(['https://www.googleapis.com/auth/cloud-platform'])
 
 _TOKEN_URI = 'https://accounts.google.com/o/oauth2/token'
 

--- a/google/cloud/forseti/common/gcp_api/api_helpers.py
+++ b/google/cloud/forseti/common/gcp_api/api_helpers.py
@@ -49,11 +49,7 @@ def get_delegated_credential(delegated_account, scopes):
 
     # Get the "bootstrap" credentials that will be used to talk to the IAM
     # API to sign blobs.
-    bootstrap_credentials, _ = get_google_default_credentials()
-
-    bootstrap_credentials = with_scopes_if_required(
-        bootstrap_credentials,
-        list(CLOUD_SCOPES))
+    bootstrap_credentials = get_google_default_credentials()
 
     # Refresh the boostrap credentials. This ensures that the information about
     # this account, notably the email, is populated.
@@ -80,12 +76,14 @@ def get_google_default_credentials():
     """Get Google default credentials.
 
     Returns:
-        Tuple[~google.auth.credentials.Credentials, Optional[str]]:
-            the current environment's credentials and project ID. Project ID
-            may be None, which indicates that the Project ID could not be
-            ascertained from the environment.
+        google.auth.credentials.Credentials:
+            google auth credentials object.
     """
-    return google.auth.default()
+    credentials, _ =  google.auth.default()
+    credentials = with_scopes_if_required(
+        credentials, list(CLOUD_SCOPES))
+    return credentials
+
 
 
 def flatten_list_results(paged_results, item_key):

--- a/google/cloud/forseti/common/gcp_api/api_helpers.py
+++ b/google/cloud/forseti/common/gcp_api/api_helpers.py
@@ -23,7 +23,8 @@ from google.auth.transport import requests
 from google.oauth2 import service_account
 
 from google.cloud.forseti.common.gcp_api._base_repository import CLOUD_SCOPES
-from google.cloud.forseti.common.util import logger, retryable_exceptions
+from google.cloud.forseti.common.util import logger
+from google.cloud.forseti.common.util import retryable_exceptions
 
 LOGGER = logger.get_logger(__name__)
 

--- a/google/cloud/forseti/common/gcp_api/api_helpers.py
+++ b/google/cloud/forseti/common/gcp_api/api_helpers.py
@@ -80,7 +80,10 @@ def get_google_default_credentials():
     """Get Google default credentials.
 
     Returns:
-        google.auth.credentials.Credentials: Credentials object.
+        Tuple[~google.auth.credentials.Credentials, Optional[str]]:
+            the current environment's credentials and project ID. Project ID
+            may be None, which indicates that the Project ID could not be
+            ascertained from the environment.
     """
     return google.auth.default()
 

--- a/google/cloud/forseti/common/util/retryable_exceptions.py
+++ b/google/cloud/forseti/common/util/retryable_exceptions.py
@@ -21,8 +21,11 @@ import urllib2
 
 import httplib2
 
+from google.auth import exceptions
+
 
 RETRYABLE_EXCEPTIONS = (
+    exceptions.DefaultCredentialsError,
     httplib.ResponseNotReady,
     httplib.IncompleteRead,
     httplib2.ServerNotFoundError,

--- a/google/cloud/forseti/services/inventory/inventory.py
+++ b/google/cloud/forseti/services/inventory/inventory.py
@@ -255,7 +255,7 @@ class Inventory(object):
                     return result.get_summary()
 
                 except Exception as e:
-                    LOGGER.error(e, exc_info=True)
+                    LOGGER.exception(e)
                     queue.put(e)
                     queue.put(None)
 

--- a/google/cloud/forseti/services/inventory/inventory.py
+++ b/google/cloud/forseti/services/inventory/inventory.py
@@ -255,7 +255,7 @@ class Inventory(object):
                     return result.get_summary()
 
                 except Exception as e:
-                    LOGGER.exception(e)
+                    LOGGER.error(e, exc_info=True)
                     queue.put(e)
                     queue.put(None)
 

--- a/tests/common/gcp_api/api_helpers_test.py
+++ b/tests/common/gcp_api/api_helpers_test.py
@@ -21,7 +21,6 @@ from tests import unittest_utils
 import google.auth
 from google.auth.compute_engine import credentials as service_account
 from google.cloud.forseti.common.gcp_api import api_helpers
-from google.cloud.forseti.common.gcp_api._base_repository import CLOUD_SCOPES
 
 
 FAKE_REQUIRED_SCOPES = frozenset([
@@ -44,7 +43,7 @@ class ApiHelpersTest(unittest_utils.ForsetiTestCase):
 
     def test_required_scope_in_private_module_has_not_changed(self):
         required_scope = 'https://www.googleapis.com/auth/cloud-platform'
-        self.assertTrue(required_scope in list(CLOUD_SCOPES))
+        self.assertTrue(required_scope in list(api_helpers.CLOUD_SCOPES))
 
 
 if __name__ == '__main__':

--- a/tests/common/gcp_api/base_repository_test.py
+++ b/tests/common/gcp_api/base_repository_test.py
@@ -220,8 +220,7 @@ class BaseRepositoryTest(unittest_utils.ForsetiTestCase):
         repo = base.GCPRepository(
             gcp_service=gcp_service_mock,
             credentials=credentials_mock,
-            component='fake_component',
-            use_cached_http=True)
+            component='fake_component')
 
         http_objects = [None] * 2
         t1 = threading.Thread(target=get_http, args=(repo, http_objects, 0))
@@ -250,33 +249,10 @@ class BaseRepositoryTest(unittest_utils.ForsetiTestCase):
             repo = base.GCPRepository(
                 gcp_service=gcp_service_mock,
                 credentials=fake_credentials,
-                component='fake_component{}'.format(i),
-                use_cached_http=False)
+                component='fake_component{}'.format(i))
             http_objects[i] = repo.http
 
         self.assertNotEqual(http_objects[0], http_objects[1])
-
-    @mock.patch('google.auth.crypt.rsa.RSASigner.from_string',
-                return_value=object())
-    def test_use_cached_http_gets_same_http_objects(self, signer_factory):
-        """Different clients with the same credential get the same http object.
-
-        This verifies that a new http object is not created when two
-        repository clients use the same credentials object.
-        """
-        fake_credentials = self.get_test_credential()
-
-        http_objects = [None] * 2
-        for i in range(2):
-            gcp_service_mock = mock.Mock()
-            repo = base.GCPRepository(
-                gcp_service=gcp_service_mock,
-                credentials=fake_credentials,
-                component='fake_component{}'.format(i),
-                use_cached_http=True)
-            http_objects[i] = repo.http
-
-        self.assertEqual(http_objects[0], http_objects[1])
 
 
 if __name__ == '__main__':

--- a/tests/common/gcp_api/base_repository_test.py
+++ b/tests/common/gcp_api/base_repository_test.py
@@ -25,6 +25,7 @@ from google.oauth2 import service_account
 
 from tests import unittest_utils
 from google.cloud import forseti as forseti_security
+from google.cloud.forseti.common.gcp_api import api_helpers
 from google.cloud.forseti.common.gcp_api import _base_repository as base
 from google.cloud.forseti.common.gcp_api import _supported_apis
 
@@ -76,7 +77,7 @@ class BaseRepositoryTest(unittest_utils.ForsetiTestCase):
         creds = self.get_test_service_account()
         self.assertTrue(creds.requires_scopes)
         scoped_creds = base.with_scopes_if_required(
-            creds, list(base.CLOUD_SCOPES))
+            creds, list(api_helpers.CLOUD_SCOPES))
         self.assertFalse(scoped_creds.requires_scopes)
 
     @mock.patch.object(discovery, 'build', autospec=True)

--- a/tests/common/gcp_api/securitycenter_test.py
+++ b/tests/common/gcp_api/securitycenter_test.py
@@ -50,10 +50,12 @@ class SecurityCenterTest(unittest_utils.ForsetiTestCase):
         securitycenter_api_client = securitycenter.SecurityCenterClient()
         self.assertEqual(None, securitycenter_api_client.repository._rate_limiter)
 
-    def test_create_findings(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_create_findings(self, fake_http):
         """Test create cscc findings."""
-        
-        http_mocks.mock_http_response(
+
+        fake_http.return_value = http_mocks.mock_http_response(
             json.dumps(fake_cscc.EXPECTED_CREATE_FINDING_RESULT))
 
         result = self.securitycenter_api_client.create_finding(
@@ -61,9 +63,11 @@ class SecurityCenterTest(unittest_utils.ForsetiTestCase):
 
         self.assertEquals(fake_cscc.EXPECTED_CREATE_FINDING_RESULT, result)
 
-    def test_create_findings_raises(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_create_findings_raises(self, fake_http):
         """Test create cscc finding raises exception."""
-        http_mocks.mock_http_response(fake_cscc.PERMISSION_DENIED, '403')
+        fake_http.return_value = http_mocks.mock_http_response(fake_cscc.PERMISSION_DENIED, '403')
 
         with self.assertRaises(api_errors.ApiExecutionError):
             self.securitycenter_api_client.create_finding(

--- a/tests/common/gcp_api/servicemanagement_test.py
+++ b/tests/common/gcp_api/servicemanagement_test.py
@@ -50,21 +50,26 @@ class ServiceManagementClientTest(unittest_utils.ForsetiTestCase):
             global_configs={})
         self.assertEqual(None, sm_api_client.repository._rate_limiter)
 
-    def test_get_enabled_apis(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_enabled_apis(self, fake_http):
         """Test that get_enabled_apis returns correctly."""
+
         mock_responses = []
         for page in fake_sm.LIST_CONSUMER_SERVICES_RESPONSES:
             mock_responses.append(({'status': '200'}, page))
-        http_mocks.mock_http_response_sequence(mock_responses)
+        fake_http.return_value = http_mocks.mock_http_response_sequence(mock_responses)
 
         return_value = self.sm_api_client.get_enabled_apis(
             fake_sm.FAKE_PROJECT_ID)
 
         self.assertEquals(fake_sm.EXPECTED_SERVICES_COUNT, len(return_value))
 
-    def test_get_enabled_apis_raises(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_enabled_apis_raises(self, fake_http):
         """Test get cloudsql instances."""
-        http_mocks.mock_http_response(fake_sm.PERMISSION_DENIED, '403')
+        fake_http.return_value = http_mocks.mock_http_response(fake_sm.PERMISSION_DENIED, '403')
 
         with self.assertRaises(api_errors.ApiExecutionError):
              self.sm_api_client.get_enabled_apis(fake_sm.FAKE_PROJECT_ID)

--- a/tests/common/gcp_api/storage_test.py
+++ b/tests/common/gcp_api/storage_test.py
@@ -60,12 +60,14 @@ class StorageTest(unittest_utils.ForsetiTestCase):
         with self.assertRaises(api_errors.InvalidBucketPathError):
             storage.get_bucket_and_path_from(None)
 
-    def test_get_buckets(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_buckets(self, fake_http):
         """Test get buckets."""
         mock_responses = []
         for page in fake_storage.GET_BUCKETS_RESPONSES:
             mock_responses.append(({'status': '200'}, page))
-        http_mocks.mock_http_response_sequence(mock_responses)
+        fake_http.return_value = http_mocks.mock_http_response_sequence(mock_responses)
 
         expected_bucket_names = fake_storage.EXPECTED_FAKE_BUCKET_NAMES
 
@@ -74,30 +76,38 @@ class StorageTest(unittest_utils.ForsetiTestCase):
         self.assertEquals(expected_bucket_names,
                           [r.get('name') for r in results])
 
-    def test_get_buckets_raises(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_buckets_raises(self, fake_http):
         """Test get buckets access forbidden."""
-        http_mocks.mock_http_response(fake_storage.ACCESS_FORBIDDEN, '403')
+        fake_http.return_value = http_mocks.mock_http_response(fake_storage.ACCESS_FORBIDDEN, '403')
 
         with self.assertRaises(api_errors.ApiExecutionError):
             self.gcs_api_client.get_buckets(fake_storage.FAKE_PROJECT_NUMBER)
 
-    def test_get_bucket_acls(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_bucket_acls(self, fake_http):
         """Test get bucket acls."""
-        http_mocks.mock_http_response(
+        fake_http.return_value = http_mocks.mock_http_response(
             fake_storage.GET_BUCKET_ACL)
 
         results = self.gcs_api_client.get_bucket_acls(
             fake_storage.FAKE_BUCKET_NAME)
         self.assertEqual(3, len(results))
 
-    def test_get_buckets_acls_raises(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_buckets_acls_raises(self, fake_http):
         """Test get buckets acls access forbidden."""
-        http_mocks.mock_http_response(fake_storage.ACCESS_FORBIDDEN, '403')
+        fake_http.return_value = http_mocks.mock_http_response(fake_storage.ACCESS_FORBIDDEN, '403')
 
         with self.assertRaises(api_errors.ApiExecutionError):
             self.gcs_api_client.get_bucket_acls(fake_storage.FAKE_BUCKET_NAME)
 
-    def test_get_buckets_acls_user_project(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_buckets_acls_user_project(self, fake_http):
         """Test get buckets acls requires user project."""
         mock_responses = [
             ({'status': '400', 'content-type': 'application/json'},
@@ -105,30 +115,36 @@ class StorageTest(unittest_utils.ForsetiTestCase):
             ({'status': '200', 'content-type': 'application/json'},
              fake_storage.GET_BUCKET_ACL),
         ]
-        http_mocks.mock_http_response_sequence(mock_responses)
+        fake_http.return_value = http_mocks.mock_http_response_sequence(mock_responses)
 
         results = self.gcs_api_client.get_bucket_acls(
             fake_storage.FAKE_BUCKET_NAME)
         self.assertEqual(3, len(results))
 
-    def test_get_bucket_iam_policy(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_bucket_iam_policy(self, fake_http):
         """Test get bucket iam policy."""
-        http_mocks.mock_http_response(
+        fake_http.return_value = http_mocks.mock_http_response(
             fake_storage.GET_BUCKET_IAM_POLICY_RESPONSE)
 
         results = self.gcs_api_client.get_bucket_iam_policy(
             fake_storage.FAKE_BUCKET_NAME)
         self.assertTrue('bindings' in results)
 
-    def test_get_buckets_iam_policy_raises(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_buckets_iam_policy_raises(self, fake_http):
         """Test get buckets iam policy access forbidden."""
-        http_mocks.mock_http_response(fake_storage.ACCESS_FORBIDDEN, '403')
+        fake_http.return_value = http_mocks.mock_http_response(fake_storage.ACCESS_FORBIDDEN, '403')
 
         with self.assertRaises(api_errors.ApiExecutionError):
             self.gcs_api_client.get_bucket_iam_policy(
                 fake_storage.FAKE_BUCKET_NAME)
 
-    def test_get_bucket_iam_policy_user_project(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_bucket_iam_policy_user_project(self, fake_http):
         """Test get bucket iam policy requires user project."""
         mock_responses = [
             ({'status': '400', 'content-type': 'application/json'},
@@ -136,30 +152,36 @@ class StorageTest(unittest_utils.ForsetiTestCase):
             ({'status': '200', 'content-type': 'application/json'},
              fake_storage.GET_BUCKET_IAM_POLICY_RESPONSE),
         ]
-        http_mocks.mock_http_response_sequence(mock_responses)
+        fake_http.return_value = http_mocks.mock_http_response_sequence(mock_responses)
 
         results = self.gcs_api_client.get_bucket_iam_policy(
             fake_storage.FAKE_BUCKET_NAME)
         self.assertTrue('bindings' in results)
 
-    def test_get_default_object_acls(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_default_object_acls(self, fake_http):
         """Test get default object acls."""
-        http_mocks.mock_http_response(
+        fake_http.return_value = http_mocks.mock_http_response(
             fake_storage.DEFAULT_OBJECT_ACL)
 
         results = self.gcs_api_client.get_default_object_acls(
             fake_storage.FAKE_BUCKET_NAME)
         self.assertEqual(3, len(results))
 
-    def test_get_default_object_acls_raises(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_default_object_acls_raises(self, fake_http):
         """Test get default object acls access forbidden."""
-        http_mocks.mock_http_response(fake_storage.ACCESS_FORBIDDEN, '403')
+        fake_http.return_value = http_mocks.mock_http_response(fake_storage.ACCESS_FORBIDDEN, '403')
 
         with self.assertRaises(api_errors.ApiExecutionError):
             self.gcs_api_client.get_default_object_acls(
                  fake_storage.FAKE_BUCKET_NAME)
 
-    def test_get_default_object_acls_user_project(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_default_object_acls_user_project(self, fake_http):
         """Test get default object acls requires user project."""
         mock_responses = [
             ({'status': '400', 'content-type': 'application/json'},
@@ -167,18 +189,20 @@ class StorageTest(unittest_utils.ForsetiTestCase):
             ({'status': '200', 'content-type': 'application/json'},
              fake_storage.DEFAULT_OBJECT_ACL),
         ]
-        http_mocks.mock_http_response_sequence(mock_responses)
+        fake_http.return_value = http_mocks.mock_http_response_sequence(mock_responses)
 
         results = self.gcs_api_client.get_default_object_acls(
             fake_storage.FAKE_BUCKET_NAME)
         self.assertEqual(3, len(results))
 
-    def test_get_objects(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_objects(self, fake_http):
         """Test get objects."""
         mock_responses = []
         for page in fake_storage.LIST_OBJECTS_RESPONSES:
             mock_responses.append(({'status': '200'}, page))
-        http_mocks.mock_http_response_sequence(mock_responses)
+        fake_http.return_value = http_mocks.mock_http_response_sequence(mock_responses)
 
         expected_object_names = fake_storage.EXPECTED_FAKE_OBJECT_NAMES
 
@@ -187,14 +211,18 @@ class StorageTest(unittest_utils.ForsetiTestCase):
         self.assertEquals(expected_object_names,
                           [r.get('name') for r in results])
 
-    def test_get_objects_raises(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_objects_raises(self, fake_http):
         """Test get objects bucket not found."""
-        http_mocks.mock_http_response(fake_storage.NOT_FOUND, '404')
+        fake_http.return_value = http_mocks.mock_http_response(fake_storage.NOT_FOUND, '404')
 
         with self.assertRaises(api_errors.ApiExecutionError):
             self.gcs_api_client.get_objects(fake_storage.FAKE_PROJECT_NUMBER)
 
-    def test_get_objects_user_project(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_objects_user_project(self, fake_http):
         """Test get objects requires user project."""
         mock_responses = [
             ({'status': '400', 'content-type': 'application/json'},
@@ -202,7 +230,7 @@ class StorageTest(unittest_utils.ForsetiTestCase):
 
         for page in fake_storage.LIST_OBJECTS_RESPONSES:
             mock_responses.append(({'status': '200'}, page))
-        http_mocks.mock_http_response_sequence(mock_responses)
+        fake_http.return_value = http_mocks.mock_http_response_sequence(mock_responses)
 
         expected_object_names = fake_storage.EXPECTED_FAKE_OBJECT_NAMES
 
@@ -211,24 +239,30 @@ class StorageTest(unittest_utils.ForsetiTestCase):
         self.assertEquals(expected_object_names,
                           [r.get('name') for r in results])
 
-    def test_get_object_iam_policy(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_object_iam_policy(self, fake_http):
         """Test get object iam policy."""
-        http_mocks.mock_http_response(
+        fake_http.return_value = http_mocks.mock_http_response(
             fake_storage.GET_OBJECT_IAM_POLICY_RESPONSE)
 
         results = self.gcs_api_client.get_object_iam_policy(
             fake_storage.FAKE_BUCKET_NAME, fake_storage.FAKE_OBJECT_NAME)
         self.assertTrue('bindings' in results)
 
-    def test_get_objects_iam_policy_raises(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_objects_iam_policy_raises(self, fake_http):
         """Test get objects iam policy access forbidden."""
-        http_mocks.mock_http_response(fake_storage.ACCESS_FORBIDDEN, '403')
+        fake_http.return_value = http_mocks.mock_http_response(fake_storage.ACCESS_FORBIDDEN, '403')
 
         with self.assertRaises(api_errors.ApiExecutionError):
             self.gcs_api_client.get_object_iam_policy(
                 fake_storage.FAKE_BUCKET_NAME, fake_storage.FAKE_OBJECT_NAME)
 
-    def test_get_object_iam_policy_user_project(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_object_iam_policy_user_project(self, fake_http):
         """Test get object iam policy requires user project."""
         mock_responses = [
             ({'status': '400', 'content-type': 'application/json'},
@@ -236,30 +270,34 @@ class StorageTest(unittest_utils.ForsetiTestCase):
             ({'status': '200', 'content-type': 'application/json'},
              fake_storage.GET_OBJECT_IAM_POLICY_RESPONSE),
         ]
-        http_mocks.mock_http_response_sequence(mock_responses)
+        fake_http.return_value = http_mocks.mock_http_response_sequence(mock_responses)
 
         results = self.gcs_api_client.get_object_iam_policy(
             fake_storage.FAKE_BUCKET_NAME, fake_storage.FAKE_OBJECT_NAME)
         self.assertTrue('bindings' in results)
 
-    def test_get_object_acls(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_object_acls(self, fake_http):
         """Test get object acls."""
-        http_mocks.mock_http_response(
+        fake_http.return_value = http_mocks.mock_http_response(
             fake_storage.GET_OBJECT_ACL)
 
         results = self.gcs_api_client.get_object_acls(
             fake_storage.FAKE_BUCKET_NAME, fake_storage.FAKE_OBJECT_NAME)
         self.assertEqual(4, len(results))
 
-    def test_get_objects_iam_policy_raises(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_objects_iam_policy_raises(self, fake_http):
         """Test get object acls access forbidden."""
-        http_mocks.mock_http_response(fake_storage.ACCESS_FORBIDDEN, '403')
+        fake_http.return_value = http_mocks.mock_http_response(fake_storage.ACCESS_FORBIDDEN, '403')
 
         with self.assertRaises(api_errors.ApiExecutionError):
             self.gcs_api_client.get_object_acls(
                 fake_storage.FAKE_BUCKET_NAME, fake_storage.FAKE_OBJECT_NAME)
 
-    def test_get_object_acls_user_project(self):
+    def test_get_object_acls_user_project(self, fake_http):
         """Test get object acls requires user project."""
         mock_responses = [
             ({'status': '400', 'content-type': 'application/json'},
@@ -272,8 +310,9 @@ class StorageTest(unittest_utils.ForsetiTestCase):
             fake_storage.FAKE_BUCKET_NAME, fake_storage.FAKE_OBJECT_NAME)
         self.assertEqual(4, len(results))
 
-
-    def test_get_text_file(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_text_file(self, fake_http):
         """Test get test file returns a valid response."""
         mock_responses = [
             ({'status': '200',
@@ -281,7 +320,7 @@ class StorageTest(unittest_utils.ForsetiTestCase):
             ({'status': '200',
               'content-range': '3-4/5'}, b'45')
         ]
-        http_mocks.mock_http_response_sequence(mock_responses)
+        fake_http.return_value = http_mocks.mock_http_response_sequence(mock_responses)
 
         expected_result = b'12345'
         result = self.gcs_api_client.get_text_file(
@@ -289,18 +328,22 @@ class StorageTest(unittest_utils.ForsetiTestCase):
                                 fake_storage.FAKE_OBJECT_NAME))
         self.assertEqual(expected_result, result)
 
-    def test_get_text_file_raises(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_get_text_file_raises(self, fake_http):
         """Test get test file returns not found error."""
-        http_mocks.mock_http_response(fake_storage.NOT_FOUND, '404')
+        fake_http.return_value = http_mocks.mock_http_response(fake_storage.NOT_FOUND, '404')
 
         with self.assertRaises(storage.errors.HttpError):
             self.gcs_api_client.get_text_file(
                 'gs://{}/{}'.format(fake_storage.FAKE_BUCKET_NAME,
                                     fake_storage.FAKE_OBJECT_NAME))
 
-    def test_upload_text_file(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_upload_text_file(self, fake_http):
         """Test upload text file."""
-        http_mocks.mock_http_response(u'{}')
+        fake_http.return_value = http_mocks.mock_http_response(u'{}')
 
         with unittest_utils.create_temp_file(b'12345') as temp_file:
             result = self.gcs_api_client.put_text_file(
@@ -309,9 +352,11 @@ class StorageTest(unittest_utils.ForsetiTestCase):
                                     fake_storage.FAKE_OBJECT_NAME))
         self.assertEqual({}, result)
 
-    def test_upload_text_file_raises(self):
+    @mock.patch('google.cloud.forseti.common.gcp_api.servicemanagement._base_repository.GCPRepository.http',
+                new_callable=mock.PropertyMock)
+    def test_upload_text_file_raises(self, fake_http):
         """Test upload text access forbidden."""
-        http_mocks.mock_http_response(fake_storage.ACCESS_FORBIDDEN, '403')
+        fake_http.return_value = http_mocks.mock_http_response(fake_storage.ACCESS_FORBIDDEN, '403')
 
         with self.assertRaises(storage.errors.HttpError):
             with unittest_utils.create_temp_file(b'12345') as temp_file:

--- a/tests/common/gcp_api/test_data/http_mocks.py
+++ b/tests/common/gcp_api/test_data/http_mocks.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 """Test data for firewall api responses."""
-
 from googleapiclient import http
-from google.cloud.forseti.common.gcp_api import _base_repository
 
 
 def mock_http_response(response, status='200'):
@@ -26,10 +24,10 @@ def mock_http_response(response, status='200'):
         'content-type': 'application/json',
     }
     http_mock.data = response
-    _base_repository.LOCAL_THREAD.http = http_mock
+    return http_mock
 
 
 def mock_http_response_sequence(responses):
     """Set the mock response to an http request."""
     http_mock = http.HttpMockSequence(responses)
-    _base_repository.LOCAL_THREAD.http = http_mock
+    return http_mock


### PR DESCRIPTION
Credentials will be None if google.auth.default() still failed after 5 trials and the inventory should proceed with other resources.

Resolves #1832