### PR TITLE
Support multiple dataset ids in BigQuery rules

### DIFF
--- a/rules/bigquery_rules.yaml
+++ b/rules/bigquery_rules.yaml
@@ -24,7 +24,7 @@ rules:
       - type: organization
         resource_ids:
           - {ORGANIZATION_ID}
-    dataset_id: '*'
+    dataset_ids: ['*']
     bindings:
       - role: '*'
         members:
@@ -35,7 +35,7 @@ rules:
       - type: organization
         resource_ids:
           - {ORGANIZATION_ID}
-    dataset_id: '*'
+    dataset_ids: ['*']
     bindings:
       - role: '*'
         members:
@@ -46,7 +46,7 @@ rules:
       - type: organization
         resource_ids:
           - {ORGANIZATION_ID}
-    dataset_id: '*'
+    dataset_ids: ['*']
     bindings:
       - role: '*'
         members:

--- a/tests/scanner/audit/bigquery_rules_engine_test.py
+++ b/tests/scanner/audit/bigquery_rules_engine_test.py
@@ -262,6 +262,20 @@ class BigqueryRulesEngineTest(ForsetiTestCase):
             fake_bigquery_scanner_data.BIGQUERY_EXPECTED_VIOLATION_LIST,
             actual_violations_list)
 
+    def test_multiple_dataset_ids(self):
+        rules_local_path = get_datafile_path(
+            __file__,
+            'bigquery_test_rules_10.yaml')
+        rules_engine = bqe.BigqueryRulesEngine(rules_local_path)
+        rules_engine.build_rule_book()
+        fake_bq_acls_data = create_list_of_bq_objects_from_data()
+        actual_violations_list = []
+        for bqt in fake_bq_acls_data:
+            violation = rules_engine.find_policy_violations(self.project, bqt)
+            actual_violations_list.extend(violation)
+        self.assertEqual(
+            [fake_bigquery_scanner_data.BIGQUERY_EXPECTED_VIOLATION_LIST[0]],
+            actual_violations_list)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scanner/audit/bigquery_rules_engine_test.py
+++ b/tests/scanner/audit/bigquery_rules_engine_test.py
@@ -262,7 +262,7 @@ class BigqueryRulesEngineTest(ForsetiTestCase):
             fake_bigquery_scanner_data.BIGQUERY_EXPECTED_VIOLATION_LIST,
             actual_violations_list)
 
-    def test_multiple_dataset_ids(self):
+    def test_find_violations_multiple_dataset_ids(self):
         rules_local_path = get_datafile_path(
             __file__,
             'bigquery_test_rules_10.yaml')

--- a/tests/scanner/audit/data/bigquery_test_rules_1.yaml
+++ b/tests/scanner/audit/data/bigquery_test_rules_1.yaml
@@ -18,7 +18,7 @@ rules:
       - type: organization
         resource_ids:
           - 234
-    dataset_id: '*'
+    dataset_ids: ['*']
     bindings:
       - role: 'OWNER'
         members: []

--- a/tests/scanner/audit/data/bigquery_test_rules_10.yaml
+++ b/tests/scanner/audit/data/bigquery_test_rules_10.yaml
@@ -19,7 +19,9 @@ rules:
       - type: organization
         resource_ids:
           - 234
-    dataset_ids: ['*']
+    dataset_ids:
+      - 'd1'
+      - 'dne'
     bindings:
       - role: 'OWNER'
         members:

--- a/tests/scanner/audit/data/bigquery_test_rules_2.yaml
+++ b/tests/scanner/audit/data/bigquery_test_rules_2.yaml
@@ -17,6 +17,6 @@ rules:
     resource:
       - type: organization
           - 234
-    dataset_id: '*'
+    dataset_ids: ['*']
     bindings:
       - role: 'OWNER'

--- a/tests/scanner/audit/data/bigquery_test_rules_3.yaml
+++ b/tests/scanner/audit/data/bigquery_test_rules_3.yaml
@@ -18,7 +18,7 @@ rules:
       - type: organization
         resource_ids:
           - 234
-    dataset_id: '*'
+    dataset_ids: ['*']
     bindings:
       - role: 'READER'
         members:

--- a/tests/scanner/audit/data/bigquery_test_rules_5.yaml
+++ b/tests/scanner/audit/data/bigquery_test_rules_5.yaml
@@ -18,7 +18,7 @@
       - type: organization
         resource_ids:
           - 234
-    dataset_id: '*'
+    dataset_ids: ['*']
     bindings:
       - role: 'OWNER'
         members:

--- a/tests/scanner/audit/data/bigquery_test_rules_6.yaml
+++ b/tests/scanner/audit/data/bigquery_test_rules_6.yaml
@@ -18,7 +18,7 @@
       - type: organization
         resource_ids:
           - 234
-    dataset_id: 'dne'
+    dataset_ids: ['dne']
     bindings:
       - role: 'READER'
         members:

--- a/tests/scanner/audit/data/bigquery_test_rules_7.yaml
+++ b/tests/scanner/audit/data/bigquery_test_rules_7.yaml
@@ -18,7 +18,7 @@
       - type: organization
         resource_ids:
           - 111
-    dataset_id: '*'
+    dataset_ids: ['*']
     bindings:
       - role: 'READER'
         members:

--- a/tests/scanner/audit/data/bigquery_test_rules_8.yaml
+++ b/tests/scanner/audit/data/bigquery_test_rules_8.yaml
@@ -18,7 +18,7 @@
       - type: organization
         resource_ids:
           - 234
-    dataset_id: '*'
+    dataset_ids: ['*']
     bindings:
       - role: 'OWNER'
         members:


### PR DESCRIPTION
dataset_id is still preserved for backwards compatibility.

Partially fixes #1937.