### PR TITLE
Templatize Forseti server region and Zone

### DIFF
--- a/deployment-templates/compute-engine/server/forseti-instance-server.py.schema
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py.schema
@@ -25,7 +25,7 @@ required:
 - zone
 - service-account
 - service-account-scopes
-- service-account-gsuite
+# - service-account-gsuite
 - scanner-bucket
 - database-name
 - src-path

--- a/deployment-templates/deploy-forseti-server.yaml.in
+++ b/deployment-templates/deploy-forseti-server.yaml.in
@@ -51,8 +51,8 @@ resources:
     image-project: ubuntu-os-cloud
     image-family: ubuntu-1804-lts
     instance-type: n1-standard-2
-    region:  $(ref.cloudsql-instance.region)
-    zone:  $(ref.cloudsql-instance.region)-c
+    region:  {FORSETI_SERVER_REGION}
+    zone:  {FORSETI_SERVER_ZONE}
 
     service-account: {GCP_SERVER_SERVICE_ACCOUNT}
     service-account-scopes:

--- a/install/gcp/installer/forseti_server_installer.py
+++ b/install/gcp/installer/forseti_server_installer.py
@@ -273,7 +273,7 @@ class ForsetiServerInstaller(ForsetiInstaller):
             'BUCKET_LOCATION': self.config.bucket_location,
             'GCP_SERVER_SERVICE_ACCOUNT': self.gcp_service_acct_email,
             'FORSETI_SERVER_REGION': self.config.cloudsql_region,
-            'FORSETI_SERVER_ZONE': str(self.config.cloudsql_region) + '-c',
+            'FORSETI_SERVER_ZONE': self.config.cloudsql_region + '-c',
             'VPC_HOST_PROJECT_ID': self.config.vpc_host_project_id,
             'VPC_HOST_NETWORK': self.config.vpc_host_network,
             'VPC_HOST_SUBNETWORK': self.config.vpc_host_subnetwork,

--- a/install/gcp/installer/forseti_server_installer.py
+++ b/install/gcp/installer/forseti_server_installer.py
@@ -272,6 +272,8 @@ class ForsetiServerInstaller(ForsetiInstaller):
             'FORSETI_BUCKET': bucket_name[len('gs://'):],
             'BUCKET_LOCATION': self.config.bucket_location,
             'GCP_SERVER_SERVICE_ACCOUNT': self.gcp_service_acct_email,
+            'FORSETI_SERVER_REGION': self.config.cloudsql_region,
+            'FORSETI_SERVER_ZONE': str(self.config.cloudsql_region) + '-c',
             'VPC_HOST_PROJECT_ID': self.config.vpc_host_project_id,
             'VPC_HOST_NETWORK': self.config.vpc_host_network,
             'VPC_HOST_SUBNETWORK': self.config.vpc_host_subnetwork,

--- a/rules/bigquery_rules.yaml
+++ b/rules/bigquery_rules.yaml
@@ -24,7 +24,7 @@ rules:
     resource:
       - type: organization
         resource_ids:
-          - {ORGANIZATION_ID}
+          - 826592752744
   - name: sample BigQuery rule to search for datasets accessible by users with gmail.com addresses
     dataset_id: '*'
     special_group: '*'
@@ -35,7 +35,7 @@ rules:
     resource:
       - type: organization
         resource_ids:
-          - {ORGANIZATION_ID}
+          - 826592752744
   - name: sample BigQuery rule to search for datasets accessible by groups with googlegroups.com addresses
     dataset_id: '*'
     special_group: '*'
@@ -46,4 +46,4 @@ rules:
     resource:
       - type: organization
         resource_ids:
-          - {ORGANIZATION_ID}
+          - 826592752744

--- a/rules/bucket_rules.yaml
+++ b/rules/bucket_rules.yaml
@@ -21,7 +21,7 @@ rules:
     role: '*'
     resource:
         - resource_ids:
-          - {ORGANIZATION_ID}
+          - 826592752744
   - name: sample bucket acls rule to search for exposed buckets
     bucket: '*'
     entity: allAuthenticatedUsers
