### PR TITLE
Fixes #1871, Update Enforcer to use the common gcp_api compute client.

### DIFF
--- a/google/cloud/forseti/common/util/date_time.py
+++ b/google/cloud/forseti/common/util/date_time.py
@@ -119,6 +119,19 @@ def get_utc_now_timestamp(date=None):
     return utc_now.strftime(string_formats.DEFAULT_FORSETI_TIMESTAMP)
 
 
+def get_utc_now_unix_timestamp(date=None):
+    """Get a 64bit int representing the current time to the millisecond.
+
+    Args:
+        date (datetime): A datetime object representing current time in UTC.
+
+    Returns:
+        int: A epoch timestamp including microseconds.
+    """
+    utc_now = date or get_utc_now_datetime()
+    return calendar.timegm(utc_now.utctimetuple())
+
+
 def get_utc_now_microtimestamp(date=None):
     """Get a 64bit int representing the current time to the millisecond.
 

--- a/google/cloud/forseti/enforcer/batch_enforcer.py
+++ b/google/cloud/forseti/enforcer/batch_enforcer.py
@@ -20,9 +20,9 @@ from __future__ import print_function
 import threading
 
 import concurrent.futures
-from google.apputils import datelib
 
 from google.cloud.forseti.common.gcp_api import compute
+from google.cloud.forseti.common.util import date_time
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.enforcer import enforcer_log_pb2
 from google.cloud.forseti.enforcer import project_enforcer
@@ -58,9 +58,9 @@ class BatchFirewallEnforcer(object):
           project_sema (threading.BoundedSemaphore): An optional semaphore
               object, used to limit the number of concurrent projects getting
               written to.
-          max_running_operations (int): Used to limit the number of concurrent
-              write operations on a single project's firewall rules. Set to 0 to
-              allow unlimited in flight asynchronous operations.
+          max_running_operations (int): [DEPRECATED] Used to limit the number of
+              concurrent write operations on a single project's firewall rules.
+              Set to 0 to allow unlimited in flight asynchronous operations.
         """
         self.global_configs = global_configs
         self.enforcement_log = enforcer_log_pb2.EnforcerLog()
@@ -68,7 +68,11 @@ class BatchFirewallEnforcer(object):
         self._concurrent_workers = concurrent_workers
 
         self._project_sema = project_sema
-        self._max_running_operations = max_running_operations
+
+        if max_running_operations:
+            LOGGER.warn(
+                'Max running operations is deprecated. Argument ignored.')
+        self._max_running_operations = None
         self._local = LOCAL_THREAD
 
     @property
@@ -80,7 +84,7 @@ class BatchFirewallEnforcer(object):
         """
         if not hasattr(self._local, 'compute_client'):
             self._local.compute_client = compute.ComputeClient(
-                self.global_configs)
+                self.global_configs, dry_run=self._dry_run)
 
         return self._local.compute_client
 
@@ -123,24 +127,26 @@ class BatchFirewallEnforcer(object):
         self.enforcement_log.Clear()
         self.enforcement_log.summary.projects_total = len(project_policies)
 
-        started_timestamp = datelib.Timestamp.now()
-        LOGGER.info('starting enforcement wave: %s', started_timestamp)
+        started_time = date_time.get_utc_now_datetime()
+        LOGGER.info('starting enforcement wave: %s', started_time)
 
         projects_enforced_count = self._enforce_projects(project_policies,
                                                          prechange_callback,
                                                          new_result_callback,
                                                          add_rule_callback)
 
-        finished_timestamp = datelib.Timestamp.now()
-        total_time = (finished_timestamp.AsSecondsSinceEpoch() -
-                      started_timestamp.AsSecondsSinceEpoch())
+        finished_time = date_time.get_utc_now_datetime()
+
+        started_timestamp = date_time.get_utc_now_unix_timestamp(started_time)
+        finished_timestamp = date_time.get_utc_now_unix_timestamp(finished_time)
+        total_time = finished_timestamp - started_timestamp
 
         LOGGER.info('finished wave in %i seconds', total_time)
 
         self.enforcement_log.summary.timestamp_start_msec = (
-            started_timestamp.AsMicroTimestamp())
+            date_time.get_utc_now_microtimestamp(started_time))
         self.enforcement_log.summary.timestamp_end_msec = (
-            finished_timestamp.AsMicroTimestamp())
+            date_time.get_utc_now_microtimestamp(finished_time))
 
         self._summarize_results()
 
@@ -164,7 +170,7 @@ class BatchFirewallEnforcer(object):
           int: The number of projects that were enforced.
         """
         # Get a 64 bit int to use as the unique batch ID for this run.
-        batch_id = datelib.Timestamp.now().AsMicroTimestamp()
+        batch_id = date_time.get_utc_now_microtimestamp()
         self.enforcement_log.summary.batch_id = batch_id
 
         projects_enforced_count = 0
@@ -211,11 +217,9 @@ class BatchFirewallEnforcer(object):
         """
         enforcer = project_enforcer.ProjectEnforcer(
             project_id,
-            global_configs=self.global_configs,
-            compute_service=self.compute_client.service,
+            compute_client=self.compute_client,
             dry_run=self._dry_run,
-            project_sema=self._project_sema,
-            max_running_operations=self._max_running_operations)
+            project_sema=self._project_sema)
 
         result = enforcer.enforce_firewall_policy(
             firewall_policy,

--- a/google/cloud/forseti/enforcer/enforcer.py
+++ b/google/cloud/forseti/enforcer/enforcer.py
@@ -51,14 +51,17 @@ def initialize_batch_enforcer(global_configs, concurrent_threads,
             execute.
         max_write_threads (str): The maximum number of enforcement threads that
             can be actively updating project firewalls.
-        max_running_operations (str): The maximum number of write operations per
-            enforcement thread.
+        max_running_operations (str): [DEPRECATED] The maximum number of write
+            operations per enforcement thread.
         dry_run (boolean): If True, will simply log what action would have been
             taken without actually applying any modifications.
 
     Returns:
         BatchFirewallEnforcer: A BatchFirewallEnforcer instance.
     """
+    if max_running_operations:
+        LOGGER.warn('Deprecated argument max_running_operations set.')
+
     if max_write_threads:
         project_sema = threading.BoundedSemaphore(value=max_write_threads)
     else:
@@ -68,8 +71,7 @@ def initialize_batch_enforcer(global_configs, concurrent_threads,
         global_configs=global_configs,
         dry_run=dry_run,
         concurrent_workers=concurrent_threads,
-        project_sema=project_sema,
-        max_running_operations=max_running_operations)
+        project_sema=project_sema)
 
     return enforcer
 

--- a/google/cloud/forseti/enforcer/project_enforcer.py
+++ b/google/cloud/forseti/enforcer/project_enforcer.py
@@ -311,6 +311,8 @@ class ProjectEnforcer(object):
                 LOGGER.warn('Project %s has been deleted.', self.project_id)
                 raise ProjectDeletedError(str(http_error))
 
+            LOGGER.exception('Error listing networks for project %s: %s',
+                             self.project_id, e)
             raise EnforcementError(
                 STATUS_ERROR,
                 'error getting current networks from API: %s' % http_error)

--- a/tests/common/gcp_api/compute_test.py
+++ b/tests/common/gcp_api/compute_test.py
@@ -224,7 +224,8 @@ class ComputeTest(unittest_utils.ForsetiTestCase):
         self.assertDictEqual(json.loads(mock_pending), e.exception.operation)
 
     @parameterized.parameterized.expand(CUD_TEST_CASES)
