### PR TITLE
Possible docs fix re:verify_policies

### DIFF
--- a/samples/scanner/scanners/firewall_rules/blacklist.yaml
+++ b/samples/scanner/scanners/firewall_rules/blacklist.yaml
@@ -22,7 +22,7 @@
 #     See: https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy
 #   c. Return the first applicable rules.
 # 3. For each applicable rule, check if the policy is a superset of one of the "match_policies" defined in the rule.
-# 4. For any rule with a matching policy, check if the policy is a superset of any of the "verify_policies"
+# 4. For any rule with a matching policy, check if the policy is a subset of any of the "verify_policies"
 #     if it is, create a RuleViolation.
 rules:
 


### PR DESCRIPTION
Whitelist docs (https://github.com/GoogleCloudPlatform/forseti-security/blob/master/samples/scanner/scanners/firewall_rules/whitelist.yaml#L25) refer to verify_policies as a "subset", whereas these (blacklist) docs refer to it as a "superset".

From context, I'm guessing that the whitelist docs are wrong and blacklist right...?

(Or that their uses are inconsistent across mode...which wouldn't be great).

***

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [ y] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [ y] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [ y] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [ y] My PR has been functionally tested.
- [ y] All of the [unit-tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) still pass.
- [ y] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
