### PR TITLE
[docs] Add missing cd command to setup guide

### DIFF
--- a/_docs/_latest/setup/install.md
+++ b/_docs/_latest/setup/install.md
@@ -49,13 +49,14 @@ steps below:
 
       ```bash
       git clone https://github.com/GoogleCloudPlatform/forseti-security.git
-      cd forseti-security
       ```
 
   1. Check out the specific version of Forseti you want to install by using a tag like `v2.0.0.`:
 
       ```bash
       # Make sure you are in the forseti-security folder.
+      cd forseti-security
+
       # If the tag exists in the remote repository but you are unable to checkout the tag,
       # run command `git fetch --all` to fetch all the latest branch/tag information and run
       # the checkout command again.

--- a/_docs/_latest/setup/install.md
+++ b/_docs/_latest/setup/install.md
@@ -49,6 +49,7 @@ steps below:
 
       ```bash
       git clone https://github.com/GoogleCloudPlatform/forseti-security.git
+      cd forseti-security
       ```
 
   1. Check out the specific version of Forseti you want to install by using a tag like `v2.0.0.`:

--- a/_docs/v2.0/setup/install.md
+++ b/_docs/v2.0/setup/install.md
@@ -49,13 +49,14 @@ steps below:
 
       ```bash
       git clone https://github.com/GoogleCloudPlatform/forseti-security.git
-      cd forseti-security
       ```
 
   1. Check out the specific version of Forseti you want to install by using a tag like `v2.0.0.`:
 
       ```bash
       # Make sure you are in the forseti-security folder.
+      cd forseti-security
+
       # If the tag exists in the remote repository but you are unable to checkout the tag,
       # run command `git fetch --all` to fetch all the latest branch/tag information and run
       # the checkout command again.

--- a/_docs/v2.0/setup/install.md
+++ b/_docs/v2.0/setup/install.md
@@ -49,6 +49,7 @@ steps below:
 
       ```bash
       git clone https://github.com/GoogleCloudPlatform/forseti-security.git
+      cd forseti-security
       ```
 
   1. Check out the specific version of Forseti you want to install by using a tag like `v2.0.0.`:

--- a/_docs/v2.1/setup/install.md
+++ b/_docs/v2.1/setup/install.md
@@ -49,13 +49,14 @@ steps below:
 
       ```bash
       git clone https://github.com/GoogleCloudPlatform/forseti-security.git
-      cd forseti-security
       ```
 
   1. Check out the specific version of Forseti you want to install by using a tag like `v2.0.0.`:
 
       ```bash
       # Make sure you are in the forseti-security folder.
+      cd forseti-security
+
       # If the tag exists in the remote repository but you are unable to checkout the tag,
       # run command `git fetch --all` to fetch all the latest branch/tag information and run
       # the checkout command again.

--- a/_docs/v2.1/setup/install.md
+++ b/_docs/v2.1/setup/install.md
@@ -49,6 +49,7 @@ steps below:
 
       ```bash
       git clone https://github.com/GoogleCloudPlatform/forseti-security.git
+      cd forseti-security
       ```
 
   1. Check out the specific version of Forseti you want to install by using a tag like `v2.0.0.`:

--- a/_docs/v2.2/setup/install.md
+++ b/_docs/v2.2/setup/install.md
@@ -49,13 +49,14 @@ steps below:
 
       ```bash
       git clone https://github.com/GoogleCloudPlatform/forseti-security.git
-      cd forseti-security
       ```
 
   1. Check out the specific version of Forseti you want to install by using a tag like `v2.0.0.`:
 
       ```bash
       # Make sure you are in the forseti-security folder.
+      cd forseti-security
+
       # If the tag exists in the remote repository but you are unable to checkout the tag,
       # run command `git fetch --all` to fetch all the latest branch/tag information and run
       # the checkout command again.

--- a/_docs/v2.2/setup/install.md
+++ b/_docs/v2.2/setup/install.md
@@ -49,6 +49,7 @@ steps below:
 
       ```bash
       git clone https://github.com/GoogleCloudPlatform/forseti-security.git
+      cd forseti-security
       ```
 
   1. Check out the specific version of Forseti you want to install by using a tag like `v2.0.0.`:

--- a/_docs/v2.3/setup/install.md
+++ b/_docs/v2.3/setup/install.md
@@ -49,13 +49,14 @@ steps below:
 
       ```bash
       git clone https://github.com/GoogleCloudPlatform/forseti-security.git
-      cd forseti-security
       ```
 
   1. Check out the specific version of Forseti you want to install by using a tag like `v2.0.0.`:
 
       ```bash
       # Make sure you are in the forseti-security folder.
+      cd forseti-security
+
       # If the tag exists in the remote repository but you are unable to checkout the tag,
       # run command `git fetch --all` to fetch all the latest branch/tag information and run
       # the checkout command again.

--- a/_docs/v2.3/setup/install.md
+++ b/_docs/v2.3/setup/install.md
@@ -49,6 +49,7 @@ steps below:
 
       ```bash
       git clone https://github.com/GoogleCloudPlatform/forseti-security.git
+      cd forseti-security
       ```
 
   1. Check out the specific version of Forseti you want to install by using a tag like `v2.0.0.`:


### PR DESCRIPTION
Copying install commands as-is misses the step to `cd` into the
freshly cloned `forseti-security` directory after a `git clone`. This
PR adds that steps for easier copy-and-paste setup.