-    def test_cud_firewall_rule_retry(self, name, verb):
+    @mock.patch('google.cloud.forseti.common.gcp_api.compute.LOGGER', autospec=True)
+    def test_cud_firewall_rule_retry(self, name, verb, mock_logger):
         """Test create/update/delete firewall rule times out."""
         mock_pending = fake_compute.PENDING_OPERATION_TEMPLATE.format(
             verb=verb,
@@ -248,8 +249,10 @@ class ComputeTest(unittest_utils.ForsetiTestCase):
             results = method(self.project_id,
                              rule=fake_compute.FAKE_FIREWALL_RULE,
                              blocking=True,
+                             timeout=1,
                              retry_count=3)
         self.assertDictEqual(json.loads(mock_finished), results)
+        self.assertTrue(mock_logger.warn.called)
 
     @parameterized.parameterized.expand(ERROR_TEST_CASES)
     def test_delete_firewall_rule_errors(self, name, response, status,

--- a/tests/common/gcp_api/compute_test.py
+++ b/tests/common/gcp_api/compute_test.py
@@ -223,6 +223,34 @@ class ComputeTest(unittest_utils.ForsetiTestCase):
                                  timeout=1)
         self.assertDictEqual(json.loads(mock_pending), e.exception.operation)
 
+    @parameterized.parameterized.expand(CUD_TEST_CASES)
+    def test_cud_firewall_rule_retry(self, name, verb):
+        """Test create/update/delete firewall rule times out."""
+        mock_pending = fake_compute.PENDING_OPERATION_TEMPLATE.format(
+            verb=verb,
+            resource_path='project1/global/firewalls/fake-firewall')
+        mock_finished = fake_compute.FINISHED_OPERATION_TEMPLATE.format(
+            verb=verb,
+            resource_path='project1/global/firewalls/fake-firewall')
+        mock_responses = [
+            ({'status': '200'}, mock_pending),
+            ({'status': '200'}, mock_pending),
+            ({'status': '200'}, mock_pending),
+            ({'status': '200'}, mock_finished)]
+        http_mocks.mock_http_response_sequence(mock_responses)
+
+        # Set initial wait to longer than the timeout
+        with mock.patch.object(self.gce_api_client,
+                               'ESTIMATED_API_COMPLETION_IN_SEC',
+                               return_value=2):
+            method = getattr(self.gce_api_client,
+                             '{}_firewall_rule'.format(verb))
+            results = method(self.project_id,
+                             rule=fake_compute.FAKE_FIREWALL_RULE,
+                             blocking=True,
+                             retry_count=3)
+        self.assertDictEqual(json.loads(mock_finished), results)
+
     @parameterized.parameterized.expand(ERROR_TEST_CASES)
     def test_delete_firewall_rule_errors(self, name, response, status,
                                        expected_exception):

--- a/tests/common/util/date_time_test.py
+++ b/tests/common/util/date_time_test.py
@@ -55,6 +55,14 @@ class DateTimeTest(ForsetiTestCase):
         expected_result = "2018-01-01T00:00:00Z"
         self.assertEqual(expected_result, result)
 
+    def test_get_utc_now_unix_timestamp(self):
+        # 2018/01/01 00:00:00.123456
+        mock_date = datetime(2018, 1, 1, 0, 0, 0, 123456)
+        result = date_time.get_utc_now_unix_timestamp(mock_date)
+        # Expected timestamp = 1514764800
+        expected_result = 1514764800
+        self.assertEqual(expected_result, result)
+
     def test_get_utc_now_microtimestamp(self):
         # 2018/01/01 00:00:00.123456
         mock_date = datetime(2018, 1, 1, 0, 0, 0, 123456)

--- a/tests/enforcer/batch_enforcer_test.py
+++ b/tests/enforcer/batch_enforcer_test.py
@@ -26,11 +26,6 @@ from google.protobuf import text_format
 from google.cloud.forseti.enforcer import enforcer_log_pb2
 from google.cloud.forseti.enforcer import batch_enforcer
 
-# Used anywhere a real timestamp could be generated to ensure consistent
-# comparisons in tests
-MOCK_MICROTIMESTAMP = 1514764800123456
-MOCK_DATETIME = datetime(2018, 1, 1, 0, 0, 0, 123456)
-
 
 class BatchFirewallEnforcerTest(constants.EnforcerTestCase):
     """Extended unit tests for BatchFirewallEnforcer class."""
@@ -45,9 +40,9 @@ class BatchFirewallEnforcerTest(constants.EnforcerTestCase):
 
         self.expected_summary = (
             enforcer_log_pb2.BatchResult(
-                batch_id=MOCK_MICROTIMESTAMP,
-                timestamp_start_msec=MOCK_MICROTIMESTAMP,
-                timestamp_end_msec=MOCK_MICROTIMESTAMP))
+                batch_id=constants.MOCK_MICROTIMESTAMP,
+                timestamp_start_msec=constants.MOCK_MICROTIMESTAMP,
+                timestamp_end_msec=constants.MOCK_MICROTIMESTAMP))
 
         self.expected_rules = copy.deepcopy(
             constants.EXPECTED_FIREWALL_RULES.values())
@@ -77,7 +72,8 @@ class BatchFirewallEnforcerTest(constants.EnforcerTestCase):
         self.assertEqual(self.expected_summary, results.summary)
 
         # Verify additional fields added to ProjectResults proto
-        self.assertEqual(MOCK_MICROTIMESTAMP, results.results[0].batch_id)
+        self.assertEqual(constants.MOCK_MICROTIMESTAMP,
+                         results.results[0].batch_id)
 
     def test_batch_enforcer_run_all_changed(self):
         """Validate a full pass of BatchFirewallEnforcer for a single project.

--- a/tests/enforcer/batch_enforcer_test.py
+++ b/tests/enforcer/batch_enforcer_test.py
@@ -16,13 +16,11 @@
 """Tests for google.cloud.forseti.enforcer.batch_enforcer."""
 
 import copy
-import json
-import httplib2
-import mock
+from datetime import datetime
 import unittest
+import mock
 
 from tests.enforcer import testing_constants as constants
-from tests.unittest_utils import ForsetiTestCase
 from google.protobuf import text_format
 
 from google.cloud.forseti.enforcer import enforcer_log_pb2
@@ -30,37 +28,26 @@ from google.cloud.forseti.enforcer import batch_enforcer
 
 # Used anywhere a real timestamp could be generated to ensure consistent
 # comparisons in tests
-MOCK_TIMESTAMP = 1234567890
+MOCK_MICROTIMESTAMP = 1514764800123456
+MOCK_DATETIME = datetime(2018, 1, 1, 0, 0, 0, 123456)
 
 
-class BatchFirewallEnforcerTest(ForsetiTestCase):
+class BatchFirewallEnforcerTest(constants.EnforcerTestCase):
     """Extended unit tests for BatchFirewallEnforcer class."""
 
     def setUp(self):
         """Set up."""
-        self.mock_compute = mock.patch.object(batch_enforcer.compute,
-                                              'ComputeClient').start()
-
-        self.gce_service = self.mock_compute().service
-        self.gce_service.networks().list().execute.return_value = (
-            constants.SAMPLE_TEST_NETWORK_SELFLINK)
-
-        self.project = constants.TEST_PROJECT
-        self.policy = json.loads(constants.RAW_EXPECTED_JSON_POLICY)
+        super(BatchFirewallEnforcerTest, self).setUp()
         self.batch_enforcer = batch_enforcer.BatchFirewallEnforcer(
             dry_run=True)
-
-        self.mock_time = mock.patch.object(batch_enforcer.datelib,
-                                           'Timestamp').start()
-
-        self.mock_time.now().AsMicroTimestamp.return_value = MOCK_TIMESTAMP
-        self.mock_time.now().AsSecondsSinceEpoch.return_value = MOCK_TIMESTAMP
+        self.batch_enforcer._local = mock.Mock(
+            compute_client=self.gce_api_client)
 
         self.expected_summary = (
             enforcer_log_pb2.BatchResult(
-                batch_id=MOCK_TIMESTAMP,
-                timestamp_start_msec=MOCK_TIMESTAMP,
-                timestamp_end_msec=MOCK_TIMESTAMP))
+                batch_id=MOCK_MICROTIMESTAMP,
+                timestamp_start_msec=MOCK_MICROTIMESTAMP,
+                timestamp_end_msec=MOCK_MICROTIMESTAMP))
 
         self.expected_rules = copy.deepcopy(
             constants.EXPECTED_FIREWALL_RULES.values())
@@ -77,7 +64,7 @@ class BatchFirewallEnforcerTest(ForsetiTestCase):
         Expected results:
           An EnforcerLog proto showing 1 success.
         """
