### PR TITLE
add charset=utf8 on MySQL connection parameter

### DIFF
--- a/install/gcp/scripts/initialize_forseti_services.sh
+++ b/install/gcp/scripts/initialize_forseti_services.sh
@@ -36,7 +36,7 @@ SQL_SERVER_LOCAL_ADDRESS="mysql://root@127.0.0.1:${SQL_PORT}"
 FORSETI_SERVICES="explain inventory model scanner notifier"
 
 FORSETI_COMMAND="$(which forseti_server) --endpoint '[::]:50051'"
-FORSETI_COMMAND+=" --forseti_db ${SQL_SERVER_LOCAL_ADDRESS}/${FORSETI_DB_NAME}"
+FORSETI_COMMAND+=" --forseti_db ${SQL_SERVER_LOCAL_ADDRESS}/${FORSETI_DB_NAME}?charset=utf8"
 FORSETI_COMMAND+=" --config_file_path ${FORSETI_SERVER_CONF}"
 FORSETI_COMMAND+=" --services ${FORSETI_SERVICES}"
 


### PR DESCRIPTION
Add charset=utf8 on MySQL connection parameters (systemd unit file)

Why:
MySQL DB and Table is UTF8, but connection is not UTF8. Therefore when inventories include not latain1 characters, raise UnicodeEncodeError.

Error Example
```
2018-12-04 10:23:11,118 INFO [forseti-security][2.7.0] google.cloud.forseti.services.dao(create): Creating a new model entry in the database, name = 20181204T102226
2018-12-04 10:23:11,983 ERROR [forseti-security][2.7.0] google.cloud.forseti.services.model.importer.importer(run): 'latin-1' codec can't encode characters in position 13-14: ordinal not in range(256)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/forseti_security-2.7.0-py2.7.egg/google/cloud/forseti/services/model/importer/importer.py", line 247, in run
    post_action=self._convert_role_post
  File "/usr/local/lib/python2.7/dist-packages/forseti_security-2.7.0-py2.7.egg/google/cloud/forseti/services/model/importer/importer.py", line 347, in model_action_wrapper
    session.flush()
  File "build/bdist.linux-x86_64/egg/sqlalchemy/orm/session.py", line 2313, in flush
    self._flush(objects)
  File "build/bdist.linux-x86_64/egg/sqlalchemy/orm/session.py", line 2440, in _flush
    transaction.rollback(_capture_exception=True)
  File "build/bdist.linux-x86_64/egg/sqlalchemy/util/langhelpers.py", line 66, in __exit__
    compat.reraise(exc_type, exc_value, exc_tb)
  File "build/bdist.linux-x86_64/egg/sqlalchemy/orm/session.py", line 2404, in _flush
    flush_context.execute()
  File "build/bdist.linux-x86_64/egg/sqlalchemy/orm/unitofwork.py", line 393, in execute
    n.execute_aggregate(self, set_)
  File "build/bdist.linux-x86_64/egg/sqlalchemy/orm/unitofwork.py", line 675, in execute_aggregate
    uow)
  File "build/bdist.linux-x86_64/egg/sqlalchemy/orm/persistence.py", line 181, in save_obj
    mapper, table, insert)
  File "build/bdist.linux-x86_64/egg/sqlalchemy/orm/persistence.py", line 836, in _emit_insert_statements
    execute(statement, multiparams)
  File "build/bdist.linux-x86_64/egg/sqlalchemy/engine/base.py", line 948, in execute
    return meth(self, multiparams, params)
  File "build/bdist.linux-x86_64/egg/sqlalchemy/sql/elements.py", line 269, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "build/bdist.linux-x86_64/egg/sqlalchemy/engine/base.py", line 1060, in _execute_clauseelement
    compiled_sql, distilled_params
  File "build/bdist.linux-x86_64/egg/sqlalchemy/engine/base.py", line 1200, in _execute_context
    context)
  File "build/bdist.linux-x86_64/egg/sqlalchemy/engine/base.py", line 1416, in _handle_dbapi_exception
    util.reraise(*exc_info)
  File "build/bdist.linux-x86_64/egg/sqlalchemy/engine/base.py", line 1170, in _execute_context
    context)
  File "build/bdist.linux-x86_64/egg/sqlalchemy/dialects/mysql/mysqldb.py", line 129, in do_executemany
    rowcount = cursor.executemany(statement, parameters)
  File "build/bdist.linux-x86_64/egg/MySQLdb/cursors.py", line 261, in executemany
    self.errorhandler(self, exc, value)
  File "build/bdist.linux-x86_64/egg/MySQLdb/connections.py", line 36, in defaulterrorhandler
    raise errorclass, errorvalue
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 13-14: ordinal not in range(256)
```

---

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
