### PR TITLE
Fix the evaluation and parsing of the conditions check for deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ deploy:
   on:
     repo: GoogleCloudPlatform/forseti-security
     branch: forsetisecurity.org
-    condition: '"$TRAVIS_SECURE_ENV_VARS" == "true" && "$TRAVIS_EVENT_TYPE" == "push"'
+    condition: 'env(TRAVIS_SECURE_ENV_VARS) IS true AND env(TRAVIS_EVENT_TYPE) == 'push''
   skip_cleanup: true
   no_promote: true


### PR DESCRIPTION
Discovered this after installing and using the travis-conditions Gem

Tested

```
bundle exec travis-conditions eval "env(TRAVIS_SECURE_ENV_VARS) IS true AND env(TRAVIS_EVENT_TYPE) == 'push'" --data '{"env": ["TRAVIS_SECURE_ENV_VARS=true","TRAVIS_EVENT_TYPE=push"]}'
true
```

```
bundle exec travis-conditions eval "env(TRAVIS_SECURE_ENV_VARS) IS true AND env(TRAVIS_EVENT_TYPE) == 'push'" --data '{"env": ["TRAVIS_SECURE_ENV_VARS=true","TRAVIS_EVENT_TYPE=pull_request"]}'
false
```