-        self.gce_service.firewalls().list().execute.return_value = (
+        self.gce_api_client.get_firewall_rules.return_value = (
             constants.EXPECTED_FIREWALL_API_RESPONSE)
 
         project_policies = [(self.project, self.policy)]
@@ -90,7 +77,7 @@ class BatchFirewallEnforcerTest(ForsetiTestCase):
         self.assertEqual(self.expected_summary, results.summary)
 
         # Verify additional fields added to ProjectResults proto
-        self.assertEqual(MOCK_TIMESTAMP, results.results[0].batch_id)
+        self.assertEqual(MOCK_MICROTIMESTAMP, results.results[0].batch_id)
 
     def test_batch_enforcer_run_all_changed(self):
         """Validate a full pass of BatchFirewallEnforcer for a single project.
@@ -105,7 +92,7 @@ class BatchFirewallEnforcerTest(ForsetiTestCase):
           An EnforcerLog proto showing 1 success, 1 project changed, and 1
           projects with all_rules_changed.
         """
-        self.gce_service.firewalls().list().execute.side_effect = [
+        self.gce_api_client.get_firewall_rules.side_effect = [
             constants.DEFAULT_FIREWALL_API_RESPONSE,
             constants.EXPECTED_FIREWALL_API_RESPONSE]
 
@@ -131,7 +118,7 @@ class BatchFirewallEnforcerTest(ForsetiTestCase):
         Expected results:
           An EnforcerLog proto showing 1 success, 1 project unchanged.
         """
-        self.gce_service.firewalls().list().execute.return_value = (
+        self.gce_api_client.get_firewall_rules.return_value = (
             constants.DEFAULT_FIREWALL_API_RESPONSE)
 
         project_policies = [(self.project, self.policy)]
@@ -184,7 +171,7 @@ class BatchFirewallEnforcerTest(ForsetiTestCase):
             self.assertEqual(expected_result, result)
             callback_called[0] += 1
 
-        self.gce_service.firewalls().list().execute.side_effect = [
+        self.gce_api_client.get_firewall_rules.side_effect = [
             constants.DEFAULT_FIREWALL_API_RESPONSE,
             constants.EXPECTED_FIREWALL_API_RESPONSE]
 

--- a/tests/enforcer/gce_firewall_enforcer_test.py
+++ b/tests/enforcer/gce_firewall_enforcer_test.py
@@ -21,11 +21,15 @@ import threading
 import unittest
 import mock
 
+from googleapiclient import errors
 import parameterized
 
 from tests.enforcer import testing_constants as constants
 from tests.unittest_utils import ForsetiTestCase
 
+from google.cloud.forseti.common.gcp_api import compute
+from google.cloud.forseti.common.gcp_api import errors as api_errors
+from google.cloud.forseti.common.gcp_api import repository_mixins
 from google.cloud.forseti.enforcer import gce_firewall_enforcer as fe
 
 class HelperFunctionTest(ForsetiTestCase):
@@ -47,23 +51,14 @@ class HelperFunctionTest(ForsetiTestCase):
                          fe.build_network_url('example.com:testing',
                                               'mytestnet'))
 
-
-class ComputeFirewallAPI(ForsetiTestCase):
-    """Tests for the ComputeFirewallAPI class."""
-
-    def setUp(self):
-        """Set up."""
-        self.gce_service = mock.MagicMock()
-        self.firewall_api = fe.ComputeFirewallAPI(self.gce_service)
-
     def test_is_successful(self):
-        """is_successful should know about bad responses and OK responses."""
+        """_is_successful should know about bad responses and OK responses."""
         self.assertTrue(
-            self.firewall_api.is_successful({
+            fe._is_successful({
                 'kind': 'compute#operation'
             }))
         self.assertFalse(
-            self.firewall_api.is_successful({
+            fe._is_successful({
                 'error': {
                     'errors': [{
                         'code': 'NOT_FOUND'
@@ -77,7 +72,7 @@ class ComputeFirewallAPI(ForsetiTestCase):
         # INVALID_FIELD_VALUE: Because the network probably disappeared
         #     out from under us.
         self.assertTrue(
-            self.firewall_api.is_successful({
+            fe._is_successful({
                 'error': {
                     'errors': [{
                         'code': 'RESOURCE_ALREADY_EXISTS'
@@ -86,7 +81,7 @@ class ComputeFirewallAPI(ForsetiTestCase):
             }))
 
         self.assertTrue(
-            self.firewall_api.is_successful({
+            fe._is_successful({
                 'error': {
                     'errors': [{
                         'code': 'INVALID_FIELD_VALUE'
@@ -94,153 +89,13 @@ class ComputeFirewallAPI(ForsetiTestCase):
                 }
             }))
 
-    def test_wait_for_any_to_complete(self):
-        """Testing waiting for requests until any finish executing.
-
-        Setup:
-          * Create mock pending response.
-          * Create mock completed response.
-          * Set compute.globalOperations.get to return mock completed response.
-
-        Expected results:
-          * wait_for_any_to_complete will return the completed and running
-            responses
-        """
-        pending_responses = [{
-            'name': 'operation-1400179586831',
-            'status': 'PENDING'
-        }, {
-            'name': 'operation-1400179586832',
-            'status': 'PENDING'
-        }]
-
-        completed_response = {
-            'name': 'operation-1400179586831',
-            'status': 'DONE'
-        }
-        running_response = {
-            'name': 'operation-1400179586832',
-            'status': 'PENDING'
-        }
-
-        self.gce_service.globalOperations().get().execute.side_effect = [
-            completed_response, running_response
-        ]
-
-        (completed, running) = self.firewall_api.wait_for_any_to_complete(
-            constants.TEST_PROJECT, pending_responses)
-
-        self.assertEqual([completed_response], completed)
-        self.assertEqual([running_response], running)
-
-    def test_wait_for_any_to_complete_empty_responses_list(self):
-        """Testing waiting for requests until any finish executing.
-
-        Setup:
-          * Run wait_for_any_to_complete with an empty list for pending
-            responses.
-
-        Expected results:
-          * wait_for_any_to_complete will return an empty list for completed and
-            running responses.
-        """
-        pending_responses = []
-
-        (completed, running) = self.firewall_api.wait_for_any_to_complete(
-            constants.TEST_PROJECT, pending_responses)
-        self.assertEqual([], completed)
-        self.assertEqual([], running)
-
-    def test_wait_for_any_to_complete_timeout(self):
-        """Testing waiting for requests until a timeout is exceeded.
-
-        Setup:
-          * Create mock pending response.
-          * Set compute.globalOperations.get to return mock pending response.
-
-        Expected results:
-          * wait_for_any_to_complete will return the pending response with a
-            timeout error
-        """
-        pending_response = {
-            'name': 'operation-1400179586831',
-            'status': 'PENDING'
-        }
-
-        expected_response = {
-            'name': 'operation-1400179586831',
-            'status': 'PENDING',
-            'error': {
-                'errors': [{
-                    'code': 'OPERATION_TIMEOUT',
-                    'message': 'Operation exceeded timeout for '
-                               'completion of 1.00 seconds'
-                }]
-            }
-        }
-
-        self.gce_service.globalOperations().get().execute.return_value = (
-            pending_response)
-
-        (completed, running) = self.firewall_api.wait_for_any_to_complete(
-            constants.TEST_PROJECT, [pending_response], timeout=1.0)
-        self.assertEqual([expected_response], completed)
-        self.assertEqual([], running)
-
-    def test_wait_for_all_to_complete(self):
-        """Testing waiting for requests until they all finish executing.
-
-        Setup:
-          * Create mock pending responses.
-          * Create mock completed responses.
-          * Set compute.globalOperations.get to return mock completed response.
-
-        Expected results:
-          * wait_for_all_to_complete will return the completed and running
-            responses
-        """
-        pending_responses = [{
-            'name': 'operation-1400179586831',
-            'status': 'PENDING'
-        }, {
-            'name': 'operation-1400179586832',
-            'status': 'PENDING'
-        }]
-
-        completed_responses = [{
-            'name': 'operation-1400179586831',
-            'status': 'DONE'
-        }, {
-            'name': 'operation-1400179586832',
-            'status': 'DONE'
-        }]
-
-        self.gce_service.globalOperations().get().execute.side_effect = [
-            completed_responses[0], pending_responses[1], completed_responses[1]
-        ]
-
-        completed = self.firewall_api.wait_for_all_to_complete(
-            constants.TEST_PROJECT, pending_responses)
-        self.assertEqual(completed_responses, completed)
-
 
 class FirewallRulesTest(ForsetiTestCase):
     """Tests for the FirewallRules class."""
 
     def setUp(self):
         """Set up."""
-        self.gce_service = mock.MagicMock()
-
-        self.mock_api_version = mock.patch(
-            'google.cloud.forseti.enforcer.gce_firewall_enforcer'
-            '.API_VERSION', 'beta').start()
-
-        self.firewall_api = fe.ComputeFirewallAPI(
-            self.gce_service)
         self.firewall_rules = fe.FirewallRules(constants.TEST_PROJECT)
-
-    def tearDown(self):
-      mock.patch.stopall()
 
     def test_add_rule_for_an_invalid_rule_type(self):
         """Validate that invalid rules raises an exception.
@@ -269,18 +124,12 @@ class FirewallRulesTest(ForsetiTestCase):
         Expected Results:
           * Imported rules were successfully added to the rules dictionary.
         """
-        page_one = copy.deepcopy(constants.EXPECTED_FIREWALL_API_RESPONSE)
-        page_one['items'] = page_one['items'][:1]
-        page_one['nextPageToken'] = 'token'
+        mock_compute_client = mock.Mock(spec=compute.ComputeClient)
 
-        page_two = copy.deepcopy(constants.EXPECTED_FIREWALL_API_RESPONSE)
-        page_two['items'] = page_two['items'][1:]
+        mock_compute_client.get_firewall_rules.return_value = (
+            constants.EXPECTED_FIREWALL_API_RESPONSE)
 
-        self.gce_service.firewalls().list().execute.side_effect = [
-            page_one, page_two
-        ]
-
-        self.firewall_rules.add_rules_from_api(self.firewall_api)
+        self.firewall_rules.add_rules_from_api(mock_compute_client)
 
         self.assertSameStructure(constants.EXPECTED_FIREWALL_RULES,
                                  self.firewall_rules.rules)
@@ -297,18 +146,12 @@ class FirewallRulesTest(ForsetiTestCase):
         Expected Results:
           * No rules were added to the rules dictionary
         """
-        page_one = copy.deepcopy(constants.EXPECTED_FIREWALL_API_RESPONSE)
-        page_one['items'] = page_one['items'][:1]
-        page_one['nextPageToken'] = 'token'
-
-        page_two = copy.deepcopy(constants.EXPECTED_FIREWALL_API_RESPONSE)
-        page_two['items'] = page_two['items'][1:]
-
-        (self.gce_service.firewalls().list().execute
-         .side_effect) = [page_one, page_two]
+        mock_compute_client = mock.Mock(spec=compute.ComputeClient)
+        mock_compute_client.get_firewall_rules.return_value = (
+            constants.EXPECTED_FIREWALL_API_RESPONSE)
 
         self.firewall_rules._add_rule_callback = lambda _: False
-        self.firewall_rules.add_rules_from_api(self.firewall_api)
+        self.firewall_rules.add_rules_from_api(mock_compute_client)
         self.assertEqual({}, self.firewall_rules.rules)
 
     def test_add_rules_from_api_add_rule(self):
@@ -323,21 +166,15 @@ class FirewallRulesTest(ForsetiTestCase):
         Expected Results:
           * Imported rules were successfully added to the rules dictionary
         """
-        page_one = copy.deepcopy(constants.EXPECTED_FIREWALL_API_RESPONSE)
-        page_one['items'] = page_one['items'][:1]
-        page_one['nextPageToken'] = 'token'
-
-        page_two = copy.deepcopy(constants.EXPECTED_FIREWALL_API_RESPONSE)
-        page_two['items'] = page_two['items'][1:]
-
-        (self.gce_service.firewalls().list().execute
-         .side_effect) = [page_one, page_two]
+        mock_compute_client = mock.Mock(spec=compute.ComputeClient)
+        mock_compute_client.get_firewall_rules.return_value = (
+            constants.EXPECTED_FIREWALL_API_RESPONSE)
 
         callback = lambda rule: (rule['name'] ==
                                  'test-network-allow-internal-1')
 
         self.firewall_rules._add_rule_callback = callback
-        self.firewall_rules.add_rules_from_api(self.firewall_api)
+        self.firewall_rules.add_rules_from_api(mock_compute_client)
         expected = {'test-network-allow-internal-1':
                     constants.EXPECTED_FIREWALL_RULES[
                         'test-network-allow-internal-1']}
@@ -515,8 +352,6 @@ class FirewallRulesCheckRuleTest(ForsetiTestCase):
 
     def setUp(self):
         """Set up."""
-        self.gce_service = mock.MagicMock()
-        self.firewall_api = fe.ComputeFirewallAPI(self.gce_service)
         self.firewall_rules = fe.FirewallRules(constants.TEST_PROJECT)
 
         self.test_rule = copy.deepcopy(
@@ -700,7 +535,8 @@ class FirewallRulesCheckRuleTest(ForsetiTestCase):
         with self.assertRaises(fe.InvalidFirewallRuleError):
           self.firewall_rules._check_rule_before_adding(new_rule)
 
-class FirewallEnforcerTest(ForsetiTestCase):
+
+class FirewallEnforcerTest(constants.EnforcerTestCase):
     """Tests for the FirewallEnforcer class."""
 
     def setUp(self):
@@ -709,19 +545,16 @@ class FirewallEnforcerTest(ForsetiTestCase):
         Creates a FirewallEnforcer object with current and expected rules set to
         an empty FirewallRules object.
         """
-        self.gce_service = mock.MagicMock()
-        self.firewall_api = fe.ComputeFirewallAPI(
-            self.gce_service, dry_run=True)
+        super(FirewallEnforcerTest, self).setUp()
 
         self.expected_rules = fe.FirewallRules(constants.TEST_PROJECT)
         self.current_rules = fe.FirewallRules(constants.TEST_PROJECT)
 
         self.project_sema = threading.BoundedSemaphore(value=1)
-        self.operation_sema = threading.BoundedSemaphore(value=5)
 
         self.enforcer = fe.FirewallEnforcer(
-            constants.TEST_PROJECT, self.firewall_api, self.expected_rules,
-            self.current_rules, self.project_sema, self.operation_sema)
+            constants.TEST_PROJECT, self.gce_api_client, self.expected_rules,
+            self.current_rules, self.project_sema, None)
 
     def test_apply_firewall_no_changes(self):
         """No changes when current and expected rules match."""
@@ -785,7 +618,7 @@ class FirewallEnforcerTest(ForsetiTestCase):
         self.expected_rules.add_rules(
             expected_policy, network_name=constants.TEST_NETWORK)
 
-        self.gce_service.firewalls().list().execute.return_value = (
+        self.gce_api_client.get_firewall_rules.return_value = (
             constants.DEFAULT_FIREWALL_API_RESPONSE)
 
         self.enforcer.current_rules = None
@@ -897,9 +730,8 @@ class FirewallEnforcerTest(ForsetiTestCase):
         self.expected_rules.rules = constants.EXPECTED_FIREWALL_RULES
 
         # Add rules to current_rules
-        for rule in [
-                'test-network-allow-internal-1', 'test-network-allow-public-0'
-        ]:
+        rules = ['test-network-allow-internal-1', 'test-network-allow-public-0']
+        for rule in rules:
             new_rule = copy.deepcopy(constants.EXPECTED_FIREWALL_RULES[rule])
             self.current_rules.add_rule(new_rule)
 
@@ -937,9 +769,8 @@ class FirewallEnforcerTest(ForsetiTestCase):
         self.expected_rules.rules = constants.EXPECTED_FIREWALL_RULES
 
         # Add rules to current_rules
-        for rule in [
-                'test-network-allow-internal-1', 'test-network-allow-public-0'
-        ]:
+        rules = ['test-network-allow-internal-1', 'test-network-allow-public-0']
+        for rule in rules:
             new_rule = copy.deepcopy(constants.EXPECTED_FIREWALL_RULES[rule])
             self.current_rules.add_rule(new_rule)
 
@@ -956,8 +787,10 @@ class FirewallEnforcerTest(ForsetiTestCase):
             prechange_callback=prechange_callback_func)
         self.assertEqual(1, changed_count)
 
-        self.assertSameStructure(self.enforcer.get_updated_rules(
-        ), [constants.EXPECTED_FIREWALL_RULES['test-network-allow-internal-0']])
+        self.assertSameStructure(
+            self.enforcer.get_updated_rules(),
+            [constants.EXPECTED_FIREWALL_RULES['test-network-allow-internal-0']]
+        )
 
     def test_build_change_set_all_rules_differ_single_network(self):
         """Build a change set for a single network when all rules differ.
@@ -1143,9 +976,9 @@ class FirewallEnforcerTest(ForsetiTestCase):
 
     def test_apply_change(self):
         """Validate apply_change works with no errors."""
-        delete_function = self.firewall_api.delete_firewall_rule
-        insert_function = self.firewall_api.insert_firewall_rule
-        update_function = self.firewall_api.update_firewall_rule
+        delete_function = self.gce_api_client.delete_firewall_rule
+        insert_function = self.gce_api_client.insert_firewall_rule
+        update_function = self.gce_api_client.update_firewall_rule
 
         test_rules = [
             copy.deepcopy(constants.EXPECTED_FIREWALL_RULES[
@@ -1161,7 +994,7 @@ class FirewallEnforcerTest(ForsetiTestCase):
 
     def test_apply_change_no_rules(self):
         """Running apply_change with no rules returns empty lists."""
-        delete_function = self.firewall_api.delete_firewall_rule
+        delete_function = self.gce_api_client.delete_firewall_rule
         (successes, failures, change_errors) = self.enforcer._apply_change(
             delete_function, [])
         self.assertListEqual([], successes)
@@ -1184,9 +1017,10 @@ class FirewallEnforcerTest(ForsetiTestCase):
             'content-type': 'application/json'
         })
         response.reason = 'Duplicate Rule'
-        error_409 = fe.errors.HttpError(response, '', uri='')
+        error_409 = errors.HttpError(response, '', uri='')
+        err = api_errors.ApiExecutionError(self.project, error_409)
 
-        insert_function = mock.Mock(side_effect=error_409)
+        insert_function = mock.Mock(side_effect=err)
 
         test_rules = [
             copy.deepcopy(constants.EXPECTED_FIREWALL_RULES[
@@ -1199,7 +1033,7 @@ class FirewallEnforcerTest(ForsetiTestCase):
         self.assertListEqual([], successes)
         error_str = 'Rule: %s\nError: %s' % (
             test_rules[0].get('name', ''),
-            error_409)
+            err)
         self.assertListEqual([error_str], change_errors)
 
     def test_apply_change_operation_status_error(self):
@@ -1214,56 +1048,29 @@ class FirewallEnforcerTest(ForsetiTestCase):
         Expected Results:
           * Passed in rule ends up in failures list.
         """
-        insert_function = self.firewall_api.insert_firewall_rule
-        self.firewall_api._create_dry_run_response = mock.Mock()
-        self.firewall_api._create_dry_run_response.return_value = {
-            'error': {
-                'errors': [{
-                    'code': 'NOT_FOUND'
-                }]
-            },
-            'status': 'DONE',
-            'name': 'test'
-        }
+        insert_function = self.gce_api_client.insert_firewall_rule
 
         test_rules = [
             copy.deepcopy(constants.EXPECTED_FIREWALL_RULES[
                 'test-network-allow-internal-0'])
         ]
+        with mock.patch.object(
+                repository_mixins, '_create_fake_operation') as mock_dry_run:
 
-        (successes, failures, change_errors) = self.enforcer._apply_change(
-            insert_function, test_rules)
+            mock_dry_run.return_value = {
+                'status': 'DONE',
+                'name': 'test',
+                'error': {
+                    'errors': [{
+                        'code': 'ERROR'
+                    }]
+                }
+            }
+            (successes, failures, change_errors) = self.enforcer._apply_change(
+                insert_function, test_rules)
+
         self.assertSameStructure(test_rules, failures)
         self.assertListEqual([], successes)
-        self.assertListEqual([], change_errors)
-
-    def test_apply_change_lots_of_rules(self):
-        """Changing more rules than permitted by the operation semaphore works.
-
-        Setup:
-          * Create a new bounded semaphore with a limit of 2 operations.
-          * Create a list of 10 rules to insert.
-          * Run _apply_change.
-
-        Expected Results:
-          * All rules end up in the successes list.
-        """
-        insert_function = self.firewall_api.insert_firewall_rule
-        self.enforcer.operation_sema = threading.BoundedSemaphore(value=2)
-
-        test_rule_name = 'test-network-allow-internal-0'
-        test_rule = constants.EXPECTED_FIREWALL_RULES[test_rule_name]
-
-        test_rules = []
-        for i in xrange(10):
-            rule = copy.deepcopy(test_rule)
-            rule['name'] = '%s-%i' % (test_rule_name, i)
-            test_rules.append(rule)
-
-        (successes, failures, change_errors) = self.enforcer._apply_change(
-            insert_function, test_rules)
-        self.assertSameStructure(test_rules, successes)
-        self.assertListEqual([], failures)
         self.assertListEqual([], change_errors)
 
     def test_apply_changes(self):
@@ -1322,39 +1129,41 @@ class FirewallEnforcerTest(ForsetiTestCase):
         self.current_rules.rules = constants.EXPECTED_FIREWALL_RULES
         self.expected_rules.rules = constants.EXPECTED_FIREWALL_RULES
 
-        self.firewall_api._create_dry_run_response = mock.Mock()
-        self.firewall_api._create_dry_run_response.return_value = {
-            'error': {
-                'errors': [{
-                    'code': 'NOT_FOUND'
-                }]
-            },
-            'status': 'DONE',
-            'name': 'test'
-        }
-
         delete_before_insert = False
 
         self.enforcer._rules_to_delete = ['test-network-allow-internal-0']
-        with self.assertRaises(fe.FirewallEnforcementFailedError):
-            self.enforcer._apply_change_set(delete_before_insert)
-        self.assertEqual([], self.enforcer.get_deleted_rules())
-        self.enforcer._rules_to_delete = []
+        with mock.patch.object(
+                repository_mixins, '_create_fake_operation') as mock_dry_run:
 
-        self.enforcer._rules_to_insert = ['test-network-allow-internal-0']
-        with self.assertRaises(fe.FirewallEnforcementFailedError):
-            self.enforcer._apply_change_set(delete_before_insert)
-        self.assertEqual([], self.enforcer.get_inserted_rules())
-        self.enforcer._rules_to_insert = []
+            mock_dry_run.return_value = {
+                'status': 'DONE',
+                'name': 'test',
+                'error': {
+                    'errors': [{
+                        'code': 'NOT_FOUND'
+                    }]
+                }
+            }
+            with self.assertRaises(fe.FirewallEnforcementFailedError):
+                self.enforcer._apply_change_set(delete_before_insert)
 
-        self.enforcer._rules_to_update = ['test-network-allow-internal-0']
-        with self.assertRaises(fe.FirewallEnforcementFailedError):
-            self.enforcer._apply_change_set(delete_before_insert)
-        self.assertEqual([], self.enforcer.get_updated_rules())
-        self.enforcer._rules_to_update = []
+            self.assertEqual([], self.enforcer.get_deleted_rules())
+            self.enforcer._rules_to_delete = []
 
-    def testApplyChangesDeleteFirst(self):
-      """Validate _ApplyChanges works with no errors.
+            self.enforcer._rules_to_insert = ['test-network-allow-internal-0']
+            with self.assertRaises(fe.FirewallEnforcementFailedError):
+                self.enforcer._apply_change_set(delete_before_insert)
+            self.assertEqual([], self.enforcer.get_inserted_rules())
+            self.enforcer._rules_to_insert = []
+
+            self.enforcer._rules_to_update = ['test-network-allow-internal-0']
+            with self.assertRaises(fe.FirewallEnforcementFailedError):
+                self.enforcer._apply_change_set(delete_before_insert)
+            self.assertEqual([], self.enforcer.get_updated_rules())
+            self.enforcer._rules_to_update = []
+
+    def test_apply_changes_delete_first(self):
+      """Validate _apply_change_set works with no errors.
 
       Setup:
         * Set current and expected rules to EXPECTED_CORP_FIREWALL_RULES
@@ -1401,10 +1210,10 @@ class FirewallEnforcerTest(ForsetiTestCase):
         ('high_quota_1', 100, 6, 10, 6, False, False),
         ('high_quota_2', 100, 85, 30, 50, False, True),
         ('unknown_quota', None, None, 1, 0, False, True)])
