### PR TITLE
[Issue #1848] Fixing logging to use Forsetting logging infrastructure.

### DIFF
--- a/tests/services/dao_test.py
+++ b/tests/services/dao_test.py
@@ -15,14 +15,16 @@
 """Unit Tests: Database abstraction objects for Forseti Server."""
 
 from collections import defaultdict
-import logging
 import unittest
 from sqlalchemy.orm.exc import NoResultFound
 from tests.unittest_utils import ForsetiTestCase
 from tests.services import test_models
 from tests.services.model_tester import ModelCreator
 from tests.services.model_tester import ModelCreatorClient
+from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.services.dao import session_creator
+
+LOGGER = logger.get_logger(__name__)
 
 
 class DaoTest(ForsetiTestCase):
@@ -478,7 +480,7 @@ class DaoTest(ForsetiTestCase):
       for item in result:
         _, acc_res, acc_members = item
         if not (acc_res, acc_members) in access:
-            logging.warn('(%s, %s), %s', acc_res, acc_members, access)
+            LOGGER.warn('(%s, %s), %s', acc_res, acc_members, access)
         self.assertIn((acc_res, acc_members), access,
                       'Should find access in expected')
 
@@ -503,7 +505,7 @@ class DaoTest(ForsetiTestCase):
       for item in result:
         _, acc_res, acc_members = item
         if not (acc_res, acc_members) in access:
-            logging.warn('(%s, %s), %s', acc_res, acc_members, access)
+            LOGGER.warn('(%s, %s), %s', acc_res, acc_members, access)
         self.assertIn((acc_res, acc_members), access,
                       'Should find access in expected')
 
@@ -526,7 +528,7 @@ class DaoTest(ForsetiTestCase):
       for item in result:
         _, acc_res, acc_members = item
         if not (acc_res, acc_members) in access:
-            logging.warn('(%s, %s), %s', acc_res, acc_members, access)
+            LOGGER.warn('(%s, %s), %s', acc_res, acc_members, access)
         self.assertIn((acc_res, acc_members), access,
                       'Should find access in expected')
 

--- a/tests/services/util/db.py
+++ b/tests/services/util/db.py
@@ -17,8 +17,8 @@
 import os
 import tempfile
 
-from google.cloud.forseti.services.dao import create_engine
 from google.cloud.forseti.common.util import logger
+from google.cloud.forseti.services.dao import create_engine
 
 LOGGER = logger.get_logger(__name__)
 

--- a/tests/services/util/db.py
+++ b/tests/services/util/db.py
@@ -14,11 +14,13 @@
 
 """Utils for Forseti Server services testing."""
 
-import logging
 import os
 import tempfile
 
 from google.cloud.forseti.services.dao import create_engine
+from google.cloud.forseti.common.util import logger
+
+LOGGER = logger.get_logger(__name__)
 
 
 def create_test_engine(enforce_fks=True):
@@ -33,7 +35,7 @@ def create_test_engine_with_file(enforce_fks=True):
 
     fd, tmpfile = tempfile.mkstemp('.db', 'forseti-test-')
     try:
-        logging.info('Creating database at %s', tmpfile)
+        LOGGER.info('Creating database at %s', tmpfile)
         engine = create_engine('sqlite:///{}'.format(tmpfile),
                                sqlite_enforce_fks=enforce_fks,
                                connect_args={'check_same_thread': False})


### PR DESCRIPTION
This is setup work to enable us to turn off console logging for unit tests that are designed to emit errors. This will prevent us from polluting logs.