### PR TITLE
Properly trap and return errors correctly in travis scripts

### DIFF
--- a/google/cloud/forseti/scanner/audit/bigquery_rules_engine.py
+++ b/google/cloud/forseti/scanner/audit/bigquery_rules_engine.py
@@ -202,14 +202,12 @@ class BigqueryRuleBook(bre.BaseRuleBook):
             raise audit_errors.InvalidRulesSchemaError(
                 'Missing bindings in rule {}'.format(rule_index))
 
-        rule = Rule(rule_name=rule_def.get('name'),
+        return Rule(rule_name=rule_def.get('name'),
                     rule_index=rule_index,
                     rule_reference=RuleReference(
                         dataset_ids=dataset_ids,
                         bindings=bindings,
                         mode=mode))
-
-        return rule
 
     @classmethod
     def _get_binding_from_old_syntax(cls, rule_def):

--- a/install/gcp/installer/util/installer_errors.py
+++ b/install/gcp/installer/util/installer_errors.py
@@ -1,3 +1,19 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Errors regarding Forseti Installer."""
+
 class InstallerError(Exception):
     """Installer Error."""
 

--- a/install/scripts/docker_pystyle_forseti.sh
+++ b/install/scripts/docker_pystyle_forseti.sh
@@ -13,13 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+trap 'return_code=$?' ERR
+
 echo "Running pylint... "
 
-docker -l error exec -it build /bin/bash -c "pylint --rcfile=pylintrc google/ install/"
+docker exec -it build /bin/bash -c "pylint --rcfile=pylintrc google/ install/"
 
 echo "Running flake8... "
 # E501: Is line too long and should be handled by pylint.
 # E711: Comparison to None and should be handled by pylint.
 # E722: Bare except, it's been deemed OK by this project in certain cases.
 # F841: Assigned but unused variable becuase flake/pycodestyle doesn't ignore _.
-docker -l error exec -it build /bin/bash -c "flake8 --max-line-length=80 --ignore=E501,E711,E722,F841 --exclude=*pb2*.py google/"
+docker exec -it build /bin/bash -c "flake8 --max-line-length=80 --ignore=E501,E711,E722,F841 --exclude=*pb2*.py google/"
+
+exit ${return_code}

--- a/install/scripts/docker_pystyle_forseti.sh
+++ b/install/scripts/docker_pystyle_forseti.sh
@@ -24,6 +24,6 @@ echo "Running flake8... "
 # E711: Comparison to None and should be handled by pylint.
 # E722: Bare except, it's been deemed OK by this project in certain cases.
 # F841: Assigned but unused variable becuase flake/pycodestyle doesn't ignore _.
-docker exec -it build /bin/bash -c "flake8 --max-line-length=80 --ignore=E501,E711,E722,F841 --exclude=*pb2*.py google/"
+docker exec -it build /bin/bash -c "flake8 -v --doctests --max-line-length=80 --ignore=E501,E711,E722,F841 --exclude=*pb2*.py google/"
 
 exit ${return_code}

--- a/install/scripts/docker_run_forseti.sh
+++ b/install/scripts/docker_run_forseti.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+trap 'return_code=$?' ERR
+
 # Check to see that the docker command is available to us.
 if [ -x "$(command -v docker)" ]; then
     # Docker command does exist.
@@ -24,11 +26,11 @@ if [ -x "$(command -v docker)" ]; then
         CI_ENV=`bash <(curl -s https://codecov.io/env)`
         # Start the container for testing and code verification.
         echo "Starting our container for testing and code verification... "
-        docker -l error run ${CI_ENV} -it -d --name build forseti/build /bin/bash
+        docker run ${CI_ENV} -it -d --name build forseti/build /bin/bash
     else
         # We're not on Travis, run without the CI_ENV environment variable.
         echo "Starting our container for testing and code verification... "
-        docker -l error run -it -d --name build forseti/build /bin/bash
+        docker run -it -d --name build forseti/build /bin/bash
     fi
 else
     echo "Can\'t run docker, exiting."
@@ -38,6 +40,8 @@ fi
 # Test to see Forseti Security was installed, these should match the entry
 # points in setup.py
 echo "Testing the container for a successfull Forseti Security installation... "
-docker -l error exec -it build /bin/bash -c "hash forseti" || exit 1
-docker -l error exec -it build /bin/bash -c "hash forseti_enforcer" || exit 1
-docker -l error exec -it build /bin/bash -c "hash forseti_server" || exit 1
+docker exec -it build /bin/bash -c "hash forseti" || exit 1
+docker exec -it build /bin/bash -c "hash forseti_enforcer" || exit 1
+docker exec -it build /bin/bash -c "hash forseti_server" || exit 1
+
+exit ${return_code}

--- a/install/scripts/docker_setup_forseti.sh
+++ b/install/scripts/docker_setup_forseti.sh
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+trap 'return_code=$?' ERR
+
 # Delete all running containers if we're not on Travis.
 if [ -z ${TRAVIS+x} ]; then
     # We are not on Travis.
     echo "Force removing any running containers... "
     if [[ $(docker ps -a -q) ]]; then
-        docker -l error rm -f $(docker ps -a -q | xargs)
+        docker rm -f $(docker ps -a -q | xargs)
     fi
 fi
 
@@ -36,9 +38,11 @@ fi
 # This assumes the script is run from the top of the source-tree.
 if [ -x "$(command -v docker)" ]; then
     echo "Building our Docker base image... "
-    docker -l error build -t forseti/base -f install/docker/base .
+    docker build -t forseti/base -f install/docker/base .
     echo "Building our Forseti image from the Docker base image... "
-    docker -l error build -t forseti/build -f install/docker/forseti --no-cache .
+    docker build -t forseti/build -f install/docker/forseti --no-cache .
 else
     echo "ERROR: Docker must be installed and it isn't, exiting." && exit 1
 fi
+
+exit ${return_code}

--- a/install/scripts/docker_unittest_forseti.sh
+++ b/install/scripts/docker_unittest_forseti.sh
@@ -13,14 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+trap 'return_code=$?' ERR
+
 echo "Running unittests... "
 
 # Check to see if we're on Travis.
 if [ ${TRAVIS+x} ]; then
     # We are on Travis.
     # Run our tests with codecov
-    docker -l error exec -it build /bin/bash -c "coverage run --source='google.cloud.forseti' --omit='__init__.py' -m unittest discover --verbose -s . -p '*_test.py'"
+    docker exec -it build /bin/bash -c "coverage run --source='google.cloud.forseti' --omit='__init__.py' -m unittest discover --verbose -s . -p '*_test.py'"
 else
     # We are NOT on Travis.
-    docker -l error exec -it build /bin/bash -c "python -m unittest discover --verbose -s . -p '*_test.py'"
+    docker exec -it build /bin/bash -c "python -m unittest discover --verbose -s . -p '*_test.py'"
 fi
+
+exit ${return_code}


### PR DESCRIPTION
This should ensure that if any command in any of the bash script test runners fail we still report the return code correctly, not just the last one.

This also defaults the docker commands back to a default log level.