### PR TITLE
[Issue 1848] Fix error in tests that stemmed from test object not being reset after each test.

### DIFF
--- a/tests/notifier/notifier_test.py
+++ b/tests/notifier/notifier_test.py
@@ -28,6 +28,9 @@ class NotifierTest(ForsetiTestCase):
     def setUp(self):
         pass
 
+    def tearDown(self):
+        reload(notifier)
+
     def test_can_convert_created_at_datetime_to_timestamp_string(self):
         violations = [
             dict(created_at_datetime=datetime(1999, 12, 25, 1, 2, 3)),
@@ -140,6 +143,7 @@ class NotifierTest(ForsetiTestCase):
         Expected outcome:
             The local find_notifiers() function is never called -> no notifiers
             are looked up, istantiated or run."""
+        reload(notifier)
         mock_dao.get_latest_scanner_index_id.return_value = None
         mock_service_cfg = mock.MagicMock()
         mock_service_cfg.get_global_config.return_value = fake_violations.GLOBAL_CONFIGS


### PR DESCRIPTION
Helps fix #1848 

BEFORE
```bash
docker -l error exec -it build /bin/bash -c "python -m unittest discover --verbose -s tests/notifier -p '*_test.py'"

test_notifications_are_not_sent_without_valid_scanner_index_id (notifier_test.NotifierTest)
The email/GCS upload notifiers are instantiated/run. ... ERROR:google.cloud.forseti.notifier.notifier:No success or partial success scanner index found for inventory index: "iid-1-2-3".
ok

# Tests clearly leak because running specific test is fine
docker -l error exec -it build /bin/bash -c "python -m unittest --verbose tests.notifier.notifier_test.NotifierTest.test_notifications_are_not_sent_without_valid_scanner_index_id"
test_notifications_are_not_sent_without_valid_scanner_index_id (tests.notifier.notifier_test.NotifierTest)
The email/GCS upload notifiers are instantiated/run. ... ok
```

AFTER
```bash
docker -l error exec -it build /bin/bash -c "python -m unittest discover --verbose -s tests/notifier -p '*_test.py'"

test_notifications_are_not_sent_without_valid_scanner_index_id (notifier_test.NotifierTest)
ok
```