### PR TITLE
Make wildcard zero or more by default

### DIFF
--- a/google/cloud/forseti/common/util/regular_exp.py
+++ b/google/cloud/forseti/common/util/regular_exp.py
@@ -18,7 +18,7 @@ import re
 
 
 # pylint: disable=anomalous-backslash-in-string
-def escape_and_globify(pattern_string, wildcard_is_zero_or_more=False):
+def escape_and_globify(pattern_string):
     """Given a pattern string with a glob, create actual regex pattern.
 
     To require > 0 length glob, change the "*" to ".+". This is to handle
@@ -30,8 +30,6 @@ def escape_and_globify(pattern_string, wildcard_is_zero_or_more=False):
 
     Args:
         pattern_string (str): The pattern string of which to make a regex.
-        wildcard_is_zero_or_more (bool): Whether the wildcard designates
-            0 or more versus 1 or more for wildcards after the prefix.
 
     Returns:
         str: The pattern string, escaped except for the "*", which is
@@ -44,7 +42,4 @@ def escape_and_globify(pattern_string, wildcard_is_zero_or_more=False):
     if pattern_string == '*':
         return '^.*$'
 
-    # TODO(2189): Make wildcards always 0 or more.
-    replace = '.*' if wildcard_is_zero_or_more else '.+'
-
-    return '^{}$'.format(re.escape(pattern_string).replace('\\*', replace))
+    return '^{}$'.format(re.escape(pattern_string).replace('\\*', '.*'))

--- a/google/cloud/forseti/scanner/audit/location_rules_engine.py
+++ b/google/cloud/forseti/scanner/audit/location_rules_engine.py
@@ -265,8 +265,7 @@ class Rule(object):
         self.applies_to = applies_to
 
         loc_re_str = '|'.join([
-            regular_exp.escape_and_globify(loc_wildcard.lower(),
-                                           wildcard_is_zero_or_more=True)
+            regular_exp.escape_and_globify(loc_wildcard.lower())
             for loc_wildcard in location_patterns
         ])
         self.location_re = re.compile(loc_re_str)

--- a/tests/common/gcp_type/iam_policy_test.py
+++ b/tests/common/gcp_type/iam_policy_test.py
@@ -108,8 +108,6 @@ class IamPolicyTest(ForsetiTestCase):
             'user:anyone@mycompany.com.notmycompany.com'))
         self.assertFalse(iam_policy_members[3].matches(
             'serviceAccount:someone@gserviceaccount.com'))
-        self.assertFalse(iam_policy_members[3].matches(
-            'serviceAccount:someone@.gserviceaccount.com'))
 
 
     def test_member_invalid_type_raises(self):
@@ -137,7 +135,7 @@ class IamPolicyTest(ForsetiTestCase):
             'members': self.test_members
         }
         iam_binding2 = IamPolicyBinding.create_from(binding2)
-        self.assertEqual('^roles\/.+$', iam_binding2.role_pattern.pattern)
+        self.assertEqual('^roles\/.*$', iam_binding2.role_pattern.pattern)
 
     def test_binding_missing_role_raises(self):
         """Test that a binding with no role raises an exception."""

--- a/tests/scanner/audit/log_sink_rules_engine_test.py
+++ b/tests/scanner/audit/log_sink_rules_engine_test.py
@@ -255,7 +255,7 @@ class LogSinkRulesEngineTest(ForsetiTestCase):
                 rule_index=0,
                 violation_type='LOG_SINK_VIOLATION',
                 sink_destination=('^bigquery\\.googleapis\\.com\\/projects\\/'
-                                  'my\\-audit\\-logs\\/datasets\\/.+$'),
+                                  'my\\-audit\\-logs\\/datasets\\/.*$'),
                 sink_filter=('^logName\\:\\"logs\\/'
                              'cloudaudit\\.googleapis\\.com\\"$'),
                 sink_include_children='*',
@@ -269,7 +269,7 @@ class LogSinkRulesEngineTest(ForsetiTestCase):
                 rule_name='Require a PubSub sink in folder-56 projects.',
                 rule_index=3,
                 violation_type='LOG_SINK_VIOLATION',
-                sink_destination='^pubsub\\.googleapis\\.com\\/.+$',
+                sink_destination='^pubsub\\.googleapis\\.com\\/.*$',
                 sink_filter='^$',
                 sink_include_children='*',
                 resource_data=''


### PR DESCRIPTION
I believe the behaviour of the wildcard is incorrect. There is no documentation apart from looking at the code for what the wildcard does, so a user would assume the incorrect form. Furthermore, the behaviour is inconsistent in Forseti itself (e.g. '*' alone matches empty string, but 'a*' does not match 'a'). See #2189 for in depth overview of this bug.

This PR makes the wildcard behave as expected.

Fix #2189
Fix #2350