### PR TITLE
Replace incorrect link with correct develop/dev/index.md link

### DIFF
--- a/_docs/_latest/develop/index.md
+++ b/_docs/_latest/develop/index.md
@@ -19,7 +19,7 @@ a pull request.
 Understand how Forseti uses branches, performs releases, and manages development of Forseti on
 GitHub.
 
-**[Start Developing on Forseti]({% link _docs/latest/use/get-help.md %})**
+**[Start Developing on Forseti]({% link _docs/latest/develop/dev/index.md %})**
 
 Get set up and started with development.
 

--- a/_docs/v2.0/develop/index.md
+++ b/_docs/v2.0/develop/index.md
@@ -19,7 +19,7 @@ a pull request.
 Understand how Forseti uses branches, performs releases, and manages development of Forseti on
 GitHub.
 
-**[Start Developing on Forseti]({% link _docs/v2.0/use/get-help.md %})**
+**[Start Developing on Forseti]({% link _docs/v2.0/develop/dev/index.md %})**
 
 Get set up and started with development.
 

--- a/_docs/v2.1/develop/index.md
+++ b/_docs/v2.1/develop/index.md
@@ -19,7 +19,7 @@ a pull request.
 Understand how Forseti uses branches, performs releases, and manages development of Forseti on
 GitHub.
 
-**[Start Developing on Forseti]({% link _docs/v2.1/use/get-help.md %})**
+**[Start Developing on Forseti]({% link _docs/v2.1/develop/dev/index.md %})**
 
 Get set up and started with development.
 

--- a/_docs/v2.10/develop/index.md
+++ b/_docs/v2.10/develop/index.md
@@ -19,7 +19,7 @@ a pull request.
 Understand how Forseti uses branches, performs releases, and manages development of Forseti on
 GitHub.
 
-**[Start Developing on Forseti]({% link _docs/v2.10/use/get-help.md %})**
+**[Start Developing on Forseti]({% link _docs/v2.10/develop/dev/index.md %})**
 
 Get set up and started with development.
 

--- a/_docs/v2.2/develop/index.md
+++ b/_docs/v2.2/develop/index.md
@@ -19,7 +19,7 @@ a pull request.
 Understand how Forseti uses branches, performs releases, and manages development of Forseti on
 GitHub.
 
-**[Start Developing on Forseti]({% link _docs/v2.2/use/get-help.md %})**
+**[Start Developing on Forseti]({% link _docs/v2.2/develop/dev/index.md %})**
 
 Get set up and started with development.
 

--- a/_docs/v2.3/develop/index.md
+++ b/_docs/v2.3/develop/index.md
@@ -19,7 +19,7 @@ a pull request.
 Understand how Forseti uses branches, performs releases, and manages development of Forseti on
 GitHub.
 
-**[Start Developing on Forseti]({% link _docs/v2.3/use/get-help.md %})**
+**[Start Developing on Forseti]({% link _docs/v2.3/develop/dev/index.md %})**
 
 Get set up and started with development.
 

--- a/_docs/v2.4/develop/index.md
+++ b/_docs/v2.4/develop/index.md
@@ -19,7 +19,7 @@ a pull request.
 Understand how Forseti uses branches, performs releases, and manages development of Forseti on
 GitHub.
 
-**[Start Developing on Forseti]({% link _docs/v2.4/use/get-help.md %})**
+**[Start Developing on Forseti]({% link _docs/v2.4/develop/dev/index.md %})**
 
 Get set up and started with development.
 

--- a/_docs/v2.5/develop/index.md
+++ b/_docs/v2.5/develop/index.md
@@ -19,7 +19,7 @@ a pull request.
 Understand how Forseti uses branches, performs releases, and manages development of Forseti on
 GitHub.
 
-**[Start Developing on Forseti]({% link _docs/v2.5/use/get-help.md %})**
+**[Start Developing on Forseti]({% link _docs/v2.5/develop/dev/index.md %})**
 
 Get set up and started with development.
 

--- a/_docs/v2.6/develop/index.md
+++ b/_docs/v2.6/develop/index.md
@@ -19,7 +19,7 @@ a pull request.
 Understand how Forseti uses branches, performs releases, and manages development of Forseti on
 GitHub.
 
-**[Start Developing on Forseti]({% link _docs/v2.6/use/get-help.md %})**
+**[Start Developing on Forseti]({% link _docs/v2.6/develop/dev/index.md %})**
 
 Get set up and started with development.
 

--- a/_docs/v2.7/develop/index.md
+++ b/_docs/v2.7/develop/index.md
@@ -19,7 +19,7 @@ a pull request.
 Understand how Forseti uses branches, performs releases, and manages development of Forseti on
 GitHub.
 
-**[Start Developing on Forseti]({% link _docs/v2.7/use/get-help.md %})**
+**[Start Developing on Forseti]({% link _docs/v2.7/develop/dev/index.md %})**
 
 Get set up and started with development.
 

--- a/_docs/v2.8/develop/index.md
+++ b/_docs/v2.8/develop/index.md
@@ -19,7 +19,7 @@ a pull request.
 Understand how Forseti uses branches, performs releases, and manages development of Forseti on
 GitHub.
 
-**[Start Developing on Forseti]({% link _docs/v2.8/use/get-help.md %})**
+**[Start Developing on Forseti]({% link _docs/v2.8/develop/dev/index.md %})**
 
 Get set up and started with development.
 

--- a/_docs/v2.9/develop/index.md
+++ b/_docs/v2.9/develop/index.md
@@ -19,7 +19,7 @@ a pull request.
 Understand how Forseti uses branches, performs releases, and manages development of Forseti on
 GitHub.
 
-**[Start Developing on Forseti]({% link _docs/v2.9/use/get-help.md %})**
+**[Start Developing on Forseti]({% link _docs/v2.9/develop/dev/index.md %})**
 
 Get set up and started with development.
 


### PR DESCRIPTION
Reference issue #2453. 

Replace incorrect link `use/get-help.md` with correct link `develop/dev/index.md`.