-    def testCheckChangeOperationOrder(self, name, quota, usage,
-                                      insert_rule_count, delete_rule_count,
-                                      expect_exception,
-                                      expect_delete_before_insert):
+    def test_check_change_operation_order(self, name, quota, usage,
+                                          insert_rule_count, delete_rule_count,
+                                          expect_exception,
+                                          expect_delete_before_insert):
 
         """Validate CheckChangeOperationOrder has expected behavior.
 
@@ -1429,12 +1238,12 @@ class FirewallEnforcerTest(ForsetiTestCase):
           * When mock project does have enough quota, the method returns False.
         """
         if quota is not None:
-          self.gce_service.projects().get().execute.return_value = {
+          self.gce_api_client.get_project.return_value = {
               'quotas': [{'metric': 'FIREWALLS',
                           'limit': quota,
                           'usage': usage}]}
         else:
-          self.gce_service.projects().get().execute.return_value = {
+          self.gce_api_client.get_project.return_value = {
               'quotas': []}
 
         if expect_exception:

--- a/tests/enforcer/gce_firewall_enforcer_test.py
+++ b/tests/enforcer/gce_firewall_enforcer_test.py
@@ -51,23 +51,8 @@ class HelperFunctionTest(ForsetiTestCase):
                          fe.build_network_url('example.com:testing',
                                               'mytestnet'))
 
-<<<<<<< HEAD
     def test_is_successful(self):
         """_is_successful should know about bad responses and OK responses."""
-=======
-
-class ComputeFirewallAPI(ForsetiTestCase):
-    """Tests for the ComputeFirewallAPI class."""
-
-    def setUp(self):
-        """Set up."""
-        self.gce_service = mock.MagicMock()
-        self.firewall_api = fe.ComputeFirewallAPI(self.gce_service)
-
-    @mock.patch('google.cloud.forseti.enforcer.gce_firewall_enforcer.LOGGER', autospec=True)
-    def test_is_successful(self, mock_logger):
-        """is_successful should know about bad responses and OK responses."""
->>>>>>> dev
         self.assertTrue(
             fe._is_successful({
                 'kind': 'compute#operation'
@@ -103,142 +88,7 @@ class ComputeFirewallAPI(ForsetiTestCase):
                     }]
                 }
             }))
