### PR TITLE
Typo in help text of gcloud command

### DIFF
--- a/install/gcp/installer/util/constants.py
+++ b/install/gcp/installer/util/constants.py
@@ -239,7 +239,7 @@ MESSAGE_NO_CLOUD_SHELL = (
     '3) Install gcloud and authenticate your account using '
     '"gcloud auth login".\n'
     '4) Set your project using '
-    '"gcloud config project set <PROJECT_ID>".\n'
+    '"gcloud config set project <PROJECT_ID>".\n'
     '5) Run this setup again, with the --no-cloudshell flag, '
     'i.e.\n\n\tpython install/gcp_installer.py --no-cloudshell\n')
 


### PR DESCRIPTION
Typo in help text.

I saw this while trying to deploy forseti from non cloudshell env.