### PR TITLE
Cherry pick project IAM roles into release

### DIFF
--- a/install/gcp/installer/forseti_server_installer.py
+++ b/install/gcp/installer/forseti_server_installer.py
@@ -77,6 +77,13 @@ class ForsetiServerInstaller(ForsetiInstaller):
             bool: Whether or not the deployment was successful.
             str: Deployment name.
         """
+
+        self.has_roles_script = gcloud.grant_server_svc_acct_project_roles(
+            self.target_id,
+            self.project_id,
+            self.gcp_service_acct_email,
+            self.user_can_grant_roles)
+
         success, deployment_name = super(ForsetiServerInstaller, self).deploy(
             deployment_tpl_path, conf_file_path, bucket_name)
 
@@ -94,7 +101,7 @@ class ForsetiServerInstaller(ForsetiInstaller):
                 constants.RULES_DIR_PATH, bucket_name,
                 is_directory=True, dry_run=self.config.dry_run)
 
-            self.has_roles_script = gcloud.grant_server_svc_acct_roles(
+            self.has_roles_script = gcloud.grant_server_svc_acct_iam_roles(
                 self.enable_write_access,
                 self.access_target,
                 self.target_id,

--- a/install/gcp/installer/forseti_server_installer.py
+++ b/install/gcp/installer/forseti_server_installer.py
@@ -77,7 +77,6 @@ class ForsetiServerInstaller(ForsetiInstaller):
             bool: Whether or not the deployment was successful.
             str: Deployment name.
         """
-
         self.has_roles_script = gcloud.grant_server_svc_acct_project_roles(
             self.target_id,
             self.project_id,

--- a/install/gcp/installer/util/gcloud.py
+++ b/install/gcp/installer/util/gcloud.py
@@ -208,8 +208,7 @@ def grant_client_svc_acct_roles(project_id,
         target_id, project_id, gcp_service_account,
         user_can_grant_roles, roles)
 
-
-def grant_server_svc_acct_roles(enable_write,
+def grant_server_svc_acct_iam_roles(enable_write,
                                 access_target,
                                 target_id,
                                 project_id,
@@ -217,16 +216,11 @@ def grant_server_svc_acct_roles(enable_write,
                                 cai_bucket_name,
                                 user_can_grant_roles):
     """Grant the following IAM roles to GCP service account.
-
-    Org/Folder/Project:
+     Org/Folder/Project:
         AppEngine App Viewer, Cloud SQL Viewer, Network Viewer
         Project Browser, Security Reviewer, Service Management Quota Viewer
         Security Admin
-
-    Project:
-        Cloud SQL Client, Storage Object Viewer, Storage Object Creator
-
-    Args:
+     Args:
         enable_write (bool): Whether or not to enable write access.
         access_target (str): Access target, either org, folder or project.
         target_id (str): Id of the access_target.
@@ -235,20 +229,18 @@ def grant_server_svc_acct_roles(enable_write,
         cai_bucket_name (str): The name of the CAI bucket.
         user_can_grant_roles (bool): Whether or not user has
             access to grant roles.
-
-    Returns:
+     Returns:
         bool: Whether or not a role script has been generated.
     """
 
-    utils.print_banner('Assigning Roles To The GCP Service Account',
+    utils.print_banner('Assigning IAM Roles To The GCP Service Account',
                        gcp_service_account)
     access_target_roles = constants.GCP_READ_IAM_ROLES
     if enable_write:
         access_target_roles.extend(constants.GCP_WRITE_IAM_ROLES)
 
-    roles = {
+     roles = {
         '%ss' % access_target: access_target_roles,
-        'forseti_project': constants.PROJECT_IAM_ROLES_SERVER,
         'service_accounts': constants.SVC_ACCT_ROLES,
     }
 
@@ -264,6 +256,33 @@ def grant_server_svc_acct_roles(enable_write,
 
     return has_role_script_bucket or has_role_script_rest
 
+ def grant_server_svc_acct_project_roles(target_id,
+                                project_id,
+                                gcp_service_account,
+                                user_can_grant_roles):
+    """Grant the following Project IAM roles to GCP service account.
+     Project:
+        Cloud SQL Client, Storage Object Viewer, Storage Object Creator
+     Args:
+        target_id (str): Id of the access_target.
+        project_id (str): GCP Project Id.
+        gcp_service_account (str): GCP service account email.
+        user_can_grant_roles (bool): Whether or not user has
+            access to grant roles.
+     Returns:
+        bool: Whether or not a role script has been generated.
+    """
+    utils.print_banner('Assigning Project IAM Roles To The GCP Service Account',
+                       gcp_service_account)
+    roles = {
+        'forseti_project': constants.PROJECT_IAM_ROLES_SERVER,
+    }
+
+    has_role_script_rest = _grant_svc_acct_roles(
+        target_id, project_id, gcp_service_account,
+        user_can_grant_roles, roles)
+
+    return has_role_script_rest
 
 def _grant_bucket_roles(gcp_service_account,
                         bucket_name,

--- a/install/gcp/installer/util/gcloud.py
+++ b/install/gcp/installer/util/gcloud.py
@@ -209,12 +209,12 @@ def grant_client_svc_acct_roles(project_id,
         user_can_grant_roles, roles)
 
 def grant_server_svc_acct_iam_roles(enable_write,
-                                access_target,
-                                target_id,
-                                project_id,
-                                gcp_service_account,
-                                cai_bucket_name,
-                                user_can_grant_roles):
+                                    access_target,
+                                    target_id,
+                                    project_id,
+                                    gcp_service_account,
+                                    cai_bucket_name,
+                                    user_can_grant_roles):
     """Grant the following IAM roles to GCP service account.
      Org/Folder/Project:
         AppEngine App Viewer, Cloud SQL Viewer, Network Viewer
@@ -256,10 +256,11 @@ def grant_server_svc_acct_iam_roles(enable_write,
 
     return has_role_script_bucket or has_role_script_rest
 
- def grant_server_svc_acct_project_roles(target_id,
-                                project_id,
-                                gcp_service_account,
-                                user_can_grant_roles):
+
+def grant_server_svc_acct_project_roles(target_id,
+                                        project_id,
+                                        gcp_service_account,
+                                        user_can_grant_roles):
     """Grant the following Project IAM roles to GCP service account.
      Project:
         Cloud SQL Client, Storage Object Viewer, Storage Object Creator

--- a/install/gcp/installer/util/gcloud.py
+++ b/install/gcp/installer/util/gcloud.py
@@ -239,7 +239,7 @@ def grant_server_svc_acct_iam_roles(enable_write,
     if enable_write:
         access_target_roles.extend(constants.GCP_WRITE_IAM_ROLES)
 
-     roles = {
+    roles = {
         '%ss' % access_target: access_target_roles,
         'service_accounts': constants.SVC_ACCT_ROLES,
     }


### PR DESCRIPTION
Cherry pick PR to address Issue #2415.

Assign the following Project IAM roles immediately after creating Forseti Server service account:
- storage.objectViewer
- storage.objectCreator
- cloudsql.client
- logging.logWriter