### PR TITLE
Added requriemodel decorator to the scanner run method, pin the version of rumael.yaml library

### DIFF
--- a/google/cloud/forseti/services/client.py
+++ b/google/cloud/forseti/services/client.py
@@ -124,6 +124,7 @@ class ScannerClient(ForsetiClient):
         echo = self.stub.Ping(scanner_pb2.PingRequest(data=data)).data
         return echo == data
 
+    @require_model
     def run(self):
         """Runs the scanner
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ REQUIRED_PACKAGES = [
     # Testing related.
     'mock>=2.0.0',
     'parameterized>=0.6.1',
-    'ruamel.yaml>=0.15.35',
+    'ruamel.yaml==0.15.37',
     'pylint',
     'pylint-quotes',
     'SQLAlchemy>=1.1.9',


### PR DESCRIPTION
The library version is required to avoid unit tests failure, the newer version of rumael.yaml is not backward compatible with the version that we were using.

Resolves #1655