-        self.assertTrue(mock_logger.error.called)
 
-<<<<<<< HEAD
-=======
-    def test_wait_for_any_to_complete(self):
-        """Testing waiting for requests until any finish executing.
-
-        Setup:
-          * Create mock pending response.
-          * Create mock completed response.
-          * Set compute.globalOperations.get to return mock completed response.
-
-        Expected results:
-          * wait_for_any_to_complete will return the completed and running
-            responses
-        """
-        pending_responses = [{
-            'name': 'operation-1400179586831',
-            'status': 'PENDING'
-        }, {
-            'name': 'operation-1400179586832',
-            'status': 'PENDING'
-        }]
-
-        completed_response = {
-            'name': 'operation-1400179586831',
-            'status': 'DONE'
-        }
-        running_response = {
-            'name': 'operation-1400179586832',
-            'status': 'PENDING'
-        }
-
-        self.gce_service.globalOperations().get().execute.side_effect = [
-            completed_response, running_response
-        ]
-
-        (completed, running) = self.firewall_api.wait_for_any_to_complete(
-            constants.TEST_PROJECT, pending_responses)
-
-        self.assertEqual([completed_response], completed)
-        self.assertEqual([running_response], running)
-
-    def test_wait_for_any_to_complete_empty_responses_list(self):
-        """Testing waiting for requests until any finish executing.
-
-        Setup:
-          * Run wait_for_any_to_complete with an empty list for pending
-            responses.
-
-        Expected results:
-          * wait_for_any_to_complete will return an empty list for completed and
-            running responses.
-        """
-        pending_responses = []
-
-        (completed, running) = self.firewall_api.wait_for_any_to_complete(
-            constants.TEST_PROJECT, pending_responses)
-        self.assertEqual([], completed)
-        self.assertEqual([], running)
-
-    @mock.patch('google.cloud.forseti.enforcer.gce_firewall_enforcer.LOGGER', autospec=True)
-    def test_wait_for_any_to_complete_timeout(self, mock_logger):
-        """Testing waiting for requests until a timeout is exceeded.
-
-        Setup:
-          * Create mock pending response.
-          * Set compute.globalOperations.get to return mock pending response.
-
-        Expected results:
-          * wait_for_any_to_complete will return the pending response with a
-            timeout error
-        """
-        pending_response = {
-            'name': 'operation-1400179586831',
-            'status': 'PENDING'
-        }
-
-        expected_response = {
-            'name': 'operation-1400179586831',
-            'status': 'PENDING',
-            'error': {
-                'errors': [{
-                    'code': 'OPERATION_TIMEOUT',
-                    'message': 'Operation exceeded timeout for '
-                               'completion of 1.00 seconds'
-                }]
-            }
-        }
-
-        self.gce_service.globalOperations().get().execute.return_value = (
-            pending_response)
-
-        (completed, running) = self.firewall_api.wait_for_any_to_complete(
-            constants.TEST_PROJECT, [pending_response], timeout=1.0)
-        self.assertEqual([expected_response], completed)
-        self.assertEqual([], running)
-        self.assertTrue(mock_logger.error.called)
-
-    def test_wait_for_all_to_complete(self):
-        """Testing waiting for requests until they all finish executing.
-
-        Setup:
-          * Create mock pending responses.
-          * Create mock completed responses.
-          * Set compute.globalOperations.get to return mock completed response.
-
-        Expected results:
-          * wait_for_all_to_complete will return the completed and running
-            responses
-        """
-        pending_responses = [{
-            'name': 'operation-1400179586831',
-            'status': 'PENDING'
-        }, {
-            'name': 'operation-1400179586832',
-            'status': 'PENDING'
-        }]
-
-        completed_responses = [{
-            'name': 'operation-1400179586831',
-            'status': 'DONE'
-        }, {
-            'name': 'operation-1400179586832',
-            'status': 'DONE'
-        }]
-
-        self.gce_service.globalOperations().get().execute.side_effect = [
-            completed_responses[0], pending_responses[1], completed_responses[1]
-        ]
-
-        completed = self.firewall_api.wait_for_all_to_complete(
-            constants.TEST_PROJECT, pending_responses)
-        self.assertEqual(completed_responses, completed)
-
->>>>>>> dev
 
 class FirewallRulesTest(ForsetiTestCase):
     """Tests for the FirewallRules class."""

