### PR TITLE
Update BufferedDbWriter to be aware of the size of data sent to SQL.

### DIFF
--- a/google/cloud/forseti/services/inventory/storage.py
+++ b/google/cloud/forseti/services/inventory/storage.py
@@ -52,6 +52,7 @@ LOGGER = logger.get_logger(__name__)
 BASE = declarative_base()
 CURRENT_SCHEMA = 1
 PER_YIELD = 1024
+MAX_ALLOWED_PACKET = 32*1024*1024  # 32 Mb is the default mysql max packet size
 
 
 class Categories(enum.Enum):
@@ -659,38 +660,49 @@ class CaiTemporaryStore(object):
 class BufferedDbWriter(object):
     """Buffered db writing."""
 
-    def __init__(self, session, max_size=1024, commit_on_flush=False):
+    def __init__(self,
+                 session,
+                 max_size=1024,
+                 max_packet_size=MAX_ALLOWED_PACKET*.75,
+                 commit_on_flush=False):
         """Initialize
 
         Args:
             session (object): db session
             max_size (int): max size of buffer
+            max_packet_size (int): max size of a packet to send to SQL
             commit_on_flush (bool): If true, the session is committed to the
                 database when the data is flushed.
         """
         self.session = session
         self.buffer = []
+        self.estimated_packet_size = 0
         self.max_size = max_size
+        self.max_packet_size = max_packet_size
         self.commit_on_flush = commit_on_flush
 
-    def add(self, obj):
+    def add(self, obj, estimated_length=0):
         """Add an object to the buffer to write to db.
 
         Args:
             obj (object): Object to write to db.
+            estimated_length (int): The estimated length of this object.
         """
 
         self.buffer.append(obj)
-        if len(self.buffer) >= self.max_size:
+        self.estimated_packet_size += estimated_length
+        if (self.estimated_packet_size > self.max_packet_size or
+                len(self.buffer) >= self.max_size):
             self.flush()
 
     def flush(self):
         """Flush all pending objects to the database."""
 
-        self.session.add_all(self.buffer)
+        self.session.bulk_save_objects(self.buffer)
         self.session.flush()
         if self.commit_on_flush:
             self.session.commit()
+        self.estimated_packet_size = 0
         self.buffer = []
 
 
@@ -729,7 +741,11 @@ class CaiDataAccess(object):
         Returns:
             int: The number of rows inserted
         """
-        commit_buffer = BufferedDbWriter(session, commit_on_flush=True)
+        # CAI data can be large, so limit the number of rows written at one
+        # time to 512.
+        commit_buffer = BufferedDbWriter(session,
+                                         max_size=512,
+                                         commit_on_flush=True)
         num_rows = 0
         try:
             for line in data:
@@ -757,7 +773,9 @@ class CaiDataAccess(object):
                                 resource.get('asset_type', ''), content_type)
                     continue
                 if row:
-                    commit_buffer.add(row)
+                    # Overestimate the packet length to ensure max size is never
+                    # exceeded. The actual length is closer to len(line)*1.5.
+                    commit_buffer.add(row, estimated_length=len(line)*2)
                     num_rows += 1
             commit_buffer.flush()
         except SQLAlchemyError as e:

--- a/google/cloud/forseti/services/inventory/storage.py
+++ b/google/cloud/forseti/services/inventory/storage.py
@@ -52,7 +52,7 @@ LOGGER = logger.get_logger(__name__)
 BASE = declarative_base()
 CURRENT_SCHEMA = 1
 PER_YIELD = 1024
-MAX_ALLOWED_PACKET = 32*1024*1024  # 32 Mb is the default mysql max packet size
+MAX_ALLOWED_PACKET = 32 * 1024 * 1024  # 32 Mb default mysql max packet size
 
 
 class Categories(enum.Enum):
@@ -663,7 +663,7 @@ class BufferedDbWriter(object):
     def __init__(self,
                  session,
                  max_size=1024,
-                 max_packet_size=MAX_ALLOWED_PACKET*.75,
+                 max_packet_size=MAX_ALLOWED_PACKET * .75,
                  commit_on_flush=False):
         """Initialize
 
@@ -774,8 +774,8 @@ class CaiDataAccess(object):
                     continue
                 if row:
                     # Overestimate the packet length to ensure max size is never
-                    # exceeded. The actual length is closer to len(line)*1.5.
-                    commit_buffer.add(row, estimated_length=len(line)*2)
+                    # exceeded. The actual length is closer to len(line) * 1.5.
+                    commit_buffer.add(row, estimated_length=len(line) * 2)
                     num_rows += 1
             commit_buffer.flush()
         except SQLAlchemyError as e:


### PR DESCRIPTION
Resolves #2292.

* Ensure that the size of a flush is never larger than MAX_ALLOWED_PACKET for Cloud Asset data.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
