### PR TITLE
Adding solution for error repeatedly encountered in forseti setup

### DIFF
--- a/_docs/_latest/develop/dev/setup.md
+++ b/_docs/_latest/develop/dev/setup.md
@@ -153,6 +153,14 @@ try the following:
 
 ``sudo apt install default-libmysqlclient-dev``
 
+------------------
+
+If on Linux executing ``workon forseti-security``
+results in ``bash: workon: command not found`` then
+check whether workon is in the source path. Try:
+
+``source /usr/local/bin/virtualenvwrapper.sh``
+
 ## Configuring Forseti settings
 
 Before you run Forseti, you need to edit the forseti configuration file.

--- a/_docs/_latest/develop/dev/setup.md
+++ b/_docs/_latest/develop/dev/setup.md
@@ -157,9 +157,12 @@ try the following:
 
 If on Linux executing ``workon forseti-security``
 results in ``bash: workon: command not found`` then
-check whether workon is in the source path. Try:
+ensure ``workon`` is in the source path. Try fixing
+source path issue by executing the following:
 
 ``source /usr/local/bin/virtualenvwrapper.sh``
+
+and then trying ``workon forseti-security`` again.
 
 ## Configuring Forseti settings
 


### PR DESCRIPTION
"bash: workon: command not found" and its solution on Linux machine.
