### PR TITLE
Prevent output to the console when using the CLI.

### DIFF
--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -84,6 +84,8 @@ def get_logger(module_name):
     logger_instance = logging.getLogger(module_name)
     logger_instance.addHandler(default_log_handler)
     logger_instance.setLevel(LOGLEVEL)
+    # Prevent output to CLI's stdout via other ancestor loggers.
+    logger_instance.propagate = False
 
     if LOG_TO_CONSOLE:
         console_handler = logging.StreamHandler()


### PR DESCRIPTION
Verified this works:
- client VM cli
- server VM cli
- server VM stackdriver logs
- dev env, can output to console

Fixes #2183 , #2164 