### PR TITLE
[Issue 1848] Update docker_unittest_forseti.sh

### DIFF
--- a/install/scripts/docker_unittest_forseti.sh
+++ b/install/scripts/docker_unittest_forseti.sh
@@ -19,8 +19,8 @@ echo "Running unittests... "
 if [ ${TRAVIS+x} ]; then
     # We are on Travis.
     # Run our tests with codecov
-    docker -l error exec -it build /bin/bash -c "coverage run --source='google.cloud.forseti' --omit='__init__.py' -m unittest discover -s . -p '*_test.py'"
+    docker -l error exec -it build /bin/bash -c "coverage run --source='google.cloud.forseti' --omit='__init__.py' -m unittest discover --verbose -s . -p '*_test.py'"
 else
     # We are NOT on Travis.
-    docker -l error exec -it build /bin/bash -c "python -m unittest discover -s . -p '*_test.py'"
+    docker -l error exec -it build /bin/bash -c "python -m unittest discover --verbose -s . -p '*_test.py'"
 fi


### PR DESCRIPTION
Helping fix #1848 by adding verbose logging so we can see the status of each individual unit test. This will allow us to see which tests are spewing out logs and go fix them.