### PR TITLE
Take out references to storage.objectAdmin

### DIFF
--- a/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
@@ -70,7 +70,6 @@ def _add_bucket_ancestor_bindings(policy_data):
         'roles/storage.admin',
         'roles/storage.objectViewer',
         'roles/storage.objectCreator',
-        'roles/storage.objectAdmin',
     ])
     bucket_data = []
     for (resource, _, bindings) in policy_data:

--- a/install/gcp/installer/forseti_server_installer.py
+++ b/install/gcp/installer/forseti_server_installer.py
@@ -100,7 +100,6 @@ class ForsetiServerInstaller(ForsetiInstaller):
                 self.target_id,
                 self.project_id,
                 self.gcp_service_acct_email,
-                self._get_cai_bucket_name(),
                 self.user_can_grant_roles)
 
             # Waiting for VM to be initialized.

--- a/install/gcp/installer/util/constants.py
+++ b/install/gcp/installer/util/constants.py
@@ -114,10 +114,6 @@ PROJECT_IAM_ROLES_CLIENT = [
     'roles/logging.logWriter'
 ]
 
-FORSETI_CAI_BUCKET_ROLES = [
-    'objectAdmin'
-]
-
 SVC_ACCT_ROLES = [
     'roles/iam.serviceAccountTokenCreator'
 ]

--- a/install/gcp/installer/util/gcloud.py
+++ b/install/gcp/installer/util/gcloud.py
@@ -252,17 +252,11 @@ def grant_server_svc_acct_roles(enable_write,
         'service_accounts': constants.SVC_ACCT_ROLES,
     }
 
-    has_role_script_bucket = _grant_bucket_roles(
-        gcp_service_account,
-        cai_bucket_name,
-        constants.FORSETI_CAI_BUCKET_ROLES,
-        user_can_grant_roles)
-
     has_role_script_rest = _grant_svc_acct_roles(
         target_id, project_id, gcp_service_account,
         user_can_grant_roles, roles)
 