@@ -30,4 +30,4 @@ rules:
     role: '*' 
     resource:
         - resource_ids:
-          - {ORGANIZATION_ID}
+          - 826592752744

--- a/rules/cloudsql_rules.yaml
+++ b/rules/cloudsql_rules.yaml
@@ -20,7 +20,7 @@ rules:
     resource:
       - type: organization
         resource_ids:
-          - {ORGANIZATION_ID}
+          - 826592752744
   - name: sample Cloud SQL rule to search for publicly exposed instances (SSL enabled)
     instance_name: '*'
     authorized_networks: '0.0.0.0/0'
@@ -28,5 +28,5 @@ rules:
     resource:
       - type: organization
         resource_ids:
-          - {ORGANIZATION_ID}
+          - 826592752744
 

--- a/rules/firewall_rules.yaml
+++ b/rules/firewall_rules.yaml
@@ -49,7 +49,7 @@ org_policy:
   resources:
     - type: organization
       resource_ids:
-        - {ORGANIZATION_ID}
+        - 826592752744
       rules:
         group_ids:
           - 'default_rules'

--- a/rules/group_rules.yaml
+++ b/rules/group_rules.yaml
@@ -17,7 +17,7 @@
   mode: whitelist
   conditions:
       # Must use quotes if the condition starts with @ symbol.
-    - member_email: "@{DOMAIN}"
+    - member_email: "@phoogle.net"
     - member_email: "@gmail.com"
 
 #- name: Allow mypartner users to be in a group.

--- a/rules/iam_rules.yaml
+++ b/rules/iam_rules.yaml
@@ -25,8 +25,8 @@ rules:
     bindings:
       - role: roles/resourcemanager.organizationAdmin
         members:
-          - user:*@{DOMAIN}
-          - group:*@{DOMAIN}
+          - user:*@phoogle.net
+          - group:*@phoogle.net
 
   # Below are the example rules that you can reference to create your own custom rule.
   #- name: Allow only service accounts to have access
@@ -53,4 +53,4 @@ rules:
   #  bindings:
   #    - role: roles/owner
   #      members:
-  #        - user:*@{DOMAIN}
+  #        - user:*@phoogle.net

--- a/rules/iap_rules.yaml
+++ b/rules/iap_rules.yaml
@@ -31,6 +31,6 @@ rules:
   #    - type: organization
   #      applies_to: self_and_children
   #      resource_ids:
-  #        - {ORGANIZATION_ID}
+  #        - 826592752744
   #  inherit_from_parents: true
   #  allowed_direct_access_sources: '10.*,monitoring-instance-tag'

--- a/rules/log_sink_rules.yaml
+++ b/rules/log_sink_rules.yaml
@@ -19,7 +19,7 @@
 #       - type: organization
 #         applies_to: children
 #         resource_ids:
-#           - {ORGANIZATION_ID}
+#           - 826592752744
 #     sink:
 #       destination: 'bigquery.googleapis.com/*'
 #       filter: 'logName:"logs/cloudaudit.googleapis.com"'
@@ -30,7 +30,7 @@
 #      - type: organization
 #        applies_to: children
 #        resource_ids:
-#          - {ORGANIZATION_ID}
+#          - 826592752744
 #    sink:
 #      destination: 'bigquery.googleapis.com/*'
 #      filter: 'logName:"logs/cloudaudit.googleapis.com"'
@@ -41,7 +41,7 @@
 #       - type: organization
 #         applies_to: self
 #         resource_ids:
-#           - {ORGANIZATION_ID}
+#           - 826592752744
 #     sink:
 #       destination: '*'
 #       filter: '*'


### PR DESCRIPTION
Currently, The deployment template for the Forseti server explicitly references ref.cloudsql-instance.region as the server's subnet region, and likewise, references ref.cloudsql-instance.region-c as the server's GCE zone. Abstracted this away into FORSETI_SERVER_REGION, and FORSETI_SERVER_ZONE template variables to better match the Forseti client template.
