### PR TITLE
Take out references to storage.objectAdmin in installer.

### DIFF
--- a/install/gcp/installer/forseti_server_installer.py
+++ b/install/gcp/installer/forseti_server_installer.py
@@ -100,7 +100,6 @@ class ForsetiServerInstaller(ForsetiInstaller):
                 self.target_id,
                 self.project_id,
                 self.gcp_service_acct_email,
-                self._get_cai_bucket_name(),
                 self.user_can_grant_roles)
 
             # Waiting for VM to be initialized.

--- a/install/gcp/installer/util/constants.py
+++ b/install/gcp/installer/util/constants.py
@@ -114,10 +114,6 @@ PROJECT_IAM_ROLES_CLIENT = [
     'roles/logging.logWriter'
 ]
 
-FORSETI_CAI_BUCKET_ROLES = [
-    'objectAdmin'
-]
-
 SVC_ACCT_ROLES = [
     'roles/iam.serviceAccountTokenCreator'
 ]

--- a/install/gcp/installer/util/gcloud.py
+++ b/install/gcp/installer/util/gcloud.py
@@ -214,7 +214,6 @@ def grant_server_svc_acct_roles(enable_write,
                                 target_id,
                                 project_id,
                                 gcp_service_account,
-                                cai_bucket_name,
                                 user_can_grant_roles):
     """Grant the following IAM roles to GCP service account.
 
@@ -232,7 +231,6 @@ def grant_server_svc_acct_roles(enable_write,
         target_id (str): Id of the access_target.
         project_id (str): GCP Project Id.
         gcp_service_account (str): GCP service account email.
-        cai_bucket_name (str): The name of the CAI bucket.
         user_can_grant_roles (bool): Whether or not user has
             access to grant roles.
 
@@ -252,17 +250,11 @@ def grant_server_svc_acct_roles(enable_write,
         'service_accounts': constants.SVC_ACCT_ROLES,
     }
 
-    has_role_script_bucket = _grant_bucket_roles(
-        gcp_service_account,
-        cai_bucket_name,
-        constants.FORSETI_CAI_BUCKET_ROLES,
-        user_can_grant_roles)
-
     has_role_script_rest = _grant_svc_acct_roles(
         target_id, project_id, gcp_service_account,
         user_can_grant_roles, roles)
 
-    return has_role_script_bucket or has_role_script_rest
+    return has_role_script_rest
 
 
 def _grant_bucket_roles(gcp_service_account,


### PR DESCRIPTION
References Issue #2499.

Take out references to storage.objectAdmin in installer as it is not needed.