### PR TITLE
When nothing is available to scan return empty set

### DIFF
--- a/google/cloud/forseti/scanner/scanners/enabled_apis_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/enabled_apis_scanner.py
@@ -135,7 +135,7 @@ class EnabledApisScanner(base_scanner.BaseScanner):
 
         if not enabled_apis_data:
             LOGGER.warn('No Enabled APIs found. Exiting.')
-            sys.exit(1)
+            return iter([])
 
         return enabled_apis_data
 

--- a/google/cloud/forseti/scanner/scanners/enabled_apis_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/enabled_apis_scanner.py
@@ -15,7 +15,6 @@
 """Scanner for Enabled APIs."""
 
 import json
-import sys
 
 from google.cloud.forseti.common.gcp_type.project import Project
 from google.cloud.forseti.common.util import logger

--- a/google/cloud/forseti/scanner/scanners/enabled_apis_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/enabled_apis_scanner.py
@@ -135,7 +135,7 @@ class EnabledApisScanner(base_scanner.BaseScanner):
 
         if not enabled_apis_data:
             LOGGER.warn('No Enabled APIs found. Exiting.')
-            return iter([])
+            sys.exit(1)
 
         return enabled_apis_data
 

--- a/google/cloud/forseti/scanner/scanners/enabled_apis_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/enabled_apis_scanner.py
@@ -15,6 +15,7 @@
 """Scanner for Enabled APIs."""
 
 import json
+import sys
 
 from google.cloud.forseti.common.gcp_type.project import Project
 from google.cloud.forseti.common.util import logger

--- a/google/cloud/forseti/scanner/scanners/enabled_apis_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/enabled_apis_scanner.py
@@ -15,7 +15,6 @@
 """Scanner for Enabled APIs."""
 
 import json
-import sys
 
 from google.cloud.forseti.common.gcp_type.project import Project
 from google.cloud.forseti.common.util import logger
@@ -135,7 +134,7 @@ class EnabledApisScanner(base_scanner.BaseScanner):
 
         if not enabled_apis_data:
             LOGGER.warn('No Enabled APIs found. Exiting.')
-            sys.exit(1)
+            return iter([])
 
         return enabled_apis_data
 

--- a/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
@@ -15,7 +15,6 @@
 """Scanner for the IAM rules engine."""
 
 import json
-import sys
 
 from google.cloud.forseti.common.gcp_type.billing_account import BillingAccount
 from google.cloud.forseti.common.gcp_type.bucket import Bucket
@@ -242,7 +241,7 @@ class IamPolicyScanner(base_scanner.BaseScanner):
 
         if not policy_data:
             LOGGER.warn('No policies found. Exiting.')
-            sys.exit(1)
+            return iter([]), 0
 
         return policy_data, resource_counts
 

--- a/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
@@ -15,6 +15,7 @@
 """Scanner for the IAM rules engine."""
 
 import json
+import sys
 
 from google.cloud.forseti.common.gcp_type.billing_account import BillingAccount
 from google.cloud.forseti.common.gcp_type.bucket import Bucket

--- a/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
@@ -242,7 +242,7 @@ class IamPolicyScanner(base_scanner.BaseScanner):
 
         if not policy_data:
             LOGGER.warn('No policies found. Exiting.')
-            sys.exit(1)
+            return iter([]), 0
 
         return policy_data, resource_counts
 

--- a/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
@@ -15,7 +15,6 @@
 """Scanner for the IAM rules engine."""
 
 import json
-import sys
 
 from google.cloud.forseti.common.gcp_type.billing_account import BillingAccount
 from google.cloud.forseti.common.gcp_type.bucket import Bucket

--- a/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
@@ -242,7 +242,7 @@ class IamPolicyScanner(base_scanner.BaseScanner):
 
         if not policy_data:
             LOGGER.warn('No policies found. Exiting.')
-            return iter([]), 0
+            sys.exit(1)
 
         return policy_data, resource_counts
 


### PR DESCRIPTION
This resolves a problem where the Enabled API and IAM Rules scanners have no results.  Previously they issued a system exit, now they return empty results.