### PR TITLE
Retain masterAuth keys for container clusters, but redact actual data

### DIFF
--- a/google/cloud/forseti/services/inventory/base/gcp.py
+++ b/google/cloud/forseti/services/inventory/base/gcp.py
@@ -441,8 +441,13 @@ class ApiClientImpl(ApiClient):
             dict: Generator of Kubernetes Engine Cluster resources.
         """
         for cluster in self.container.get_clusters(projectid):
+
             # Don't store the master auth data in the database.
-            cluster.pop('masterAuth', None)
+            if 'masterAuth' in cluster:
+                cluster['masterAuth'] = {
+                    k: '[redacted]'
+                    for k in cluster['masterAuth'].keys()}
+
             yield cluster
 
     @create_lazy('container', _create_container)


### PR DESCRIPTION
In the future we may want to be able to write scanner rules based on what type of authentication is enabled for a cluster. We can figure this out based on the keys present _masterAuth_ portion of the API response. Examples:

If basic auth is enabled, the section would look something like this:
```
"masterAuth": {
  "clusterCaCertificate": "xxx",
  "password": "xxx",
  "username": "xxx"
}
```

If client certificate auth is enabled, we'll see something like this:
```
"masterAuth": {
  "clientCertificate": "xxx",
  "clientKey": "xxx",
  "clusterCaCertificate": "xxx"
}
```

So rather that removing the _masterAuth_ section entirely before storing it in the database, this will just remove the secrets, but leave the _masterAuth_ section and the keys it contains. In the database it ends up looking like this:

```
  "masterAuth": {
    "clientCertificate": "[redacted]",
    "clientKey": "[redacted]",
    "clusterCaCertificate": "[redacted]"
  }
```