### PR TITLE
Take out roles/storage.objectAdmin bullet

### DIFF
--- a/_includes/docs/latest/forseti-server-gcp-required-roles.md
+++ b/_includes/docs/latest/forseti-server-gcp-required-roles.md
@@ -22,7 +22,3 @@
 **Granted at the service account level**
 
  * `roles/iam.serviceAccountTokenCreator` (server)
- 
-**Granted at the bucket level for CAI**
-
- * `roles/storage.objectAdmin` (server)

--- a/_includes/docs/v2.10/forseti-server-gcp-required-roles.md
+++ b/_includes/docs/v2.10/forseti-server-gcp-required-roles.md
@@ -22,7 +22,3 @@
 **Granted at the service account level**
 
  * `roles/iam.serviceAccountTokenCreator` (server)
- 
-**Granted at the bucket level for CAI**
-
- * `roles/storage.objectAdmin` (server)

--- a/_includes/docs/v2.5/forseti-server-gcp-required-roles.md
+++ b/_includes/docs/v2.5/forseti-server-gcp-required-roles.md
@@ -21,7 +21,3 @@
 **Granted at the service account level**
 
  * `roles/iam.serviceAccountTokenCreator` (server)
- 
-**Granted at the bucket level for CAI**
-
- * `roles/storage.objectAdmin` (server)

--- a/_includes/docs/v2.6/forseti-server-gcp-required-roles.md
+++ b/_includes/docs/v2.6/forseti-server-gcp-required-roles.md
@@ -22,7 +22,3 @@
 **Granted at the service account level**
 
  * `roles/iam.serviceAccountTokenCreator` (server)
- 
-**Granted at the bucket level for CAI**
-
- * `roles/storage.objectAdmin` (server)

--- a/_includes/docs/v2.7/forseti-server-gcp-required-roles.md
+++ b/_includes/docs/v2.7/forseti-server-gcp-required-roles.md
@@ -22,7 +22,3 @@
 **Granted at the service account level**
 
  * `roles/iam.serviceAccountTokenCreator` (server)
- 
-**Granted at the bucket level for CAI**
-
- * `roles/storage.objectAdmin` (server)

--- a/_includes/docs/v2.8/forseti-server-gcp-required-roles.md
+++ b/_includes/docs/v2.8/forseti-server-gcp-required-roles.md
@@ -22,7 +22,3 @@
 **Granted at the service account level**
 
  * `roles/iam.serviceAccountTokenCreator` (server)
- 
-**Granted at the bucket level for CAI**
-
- * `roles/storage.objectAdmin` (server)

--- a/_includes/docs/v2.9/forseti-server-gcp-required-roles.md
+++ b/_includes/docs/v2.9/forseti-server-gcp-required-roles.md
@@ -22,7 +22,3 @@
 **Granted at the service account level**
 
  * `roles/iam.serviceAccountTokenCreator` (server)
- 
-**Granted at the bucket level for CAI**
-
- * `roles/storage.objectAdmin` (server)


### PR DESCRIPTION
References issue #2502. 

Take out 
```
**Granted at the bucket level for CAI**	

  * `roles/storage.objectAdmin` (server)
```