### PR TITLE
Fix Firewall Tests

### DIFF
--- a/google/cloud/forseti/common/gcp_type/firewall_rule.py
+++ b/google/cloud/forseti/common/gcp_type/firewall_rule.py
@@ -518,16 +518,16 @@ class FirewallRule(object):
                    other.network is None)
         source_tags = set(self.source_tags).issubset(other.source_tags)
         target_tags = set(self.target_tags).issubset(other.target_tags)
+        firewall_action = self.firewall_action < other.firewall_action
         source_ranges = ips_in_list(self.source_ranges, other.source_ranges)
         destination_ranges = ips_in_list(self.destination_ranges,
                                          other.destination_ranges)
 
-        # Moving firewall_actions out from here will make tests fail.
         result = (direction and
                   network and
                   source_tags and
                   target_tags and
-                  self.firewall_action < other.firewall_action and
+                  firewall_action and
                   source_ranges and
                   destination_ranges)
         return result

--- a/tests/scanner/audit/data/firewall_test_rules.yaml
+++ b/tests/scanner/audit/data/firewall_test_rules.yaml
@@ -8,7 +8,7 @@ rules:
         targetTags:
           - 'test'
     verify_policies:
-      - allowed: '*'
+      - allowed: ['*']
         sourceRanges:
         - '10.0.0.0/8'
 


### PR DESCRIPTION
The change here matches the [sample rule](https://github.com/GoogleCloudPlatform/forseti-security/blob/dev/samples/scanner/scanners/firewall_rules/whitelist.yaml#L80)

Fixes the failing tests in #2050 and #2015.