### PR TITLE
Update apt_packages to include new mysql name

### DIFF
--- a/install/dependencies/apt_packages.txt
+++ b/install/dependencies/apt_packages.txt
@@ -3,7 +3,7 @@ build-essential
 git
 libffi-dev
 libssl-dev
-libmysqlclient-dev
+default-libmysqlclient-dev
 libpython-dev
 python-pip
 python-dev


### PR DESCRIPTION
libmysqlclient-dev is no longer available after Debian Jessie (oldstable). It is now default-libmysqlclient-dev.

https://packages.debian.org/search?searchon=names&keywords=libmysqlclient-dev