--- a/tests/enforcer/project_enforcer_test.py
+++ b/tests/enforcer/project_enforcer_test.py
@@ -16,43 +16,33 @@
 """Tests for google.cloud.forseti.enforcer.project_enforcer."""
 
 import copy
+from datetime import datetime
 import json
 import unittest
+from googleapiclient import errors
 import httplib2
 import mock
 
 from tests.enforcer import testing_constants as constants
-from tests.unittest_utils import ForsetiTestCase
 
+from google.cloud.forseti.common.gcp_api import errors as api_errors
+from google.cloud.forseti.common.gcp_api import repository_mixins
 from google.cloud.forseti.enforcer import enforcer_log_pb2
 from google.cloud.forseti.enforcer import project_enforcer
 
-# Used anywhere a real timestamp could be generated to ensure consistent
-# comparisons in tests
-MOCK_TIMESTAMP = 1234567890
 
-
-class ProjectEnforcerTest(ForsetiTestCase):
+class ProjectEnforcerTest(constants.EnforcerTestCase):
     """Extended unit tests for ProjectEnforcer class."""
 
     def setUp(self):
         """Set up."""
-        self.gce_service = mock.Mock()
-        self.gce_service.networks().list().execute.return_value = (
-            constants.SAMPLE_TEST_NETWORK_SELFLINK)
-
-        self.mock_time = mock.patch.object(project_enforcer.datelib,
-                                           'Timestamp').start()
-        self.mock_time.now().AsMicroTimestamp.return_value = MOCK_TIMESTAMP
-
-        self.project = constants.TEST_PROJECT
-        self.policy = json.loads(constants.RAW_EXPECTED_JSON_POLICY)
+        super(ProjectEnforcerTest, self).setUp()
         self.enforcer = project_enforcer.ProjectEnforcer(
-            self.project, compute_service=self.gce_service, dry_run=True)
+            self.project, compute_client=self.gce_api_client, dry_run=True)
 
         self.expected_proto = enforcer_log_pb2.ProjectResult(
-            timestamp_sec=MOCK_TIMESTAMP,
-            project_id=self.project,)
+            timestamp_sec=constants.MOCK_MICROTIMESTAMP,
+            project_id=self.project)
 
         self.expected_rules = copy.deepcopy(
             constants.EXPECTED_FIREWALL_RULES.values())
@@ -62,11 +52,7 @@ class ProjectEnforcerTest(ForsetiTestCase):
             'content-type': 'application/json'
         })
         response_403.reason = 'Failed'
-        self.error_403 = project_enforcer.errors.HttpError(response_403, '',
-                                                           uri='')
-
-        # used in get_firewalls_quota
-        self.gce_service.projects().get().execute.return_value = {}
+        self.error_403 = errors.HttpError(response_403, '', uri='')
 
         self.addCleanup(mock.patch.stopall)
 
@@ -129,9 +115,8 @@ class ProjectEnforcerTest(ForsetiTestCase):
           A ProjectResult proto with status=SUCCESS and all rules listed in
           rules_unchanged.
         """
-        self.gce_service.firewalls().list().execute.return_value = {
-            'items': self.expected_rules
-        }
+        self.gce_api_client.get_firewall_rules.return_value = (
+            self.expected_rules)
 
         self.expected_proto.status = project_enforcer.STATUS_SUCCESS
         unchanged = get_rule_names(self.expected_rules)
@@ -154,11 +139,9 @@ class ProjectEnforcerTest(ForsetiTestCase):
           changed, all_rules_changed set to True, and a copy of the previous and
           current firewall rules.
         """
-        self.gce_service.firewalls().list().execute.side_effect = [
+        self.gce_api_client.get_firewall_rules.side_effect = [
             constants.DEFAULT_FIREWALL_API_RESPONSE,
-            {
-                'items': self.expected_rules
-            },
+            self.expected_rules,
         ]
 
         result = self.enforcer.enforce_firewall_policy(self.policy)
@@ -168,7 +151,7 @@ class ProjectEnforcerTest(ForsetiTestCase):
 
         added = get_rule_names(self.expected_rules)
         deleted = get_rule_names(
-            constants.DEFAULT_FIREWALL_API_RESPONSE['items'])
+            constants.DEFAULT_FIREWALL_API_RESPONSE)
         self.set_expected_audit_log(added=added, deleted=deleted)
 
         self.validate_results(self.expected_proto, result,
@@ -202,15 +185,11 @@ class ProjectEnforcerTest(ForsetiTestCase):
 
         # Add a new rule that will need to be deleted
         current_fw_rules.append(
-            constants.DEFAULT_FIREWALL_API_RESPONSE['items'][0])
+            constants.DEFAULT_FIREWALL_API_RESPONSE[0])
 
