### PR TITLE
Handle the no data retrieved more consistently with empty data instead of raising exception.

### DIFF
--- a/google/cloud/forseti/scanner/scanners/enabled_apis_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/enabled_apis_scanner.py
@@ -17,7 +17,6 @@
 import json
 
 from google.cloud.forseti.common.gcp_type.project import Project
-from google.cloud.forseti.common.util import errors as util_errors
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.scanner.audit import enabled_apis_rules_engine
 from google.cloud.forseti.scanner.scanners import base_scanner
@@ -137,17 +136,13 @@ class EnabledApisScanner(base_scanner.BaseScanner):
                          enabled_apis))
 
         if not enabled_apis_data:
-            LOGGER.warn('No Enabled APIs found. Exiting.')
-            raise util_errors.NoDataError('No enabled APIs found. Exiting')
+            LOGGER.warn('No Enabled APIs found.')
+            return []
 
         return enabled_apis_data
 
     def run(self):
         """Runs the data collection."""
-        try:
-            enabled_apis_data = self._retrieve()
-        except util_errors.NoDataError:
-            return
-
+        enabled_apis_data = self._retrieve()
         all_violations = self._find_violations(enabled_apis_data)
         self._output_results(all_violations)

--- a/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
@@ -23,7 +23,6 @@ from google.cloud.forseti.common.gcp_type import iam_policy
 from google.cloud.forseti.common.gcp_type.organization import Organization
 from google.cloud.forseti.common.gcp_type.project import Project
 from google.cloud.forseti.common.gcp_type.resource import ResourceType
-from google.cloud.forseti.common.util import errors as util_errors
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.scanner.audit import iam_rules_engine
 from google.cloud.forseti.scanner.scanners import base_scanner
@@ -244,18 +243,14 @@ class IamPolicyScanner(base_scanner.BaseScanner):
                          policy, policy_bindings))
 
         if not policy_data:
-            LOGGER.warn('No policies found. Exiting.')
-            raise util_errors.NoDataError('No policies found. Exiting.')
+            LOGGER.warn('No policies found.')
+            return [], 0
 
         return policy_data, resource_counts
 
     def run(self):
         """Runs the data collection."""
-        try:
-            policy_data, _ = self._retrieve()
-        except util_errors.NoDataError:
-            return
-
+        policy_data, _ = self._retrieve()
         _add_bucket_ancestor_bindings(policy_data)
         all_violations = self._find_violations(policy_data)
         self._output_results(all_violations)


### PR DESCRIPTION
Rework of #2307, to align with the handling of no retrieved data in #2294.  Return empty data so that at least the empty data can passed on to the rules engine to find for violation in the case where `mode: required`.