### PR TITLE
Fix Client Config Path

### DIFF
--- a/google/cloud/forseti/services/cli.py
+++ b/google/cloud/forseti/services/cli.py
@@ -1181,8 +1181,7 @@ def get_config_path():
         str: Configuration path.
     """
 
-    default_path = os.path.join(os.getenv('HOME'), '.forseti')
-    config_path = read_env('FORSETI_SERVER_CONFIG', default_path)
+    config_path = os.path.join(os.getenv('HOME'), '.forseti')
     return config_path
 
 


### PR DESCRIPTION
`FORSETI_SERVER_CONFIG` is a typo, does not exist anywhere, and thus causes everything to fall back to the `default_path`.

As a side-note, it's really meant to be `FORSETI_CLIENT_CONFIG`, but that is a yaml file on GCS bucket, and will not be read correctly as json later on.

So, removing this entire line, as it has never been used correctly, and thus is not needed.

Please cherrypick this into 2.5.0 release.
