### PR TITLE
Adjust Dockerfiles to speed up builds during development

### DIFF
--- a/install/docker/base
+++ b/install/docker/base
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Do not add forseti source in this file to avoid rebuilding base during development.
+
 FROM ubuntu:18.04
 
-# Add only the apt dependencies to avoid rebuilding base during development
+# Add the apt dependencies
 ADD install/dependencies/apt_packages.txt /tmp
 
 # Install host dependencies.

--- a/install/docker/base
+++ b/install/docker/base
@@ -14,13 +14,12 @@
 
 FROM ubuntu:18.04
 
-# Expose our source so we can read in dependencies.
-ADD . /forseti-security/
-WORKDIR /forseti-security/
+# Add only the apt dependencies to avoid rebuilding base during development
+ADD install/dependencies/apt_packages.txt /tmp
 
 # Install host dependencies.
 RUN apt-get update -qq 1> /dev/null && \
-    apt-get install -qq -y $(cat install/dependencies/apt_packages.txt | grep -v "#" | xargs) 1> /dev/null && \
+    apt-get install -qq -y $(cat /tmp/apt_packages.txt | grep -v "#" | xargs) 1> /dev/null && \
     rm -rf /var/lib/apt/lists/*
 
 # Install the CloudSDK for `gcloud`.

--- a/install/docker/forseti
+++ b/install/docker/forseti
@@ -15,8 +15,8 @@
 ARG BASE_IMAGE=forseti/base
 FROM ${BASE_IMAGE}
 
-# Expose our source so we can install Forseti Security.
-ADD . /forseti-security/
+# Add pip requirements file
+ADD requirements.txt /forseti-security/
 WORKDIR /forseti-security/
 
 # Install Forseti Security dependencies.
@@ -26,6 +26,9 @@ WORKDIR /forseti-security/
 RUN pip install -q --upgrade pip==9.0.3
 RUN pip install -q --upgrade setuptools wheel 1> /dev/null
 RUN pip install -q --upgrade -r requirements.txt 1> /dev/null
+
+# Expose our source so we can install Forseti Security.
+ADD . /forseti-security/
 
 # Install Forseti Security.
 RUN python setup.py install 1> /dev/null


### PR DESCRIPTION
Currently, any change to the forseti code causes a rebuild of both docker images.  This is slow, since docker can't cache intermediate work.  This PR fixes that by only copying the requirements files when they are used.  Copying the full source tree is delayed to the end.