-        self.gce_service.firewalls().list().execute.side_effect = [
-            {
-                'items': current_fw_rules
-            },
-            {
-                'items': self.expected_rules
-            },
+        self.gce_api_client.get_firewall_rules.side_effect = [
+            current_fw_rules,
+            self.expected_rules,
         ]
 
         result = self.enforcer.enforce_firewall_policy(self.policy)
@@ -243,9 +222,10 @@ class ProjectEnforcerTest(ForsetiTestCase):
         # Make a change to one of the rules
         current_fw_rules[0]['sourceRanges'].append('10.0.0.0/8')
 
-        self.gce_service.firewalls().list().execute.side_effect = [
-            {'items': current_fw_rules},
-            {'items': self.expected_rules}]
+        self.gce_api_client.get_firewall_rules.side_effect = [
+            current_fw_rules,
+            self.expected_rules,
+        ]
 
         result = self.enforcer.enforce_firewall_policy(self.policy)
 
@@ -274,12 +254,13 @@ class ProjectEnforcerTest(ForsetiTestCase):
         """
         extra_rules = copy.deepcopy(self.expected_rules)
         extra_rules.extend(
-            constants.DEFAULT_FIREWALL_API_RESPONSE['items'][:1])
-        self.gce_service.firewalls().list().execute.side_effect = [
+            constants.DEFAULT_FIREWALL_API_RESPONSE[:1])
+        self.gce_api_client.get_firewall_rules.side_effect = [
             constants.DEFAULT_FIREWALL_API_RESPONSE,
-            {'items': extra_rules},
-            {'items': extra_rules},
-            {'items': self.expected_rules}]
+            extra_rules,
+            extra_rules,
+            self.expected_rules
+        ]
 
         result = self.enforcer.enforce_firewall_policy(
             self.policy, retry_on_dry_run=True)
@@ -289,9 +270,9 @@ class ProjectEnforcerTest(ForsetiTestCase):
 
         added = get_rule_names(self.expected_rules)
         deleted = get_rule_names(
-            constants.DEFAULT_FIREWALL_API_RESPONSE['items'])
+            constants.DEFAULT_FIREWALL_API_RESPONSE)
         deleted.extend(get_rule_names(
-            constants.DEFAULT_FIREWALL_API_RESPONSE['items'][:1]))
+            constants.DEFAULT_FIREWALL_API_RESPONSE[:1]))
 
         self.set_expected_audit_log(added=added, deleted=sorted(deleted))
 
@@ -313,17 +294,19 @@ class ProjectEnforcerTest(ForsetiTestCase):
         """
         extra_rules = copy.deepcopy(self.expected_rules)
         extra_rules.extend(
-            constants.DEFAULT_FIREWALL_API_RESPONSE['items'][:1])
+            constants.DEFAULT_FIREWALL_API_RESPONSE[:1])
 
-        firewall_list = [constants.DEFAULT_FIREWALL_API_RESPONSE,
-                         {'items': extra_rules}]
+        firewall_list = [
+            constants.DEFAULT_FIREWALL_API_RESPONSE,
+            extra_rules
+        ]
 
         maximum_retries = 3
 
         # Return the same extra rule for each retry.
-        firewall_list.extend([{'items': extra_rules}] * maximum_retries * 2)
+        firewall_list.extend([extra_rules] * maximum_retries * 2)
 
-        self.gce_service.firewalls().list().execute.side_effect = firewall_list
+        self.gce_api_client.get_firewall_rules.side_effect = firewall_list
 
         result = self.enforcer.enforce_firewall_policy(
             self.policy, retry_on_dry_run=True, maximum_retries=maximum_retries)
@@ -335,15 +318,15 @@ class ProjectEnforcerTest(ForsetiTestCase):
 
         added = get_rule_names(self.expected_rules)
         deleted = get_rule_names(
-            constants.DEFAULT_FIREWALL_API_RESPONSE['items'])
+            constants.DEFAULT_FIREWALL_API_RESPONSE)
 
         # Rule is deleted 3 times, but always comes back.
         for _ in range(maximum_retries):
             deleted.extend(get_rule_names(
-                constants.DEFAULT_FIREWALL_API_RESPONSE['items'][:1]))
+                constants.DEFAULT_FIREWALL_API_RESPONSE[:1]))
 
         unchanged = get_rule_names(
-            constants.DEFAULT_FIREWALL_API_RESPONSE['items'][:1])
+            constants.DEFAULT_FIREWALL_API_RESPONSE[:1])
 
         self.set_expected_audit_log(added=added, deleted=sorted(deleted),
                                     unchanged=unchanged)
@@ -363,7 +346,7 @@ class ProjectEnforcerTest(ForsetiTestCase):
         Expected Results:
           A ProjectResult proto showing status=SUCCESS, with no rules changed.
         """
-        self.gce_service.firewalls().list().execute.return_value = (
+        self.gce_api_client.get_firewall_rules.return_value = (
             constants.DEFAULT_FIREWALL_API_RESPONSE)
 
         prechange_callback_func = lambda *unused_args: False
@@ -374,8 +357,7 @@ class ProjectEnforcerTest(ForsetiTestCase):
 
         self.expected_proto.status = project_enforcer.STATUS_SUCCESS
 
-        unchanged = get_rule_names(
-            constants.DEFAULT_FIREWALL_API_RESPONSE['items'])
+        unchanged = get_rule_names(constants.DEFAULT_FIREWALL_API_RESPONSE)
 
         self.set_expected_audit_log(added=[], deleted=[], unchanged=unchanged)
 
@@ -393,30 +375,28 @@ class ProjectEnforcerTest(ForsetiTestCase):
           The rules on the test network are changed, but the rules on the
           default network remain the same.
         """