-    return has_role_script_bucket or has_role_script_rest
+    return has_role_script_rest
 
 
 def _grant_bucket_roles(gcp_service_account,

--- a/install/gcp/installer/util/gcloud.py
+++ b/install/gcp/installer/util/gcloud.py
@@ -214,7 +214,6 @@ def grant_server_svc_acct_roles(enable_write,
                                 target_id,
                                 project_id,
                                 gcp_service_account,
-                                cai_bucket_name,
                                 user_can_grant_roles):
     """Grant the following IAM roles to GCP service account.
 
@@ -232,7 +231,6 @@ def grant_server_svc_acct_roles(enable_write,
         target_id (str): Id of the access_target.
         project_id (str): GCP Project Id.
         gcp_service_account (str): GCP service account email.
-        cai_bucket_name (str): The name of the CAI bucket.
         user_can_grant_roles (bool): Whether or not user has
             access to grant roles.
 

--- a/tests/notifier/notifiers/test_data/expected_attachment.csv
+++ b/tests/notifier/notifiers/test_data/expected_attachment.csv
@@ -1,3 +1,2 @@
 resource_id,resource_type,resource_name,full_name,rule_index,rule_name,violation_type,violation_data
-be-1-ext,bucket,be-1-ext,o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/,1,Allow only service accounts to have access,IAM_POLICY_VIOLATION,"{""full_name"": ""o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/"", ""member"": ""user:ghi@example.com"", ""role"": ""roles/storage.objectAdmin""}"
 be-1-ext,bucket,be-1-ext,o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/,1,Allow only service accounts to have access,IAM_POLICY_VIOLATION,"{""full_name"": ""o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/"", ""member"": ""user:jkl@example.com"", ""role"": ""roles/storage.admin""}"

--- a/tests/notifier/notifiers/test_data/fake_violations.py
+++ b/tests/notifier/notifiers/test_data/fake_violations.py
@@ -134,30 +134,6 @@ VIOLATIONS = {
     'iap_violations': [
         {'created_at_datetime': '2018-03-16T09:29:52Z',
          'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
-         'id': 47L,
-         'inventory_data': {
-             'bindings': [
-                 {'members': ['pEditor:be-p1-196611', 'pOwner:be-p1-196611'],
-                  'role': 'roles/storage.legacyBucketOwner'},
-                 {'members': ['pViewer:be-p1-196611'],
-                  'role': 'roles/storage.legacyBucketReader'}],
-             'etag': 'CAE=',
-             'kind': 'storage#policy',
-             'resourceId': 'ps/_/buckets/be-1-ext'},
-         'inventory_index_id': '2018-03-14T14:49:36.101287',
-         'resource_id': 'be-1-ext',
-         'resource_type': 'bucket',
-         'resource_name': 'be-1-ext',
-         'rule_index': 1L,
-         'rule_name': 'Allow only service accounts to have access',
-         'violation_data': {
-             'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
-             'member': 'user:abc@example.com',
-             'role': 'roles/storage.objectAdmin'},
-         'violation_hash': '15fda93a6fdd32d867064677cf07686f79b65d',
-         'violation_type': 'IAP_VIOLATION'},
-        {'created_at_datetime': '2018-03-16T09:29:52Z',
-         'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
          'id': 48L,
          'inventory_data': {
              'bindings': [
@@ -181,30 +157,6 @@ VIOLATIONS = {
          'violation_hash': 'f93745f39163060ceee17385b4677b91746382',
          'violation_type': 'IAP_VIOLATION'}],
     'iam_policy_violations': [
-        {'created_at_datetime': '2018-03-16T09:29:52Z',
-         'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
-         'id': 1L,
-         'inventory_data': {
-             'bindings': [
-                 {'members': ['pEditor:be-p1-196611', 'pOwner:be-p1-196611'],
-                  'role': 'roles/storage.legacyBucketOwner'},
-                 {'members': ['pViewer:be-p1-196611'],
-                  'role': 'roles/storage.legacyBucketReader'}],
-             'etag': 'CAE=',
-             'kind': 'storage#policy',
-             'resourceId': 'ps/_/buckets/be-1-ext'},
-         'inventory_index_id': '2018-03-14T14:49:36.101287',
-         'resource_id': 'be-1-ext',
-         'resource_name': 'be-1-ext',
-         'resource_type': 'bucket',
-         'rule_index': 1L,
-         'rule_name': 'Allow only service accounts to have access',
-         'violation_data': {
-             'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
-             'member': 'user:ghi@example.com',
-             'role': 'roles/storage.objectAdmin'},
-         'violation_hash': '15fda93a6fdd32d867064677cf07686f79b',
-         'violation_type': 'IAM_POLICY_VIOLATION'},
         {'created_at_datetime': '2018-03-16T09:29:52Z',
          'full_name': 'o/5/g/f/4/g/f/9/g/p/be-p1-196611/bucket/be-1-ext/',
          'id': 2L,

--- a/tests/scanner/scanners/iam_rules_scanner_test.py
+++ b/tests/scanner/scanners/iam_rules_scanner_test.py
@@ -716,28 +716,6 @@ class IamRulesScannerTest(ForsetiTestCase):
         policy_data = [
                 (self.org_234, self.org_234_policy_resource, org_bindings)]
 
-        proj_2_policy = {
-            'bindings': [
-                {
-                    'role': 'roles/owner',
-                    'members': [
-                        'user:someone@company.com',
-                    ]
-                },
-                {
-                    'role': 'roles/storage.objectAdmin',
-                    'members': [
-                        'user:admin@storage.com',
-                    ]
-                },
-            ]
-        }
-        proj_2_bindings = filter(None, [ # pylint: disable=bad-builtin
-            iam_policy.IamPolicyBinding.create_from(b)
-            for b in proj_2_policy.get('bindings')])
-        policy_data.append(
-                (self.proj_2, self.proj_2_policy_resource, proj_2_bindings))
-
         folder_1_policy = {
             'bindings': [
                 {
@@ -783,11 +761,6 @@ class IamRulesScannerTest(ForsetiTestCase):
         policy_data.append(
                 (self.proj_3, self.proj_3_policy_resource, proj_3_bindings))
 
-        bucket_2_1_bindings = []
-        policy_data.append(
-                (self.bucket_2_1, self.bucket_2_1_policy_resource,
-                    bucket_2_1_bindings))
-
         bucket_3_1_bindings = []
         policy_data.append(
                 (self.bucket_3_1, self.bucket_3_1_policy_resource,
@@ -800,10 +773,8 @@ class IamRulesScannerTest(ForsetiTestCase):
 
         iam_rules_scanner._add_bucket_ancestor_bindings(policy_data)
 
-        self.assertEqual(1, len(bucket_2_1_bindings))
         self.assertEqual(2, len(bucket_3_1_bindings))
         self.assertEqual(2, len(bucket_3_2_bindings))
-
 
         expected_b3_policy = {
             'bindings': [
@@ -827,22 +798,6 @@ class IamRulesScannerTest(ForsetiTestCase):
 
         self.assertEqual(expected_b3_bindings, bucket_3_1_bindings)
         self.assertEqual(expected_b3_bindings, bucket_3_2_bindings)
-
-        expected_b2_policy = {
-            'bindings': [
-                {
-                    'role': 'roles/storage.objectAdmin',
-                    'members': [
-                        'user:admin@storage.com',
-                    ]
-                },
-            ]
-        }
-        expected_b2_bindings = filter(None, [ # pylint: disable=bad-builtin
-            iam_policy.IamPolicyBinding.create_from(b)
-            for b in expected_b2_policy.get('bindings')])
-
-        self.assertEqual(expected_b2_bindings, bucket_2_1_bindings)
 
     def test_retrieve_finds_bucket_policies(self):
         """IamPolicyScanner::_retrieve() finds bucket policies.


### PR DESCRIPTION
References Issue #2499. 

Take out references to storage.objectAdmin as it is not needed.