### PR TITLE
Shorten the violation hash id to 32 characters for upload to CSCC

### DIFF
--- a/google/cloud/forseti/notifier/notifiers/cscc_notifier.py
+++ b/google/cloud/forseti/notifier/notifiers/cscc_notifier.py
@@ -119,7 +119,7 @@ class CsccNotifier(object):
         for violation in violations:
             finding = {
                 # CSCC can't accept the full hash, so this must be shortened.
-                'id': violation.get('violation_hash')[:64],
+                'id': violation.get('violation_hash')[:32],
                 'assetIds': [
                     violation.get('full_name')
                 ],

--- a/tests/notifier/notifiers/cscc_notifier_test.py
+++ b/tests/notifier/notifiers/cscc_notifier_test.py
@@ -60,7 +60,7 @@ class CsccNotifierTest(ScannerBaseDbTestCase):
             {'assetIds': ['full_name_111'],
              'category': 'UNKNOWN_RISK',
              'eventTime': '2010-08-28T10:20:30Z',
-             'id': '539cfbdb1113a74ec18edf583eada77ab1a60542c6edcb4120b50f34629b6b69',
+             'id': '539cfbdb1113a74ec18edf583eada77a',
              'properties': {
                  'inventory_index_id': 'iii',
                  'resource_data': 'inventory_data_111',
@@ -73,7 +73,7 @@ class CsccNotifierTest(ScannerBaseDbTestCase):
             {'assetIds': ['full_name_222'],
              'category': 'UNKNOWN_RISK',
              'eventTime': '2010-08-28T10:20:30Z',
-             'id': '3eff279ccb96799d9eb18e6b76055b2242d1f2e6f14c1fb3bb48f7c8c03b4ce4',
+             'id': '3eff279ccb96799d9eb18e6b76055b22',
              'properties': {
                  'inventory_index_id': 'iii',
                  'resource_data': 'inventory_data_222',


### PR DESCRIPTION
Moving forward, CSCC will only accept 32 characters for the violation id.  FYI: @mcapts