### PR TITLE
fix lt, gt for source and target tags

### DIFF
--- a/google/cloud/forseti/common/gcp_type/firewall_rule.py
+++ b/google/cloud/forseti/common/gcp_type/firewall_rule.py
@@ -516,8 +516,8 @@ class FirewallRule(object):
                      other.direction is None)
         network = (self.network == other.network or
                    other.network is None)
-        source_tags = set(self.source_tags).issubset(other.source_tags)
-        target_tags = set(self.target_tags).issubset(other.target_tags)
+        source_tags = set(self.source_tags).issubset(other.source_tags) or not other.source_tags
+        target_tags = set(self.target_tags).issubset(other.target_tags) or not other.target_tags
         source_ranges = ips_in_list(self.source_ranges, other.source_ranges)
         destination_ranges = ips_in_list(self.destination_ranges,
                                          other.destination_ranges)
@@ -551,8 +551,8 @@ class FirewallRule(object):
         network = (self.network is None or
                    other.network is None or
                    self.network == other.network)
-        source_tags = set(other.source_tags).issubset(self.source_tags)
-        target_tags = set(other.target_tags).issubset(self.target_tags)
+        source_tags = set(other.source_tags).issubset(self.source_tags) or not self.source_tags
+        target_tags = set(other.target_tags).issubset(self.target_tags) or not self.target_tags
         firewall_action = self.firewall_action > other.firewall_action
         source_ranges = ips_in_list(other.source_ranges, self.source_ranges)
         destination_ranges = ips_in_list(other.destination_ranges,


### PR DESCRIPTION
- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)

When you have a firewall policy in GCP **with** a target tag

```{
    "name": "firewall",
    "network": "network_name",
    "priority": priority_number,
    "sourceRanges": [
      "any_ip",
      ],
    "targetTags": [
     "target_tag_name",
     ],
    "allowed": [
      {
        "IPProtocol": "all",
      }
    ],
```


but the verifying policy in your Forseti rules **does not**:

```
  - rule_id: 'blah'
    description: blah
    mode: whitelist
    match_policies:
      - direction: ingress
        allowed: ['*']
    verify_policies:
      - allowed:
        - IPProtocol: 'all'
        sourceRanges:
          - '0.0.0.0/0'
```

a violation is triggered.  This seems incorrect.

This happens in `is_whitelist_violation`

https://github.com/GoogleCloudPlatform/forseti-security/blob/aca013268be794fc991c74e810428f539c767c48/google/cloud/forseti/scanner/audit/firewall_rules_engine.py#L608

when we check if a policy is not a subset of the verifying rules.  This subset check is done via an overwritten `__lt__` where if the policy `target_tag` is not a subset of the rule `target_tag`, a violation is triggered.

This happens because if the rule does not specify a `target_tag` (what we interpret to mean that it should consider policies with any or no `target_tag`) but the policy does have a `target_tag`, the following comparison

https://github.com/GoogleCloudPlatform/forseti-security/blob/aca013268be794fc991c74e810428f539c767c48/google/cloud/forseti/common/gcp_type/firewall_rule.py#L520

will return `False` and bubble up to cause a whitelist violation.

By symmetry, we will also fix **incorrect** violations that are triggered in the following cases:

1. policy has target tag; verifying rule does not have target tag (case mentioned above)
1. policy has source tag; verifying rule does not have target tag
1. policy does not have target tag; matching rule has target tag
1. policy does not have source tag; matching rule has source tag

We also took a look at extending the unit tests, but it was not very welcoming :(