### PR TITLE
Fix cloudasset_test.py

### DIFF
--- a/tests/services/inventory/cloudasset_test.py
+++ b/tests/services/inventory/cloudasset_test.py
@@ -18,6 +18,8 @@ import unittest
 from googleapiclient import errors
 import httplib2
 import mock
+import google.auth
+from google.oauth2 import credentials
 from sqlalchemy.orm import sessionmaker
 
 from tests.services.util.db import create_test_engine_with_file
@@ -94,6 +96,11 @@ class InventoryCloudAssetTest(ForsetiTestCase):
             file_loader,
             'copy_file_from_gcs',
             autospec=True).start()
+        self.mock_auth = mock.patch.object(
+            google.auth,
+            'default',
+            return_value=(mock.Mock(
+                spec_set=credentials.Credentials), 'test-project')).start()
 
     def tearDown(self):
         """tearDown."""
@@ -235,5 +242,3 @@ class InventoryCloudAssetTest(ForsetiTestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
-


### PR DESCRIPTION
```
(forseti-security) umairidris@umairidris:~/forseti-security$ python -m unittest discover -s . -p "cloudasset*test*"
.EEEEE..........
======================================================================
ERROR: test_load_cloudasset_data (tests.services.inventory.cloudasset_test.InventoryCloudAssetTest)
Validate load_cloudasset_data correctly dumps and imports data.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/umairidris/forseti-security/tests/services/inventory/cloudasset_test.py", line 185, in test_load_cloudasset_data
    self.inventory_config)
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/services/inventory/base/cloudasset.py", line 48, in load_cloudasset_data
    config.get_api_quota_configs())
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/cloudasset.py", line 176, in __init__
    use_rate_limiter=kwargs.get('use_rate_limiter', True))
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/cloudasset.py", line 58, in __init__
    use_rate_limiter=use_rate_limiter)
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/_base_repository.py", line 186, in __init__
    credentials, _ = google.auth.default()
  File "/usr/local/google/home/umairidris/IdeaProjects/forseti-security/.eggs/google_auth-1.5.1-py2.7.egg/google/auth/_default.py", line 306, in default
    raise exceptions.DefaultCredentialsError(_HELP_MESSAGE)
DefaultCredentialsError: Could not automatically determine credentials. Please set GOOGLE_APPLICATION_CREDENTIALS or explicitly create credentials and re-run the application. For more information, please see https://developers.google.com/accounts/docs/application-default-credentials.

======================================================================
ERROR: test_load_cloudasset_data_cai_apierror (tests.services.inventory.cloudasset_test.InventoryCloudAssetTest)
Validate load_cloud_asset handles an API error from CAI.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/umairidris/forseti-security/tests/services/inventory/cloudasset_test.py", line 202, in test_load_cloudasset_data_cai_apierror
    self.inventory_config)
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/services/inventory/base/cloudasset.py", line 48, in load_cloudasset_data
    config.get_api_quota_configs())
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/cloudasset.py", line 176, in __init__
    use_rate_limiter=kwargs.get('use_rate_limiter', True))
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/cloudasset.py", line 58, in __init__
    use_rate_limiter=use_rate_limiter)
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/_base_repository.py", line 186, in __init__
    credentials, _ = google.auth.default()
  File "/usr/local/google/home/umairidris/IdeaProjects/forseti-security/.eggs/google_auth-1.5.1-py2.7.egg/google/auth/_default.py", line 306, in default
    raise exceptions.DefaultCredentialsError(_HELP_MESSAGE)
DefaultCredentialsError: Could not automatically determine credentials. Please set GOOGLE_APPLICATION_CREDENTIALS or explicitly create credentials and re-run the application. For more information, please see https://developers.google.com/accounts/docs/application-default-credentials.

======================================================================
ERROR: test_load_cloudasset_data_cai_error_response (tests.services.inventory.cloudasset_test.InventoryCloudAssetTest)
Validate load_cloud_asset handles an error result from CAI.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/umairidris/forseti-security/tests/services/inventory/cloudasset_test.py", line 221, in test_load_cloudasset_data_cai_error_response
    self.inventory_config)
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/services/inventory/base/cloudasset.py", line 48, in load_cloudasset_data
    config.get_api_quota_configs())
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/cloudasset.py", line 176, in __init__
    use_rate_limiter=kwargs.get('use_rate_limiter', True))
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/cloudasset.py", line 58, in __init__
    use_rate_limiter=use_rate_limiter)
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/_base_repository.py", line 186, in __init__
    credentials, _ = google.auth.default()
  File "/usr/local/google/home/umairidris/IdeaProjects/forseti-security/.eggs/google_auth-1.5.1-py2.7.egg/google/auth/_default.py", line 306, in default
    raise exceptions.DefaultCredentialsError(_HELP_MESSAGE)
DefaultCredentialsError: Could not automatically determine credentials. Please set GOOGLE_APPLICATION_CREDENTIALS or explicitly create credentials and re-run the application. For more information, please see https://developers.google.com/accounts/docs/application-default-credentials.

======================================================================
ERROR: test_load_cloudasset_data_cai_timeout (tests.services.inventory.cloudasset_test.InventoryCloudAssetTest)
Validate load_cloud_asset handles a timeout error.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/umairidris/forseti-security/tests/services/inventory/cloudasset_test.py", line 212, in test_load_cloudasset_data_cai_timeout
    self.inventory_config)
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/services/inventory/base/cloudasset.py", line 48, in load_cloudasset_data
    config.get_api_quota_configs())
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/cloudasset.py", line 176, in __init__
    use_rate_limiter=kwargs.get('use_rate_limiter', True))
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/cloudasset.py", line 58, in __init__
    use_rate_limiter=use_rate_limiter)
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/_base_repository.py", line 186, in __init__
    credentials, _ = google.auth.default()
  File "/usr/local/google/home/umairidris/IdeaProjects/forseti-security/.eggs/google_auth-1.5.1-py2.7.egg/google/auth/_default.py", line 306, in default
    raise exceptions.DefaultCredentialsError(_HELP_MESSAGE)
DefaultCredentialsError: Could not automatically determine credentials. Please set GOOGLE_APPLICATION_CREDENTIALS or explicitly create credentials and re-run the application. For more information, please see https://developers.google.com/accounts/docs/application-default-credentials.

======================================================================
ERROR: test_load_cloudasset_data_download_error (tests.services.inventory.cloudasset_test.InventoryCloudAssetTest)
Validate load_cloud_asset handles an error downloading from GCS.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/umairidris/forseti-security/tests/services/inventory/cloudasset_test.py", line 238, in test_load_cloudasset_data_download_error
    self.inventory_config)
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/services/inventory/base/cloudasset.py", line 48, in load_cloudasset_data
    config.get_api_quota_configs())
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/cloudasset.py", line 176, in __init__
    use_rate_limiter=kwargs.get('use_rate_limiter', True))
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/cloudasset.py", line 58, in __init__
    use_rate_limiter=use_rate_limiter)
  File "/usr/local/google/home/umairidris/forseti-security/google/cloud/forseti/common/gcp_api/_base_repository.py", line 186, in __init__
    credentials, _ = google.auth.default()
  File "/usr/local/google/home/umairidris/IdeaProjects/forseti-security/.eggs/google_auth-1.5.1-py2.7.egg/google/auth/_default.py", line 306, in default
    raise exceptions.DefaultCredentialsError(_HELP_MESSAGE)
DefaultCredentialsError: Could not automatically determine credentials. Please set GOOGLE_APPLICATION_CREDENTIALS or explicitly create credentials and re-run the application. For more information, please see https://developers.google.com/accounts/docs/application-default-credentials.
```