-        current_fw_rules_page1 = copy.deepcopy(
+        current_fw_rules_network1 = copy.deepcopy(
             constants.DEFAULT_FIREWALL_API_RESPONSE)
-        current_fw_rules_page1['nextPageToken'] = 'page2'
-        current_fw_rules_page2 = json.loads(
+        current_fw_rules_network2 = json.loads(
             json.dumps(constants.DEFAULT_FIREWALL_API_RESPONSE).replace(
                 'test-network', 'default'))
 
-        expected_rules_page1 = copy.deepcopy(
+        expected_fw_rules_network1 = copy.deepcopy(
             constants.EXPECTED_FIREWALL_API_RESPONSE)
-        expected_rules_page1['nextPageToken'] = 'page2'
-        expected_rules_page2 = copy.deepcopy(current_fw_rules_page2)
+        expected_fw_rules_network2 = copy.deepcopy(current_fw_rules_network2)
 
-        self.gce_service.firewalls().list().execute.side_effect = [
-            current_fw_rules_page1, current_fw_rules_page2,
-            expected_rules_page1, expected_rules_page2
+        self.gce_api_client.get_firewall_rules.side_effect = [
+            current_fw_rules_network1 + current_fw_rules_network2,
+            expected_fw_rules_network1 + expected_fw_rules_network2
         ]
 
         result = self.enforcer.enforce_firewall_policy(
             self.policy, networks=[constants.TEST_NETWORK])
 
         self.expected_proto.status = project_enforcer.STATUS_SUCCESS
-        added = get_rule_names(expected_rules_page1['items'])
-        deleted = get_rule_names(current_fw_rules_page1['items'])
-        unchanged = get_rule_names(current_fw_rules_page2['items'])
+        added = get_rule_names(expected_fw_rules_network1)
+        deleted = get_rule_names(current_fw_rules_network1)
+        unchanged = get_rule_names(current_fw_rules_network2)
         self.set_expected_audit_log(
             added=added, deleted=deleted, unchanged=unchanged)
 
@@ -436,9 +416,8 @@ class ProjectEnforcerTest(ForsetiTestCase):
         """
         firewall_policy = []
 
-        self.gce_service.firewalls().list().execute.return_value = {
-            'items': self.expected_rules
-        }
+        self.gce_api_client.get_firewall_rules.return_value = (
+                self.expected_rules)
 
         result = self.enforcer.enforce_firewall_policy(firewall_policy)
 
@@ -467,9 +446,10 @@ class ProjectEnforcerTest(ForsetiTestCase):
         """
         firewall_policy = []
 
-        self.gce_service.firewalls().list().execute.side_effect = [
-            {'items': self.expected_rules},
-            {'items': []}]
+        self.gce_api_client.get_firewall_rules.side_effect = [
+            self.expected_rules,
+            []
+        ]
 
         result = self.enforcer.enforce_firewall_policy(
             firewall_policy, allow_empty_ruleset=True)
@@ -494,30 +474,27 @@ class ProjectEnforcerTest(ForsetiTestCase):
         Expected Result:
           A ProjectResult proto showing status=ERROR and a reason string.
         """
-        mock_dry_run = mock.patch.object(project_enforcer.fe.ComputeFirewallAPI,
-                                         '_create_dry_run_response').start()
-
-        mock_dry_run.return_value = {
-            'status': 'DONE',
-            'name': 'test-net-allow-all-tcp',
-            'error': {
-                'errors': [{
-                    'code': 'ERROR'
-                }]
-            }
-        }
-
         # Make a deep copy of the expected rules
         current_fw_rules = copy.deepcopy(self.expected_rules)
 
         # Make a change to one of the rules
         current_fw_rules[0]['sourceRanges'].append('10.0.0.0/8')
 
-        self.gce_service.firewalls().list().execute.return_value = {
-            'items': current_fw_rules
-        }
+        self.gce_api_client.get_firewall_rules.return_value = current_fw_rules
 
-        result = self.enforcer.enforce_firewall_policy(self.policy)
+        with mock.patch.object(
+                repository_mixins, '_create_fake_operation') as mock_dry_run:
+
+            mock_dry_run.return_value = {
+                'status': 'DONE',
+                'name': 'test-net-allow-all-tcp',
+                'error': {
+                    'errors': [{
+                        'code': 'ERROR'
+                    }]
+                }
+            }
+            result = self.enforcer.enforce_firewall_policy(self.policy)
 
         self.expected_proto.status = project_enforcer.STATUS_ERROR
         unchanged = get_rule_names(self.expected_rules)
@@ -567,32 +544,26 @@ class ProjectEnforcerTest(ForsetiTestCase):
 
         # Add a new rule that will need to be deleted
         current_fw_rules.append(
-            constants.DEFAULT_FIREWALL_API_RESPONSE['items'][0])
+            constants.DEFAULT_FIREWALL_API_RESPONSE[0])
 
-        self.gce_service.firewalls().list().execute.side_effect = [
-            {
-                'items': current_fw_rules
-            },
-            {
-                'items': self.expected_rules
-            },
+        self.gce_api_client.get_firewall_rules.side_effect = [
+            current_fw_rules,
+            self.expected_rules,
         ]
 
-        mock_update_firewall_rule = mock.patch.object(
-            project_enforcer.fe.ComputeFirewallAPI,
-            'update_firewall_rule').start()
-
-        mock_update_firewall_rule.return_value = {
-            'status': 'DONE',
-            'name': 'test-net-allow-corp-internal-0',
-            'error': {
-                'errors': [{
-                    'code': 'ERROR'
-                }]
+        with mock.patch.object(self.gce_api_client,
+                               'update_firewall_rule') as mock_updater:
+            mock_updater.return_value = {
+                'status': 'DONE',
+                'name': 'test-net-allow-corp-internal-0',
+                'error': {
+                    'errors': [{
+                        'code': 'ERROR'
+                    }]
+                }
             }
-        }
 
-        result = self.enforcer.enforce_firewall_policy(self.policy)
+            result = self.enforcer.enforce_firewall_policy(self.policy)
 
         self.expected_proto.status = project_enforcer.STATUS_ERROR
         added = get_rule_names(self.expected_rules[-1:])  # expected rule added
@@ -633,13 +604,14 @@ class ProjectEnforcerTest(ForsetiTestCase):
         # Make a change to one of the rules
         current_fw_rules[0]['sourceRanges'].append('10.0.0.0/8')
 
-        self.gce_service.firewalls().list().execute.side_effect = [
-            {
-                'items': current_fw_rules
-            },
-            self.error_403,
-            self.error_403,
+        err = api_errors.ApiExecutionError(self.project, self.error_403)
+
+        self.gce_api_client.get_firewall_rules.side_effect = [
+            current_fw_rules,
+            err,
+            err,
         ]
+
 
         result = self.enforcer.enforce_firewall_policy(self.policy)
 
@@ -675,16 +647,18 @@ class ProjectEnforcerTest(ForsetiTestCase):
           A ProjectResult proto showing status=ERROR and the correct reason
           string.
         """
-        self.gce_service.networks().list().execute.side_effect = self.error_403
+        err = api_errors.ApiExecutionError(self.project, self.error_403)
+        self.gce_api_client.get_networks.side_effect = err
 
-        self.gce_service.firewalls().list().execute.return_value = {
-            'items': self.expected_rules
-        }
+        self.gce_api_client.get_firewall_rules.return_value = (
+                self.expected_rules)
 
         result = self.enforcer.enforce_firewall_policy(self.policy)
 
         self.expected_proto.status = project_enforcer.STATUS_ERROR
-        self.expected_proto.status_reason = 'no networks found for project'
+        self.expected_proto.status_reason = (
+                'error getting current networks from API: <HttpError 403 '
+                '"Failed">')
 
         self.validate_results(self.expected_proto, result)
 
@@ -698,7 +672,8 @@ class ProjectEnforcerTest(ForsetiTestCase):
           A ProjectResult proto showing status=ERROR and the correct reason
           string.
         """
-        self.gce_service.firewalls().list().execute.side_effect = self.error_403
+        err = api_errors.ApiExecutionError(self.project, self.error_403)
+        self.gce_api_client.get_firewall_rules.side_effect = err
 
         result = self.enforcer.enforce_firewall_policy(self.policy)
 
@@ -727,9 +702,8 @@ class ProjectEnforcerTest(ForsetiTestCase):
         # Set the first firewall policy rule to have a very long name
         self.policy[0]['name'] = 'long-name-' + 'x' * 54
 
-        self.gce_service.firewalls().list().execute.return_value = {
-            'items': self.expected_rules
-        }
+        self.gce_api_client.get_firewall_rules.return_value = (
+            self.expected_rules)
 
         result = self.enforcer.enforce_firewall_policy(self.policy)
 
@@ -767,11 +741,10 @@ class ProjectEnforcerTest(ForsetiTestCase):
                               'https://console.developers.google.com/iam-admin/'
                               'projects?pendingDeletion=true to undelete the '
                               'project.')
-        error_deleted_403 = project_enforcer.errors.HttpError(deleted_403, '',
-                                                              uri='')
+        error_deleted_403 = errors.HttpError(deleted_403, '', uri='')
+        err = api_errors.ApiExecutionError(self.project, error_deleted_403)
 
-        self.gce_service.firewalls().list().execute.side_effect = (
-            error_deleted_403)
+        self.gce_api_client.get_networks.side_effect = err
         result = self.enforcer.enforce_firewall_policy(self.policy)
 
         self.expected_proto.status = project_enforcer.STATUS_DELETED
@@ -802,11 +775,10 @@ class ProjectEnforcerTest(ForsetiTestCase):
             'content-type': 'application/json'
         })
         deleted_400.reason = 'Invalid value for project: %s' % self.project
-        error_deleted_400 = project_enforcer.errors.HttpError(deleted_400, '',
-                                                              uri='')
+        error_deleted_400 = errors.HttpError(deleted_400, '', uri='')
+        err = api_errors.ApiExecutionError(self.project, error_deleted_400)
 
-        self.gce_service.firewalls().list().execute.side_effect = (
-            error_deleted_400)
+        self.gce_api_client.get_firewall_rules.side_effect = err
         result = self.enforcer.enforce_firewall_policy(self.policy)
 
         self.expected_proto.status = project_enforcer.STATUS_DELETED
@@ -842,11 +814,12 @@ class ProjectEnforcerTest(ForsetiTestCase):
             'overview?project=1 then retry. If you enabled this API recently,'
             'wait a few minutes for the action to propagate to our systems and '
             'retry.')
-        error_api_disabled_403 = project_enforcer.errors.HttpError(
-            api_disabled_403, '', uri='')
-
-        self.gce_service.firewalls().list().execute.side_effect = (
+        error_api_disabled_403 = errors.HttpError(api_disabled_403, '', uri='')
+        err = api_errors.ApiNotEnabledError(
+            'https://console.developers.google.com/apis/api/compute_component/',
             error_api_disabled_403)
+
+        self.gce_api_client.get_firewall_rules.side_effect = err
         result = self.enforcer.enforce_firewall_policy(self.policy)
 
         self.expected_proto.status = project_enforcer.STATUS_DELETED


### PR DESCRIPTION
Fixes #1871.

 * Remove one off compute API implementation from Enforcer
 * Update the Compute Insert/Update/Delete firewall rules to take an
 optional retry argument
 * Update the common date_time library and remove the requirement for
 the google python datelib module.
 * Switch enforcement from running multiple simultaneous operations to
 running a single operation in blocking mode. This will reduce load on
 the back end and should improve reliability of operations.

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
