### PR TITLE
Add default value for disabled attribute on firewall rules in enforcer.

### DIFF
--- a/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
+++ b/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
@@ -193,6 +193,7 @@ class FirewallRules(object):
 
     DEFAULT_PRIORITY = 1000
     DEFAULT_DIRECTION = 'INGRESS'
+    DEFAULT_DISABLED = False
     DEFAULT_LOGCONFIG = {'enable': False}
 
     def __init__(self, project, rules=None, add_rule_callback=None):
@@ -353,6 +354,9 @@ class FirewallRules(object):
         if 'logConfig' not in new_rule:
             new_rule['logConfig'] = self.DEFAULT_LOGCONFIG
 
+        if 'disabled' not in new_rule:
+            new_rule['disabled'] = self.DEFAULT_DISABLED
+
         if self._check_rule_before_adding(new_rule):
             self.rules[new_rule['name']] = new_rule
 
@@ -492,11 +496,6 @@ class FirewallRules(object):
                     'Rule missing required field "%s": "%s".' % (key, rule))
 
         if 'direction' not in rule or rule['direction'] == 'INGRESS':
-            if 'sourceRanges' not in rule and 'sourceTags' not in rule:
-                raise InvalidFirewallRuleError(
-                    'Ingress rule missing required field oneof '
-                    '"sourceRanges" or "sourceTags": "%s".' % rule)
-
             if 'destinationRanges' in rule:
                 raise InvalidFirewallRuleError(
                     'Ingress rules cannot include "destinationRanges": "%s".'
@@ -506,11 +505,6 @@ class FirewallRules(object):
             if 'sourceRanges' in rule or 'sourceTags' in rule:
                 raise InvalidFirewallRuleError(
                     'Egress rules cannot include "sourceRanges", "sourceTags":'
-                    '"%s".' % rule)
-
-            if 'destinationRanges' not in rule:
-                raise InvalidFirewallRuleError(
-                    'Egress rule missing required field "destinationRanges":'
                     '"%s".' % rule)
 
         else:

--- a/tests/enforcer/gce_firewall_enforcer_test.py
+++ b/tests/enforcer/gce_firewall_enforcer_test.py
@@ -386,17 +386,6 @@ class FirewallRulesCheckRuleTest(ForsetiTestCase):
             with self.assertRaises(fe.InvalidFirewallRuleError):
                 self.firewall_rules._check_rule_before_adding(test_rule)
 
-    def test_missing_source_key(self):
-        """Rule missing source(Ranges|Tags) raises InvalidFirewallRuleError."""
-        self.test_rule.pop('sourceRanges')
-        with self.assertRaises(fe.InvalidFirewallRuleError):
-            self.firewall_rules._check_rule_before_adding(self.test_rule)
-
-        # Adding sourceTags makes the rule valid again
-        self.test_rule['sourceTags'] = 'test-tag'
-        self.assertTrue(
-            self.firewall_rules._check_rule_before_adding(self.test_rule))
-
     def test_missing_ip_protocol(self):
         """Rule missing IPProtocol in an allow predicate raises an exception."""
         self.test_rule['allowed'][0].pop('IPProtocol')
@@ -464,14 +453,6 @@ class FirewallRulesCheckRuleTest(ForsetiTestCase):
       """Rule with direction set to EGRESS with sourceRanges raises
          exception."""
       self.test_rule['direction'] = 'EGRESS'
-      with self.assertRaises(fe.InvalidFirewallRuleError):
-        self.firewall_rules._check_rule_before_adding(self.test_rule)
-
-    def test_direction_egress_no_ranges(self):
-      """Rule with direction set to EGRESS with no IP ranges raises
-         exception."""
-      self.test_rule['direction'] = 'EGRESS'
-      self.test_rule.pop('sourceRanges')
       with self.assertRaises(fe.InvalidFirewallRuleError):
         self.firewall_rules._check_rule_before_adding(self.test_rule)
 
@@ -692,6 +673,7 @@ class FirewallEnforcerTest(constants.EnforcerTestCase):
                         'test-net').format(fe.API_VERSION),
             'sourceRanges': [u'10.2.3.4/32'],
             'logConfig': {'enable': False},
+            'disabled': False,
             'priority': 1000,
             'direction': u'INGRESS'
         }

--- a/tests/enforcer/testing_constants.py
+++ b/tests/enforcer/testing_constants.py
@@ -159,6 +159,7 @@ EXPECTED_FIREWALL_API_RESPONSE = [
             "IPProtocol": u"icmp"
         }],
         "direction": "INGRESS",
+        "disabled": False,
         "priority": 1000,
         "logConfig": {"enable": False},
         "name":
@@ -179,6 +180,7 @@ EXPECTED_FIREWALL_API_RESPONSE = [
             "IPProtocol": u"icmp"
         }],
         "direction": "INGRESS",
+        "disabled": False,
         "priority": 1000,
         "logConfig": {"enable": False},
         "name":
@@ -201,6 +203,7 @@ EXPECTED_FIREWALL_API_RESPONSE = [
             "IPProtocol": u"ah"
         }],
         "direction": "INGRESS",
+        "disabled": False,
         "priority": 1000,
         "logConfig": {"enable": False},
         "name":
@@ -228,6 +231,7 @@ EXPECTED_FIREWALL_RULES = {
         "sourceRanges": [u"10.8.0.0/24"],
         "priority": 1000,
         "logConfig": {"enable": False},
+        "disabled": False,
         "direction": "INGRESS"},
     "test-network-allow-internal-0": {
         "allowed": [{
@@ -248,6 +252,7 @@ EXPECTED_FIREWALL_RULES = {
         "sourceRanges": [u"10.0.0.0/8"],
         "priority": 1000,
         "logConfig": {"enable": False},
+        "disabled": False,
         "direction": "INGRESS"},
     "test-network-allow-public-0": {
         "allowed": [{
@@ -270,6 +275,7 @@ EXPECTED_FIREWALL_RULES = {
         "sourceRanges": [u"127.0.0.1/32", u"127.0.0.2/32"],
         "priority": 1000,
         "logConfig": {"enable": False},
+        "disabled": False,
         "direction": "INGRESS"},
 }
 
@@ -345,6 +351,7 @@ DEFAULT_FIREWALL_API_RESPONSE = [
         "allowed": [{
             "IPProtocol": u"icmp"
         }],
+        "disabled": False,
         "logConfig": {"enable": False},
         "name":
             u"test-network-allow-icmp"
@@ -362,6 +369,7 @@ DEFAULT_FIREWALL_API_RESPONSE = [
         }, {
             "IPProtocol": u"icmp"
         }],
+        "disabled": False,
         "logConfig": {"enable": False},
         "name":
             u"test-network-allow-internal"
@@ -377,6 +385,7 @@ DEFAULT_FIREWALL_API_RESPONSE = [
                 "ports": [u"3389"]
             },
         ],
+        "disabled": False,
         "logConfig": {"enable": False},
         "name":
             u"test-network-allow-rdp"
@@ -392,6 +401,7 @@ DEFAULT_FIREWALL_API_RESPONSE = [
                 "ports": [u"22"]
             },
         ],
+        "disabled": False,
         "logConfig": {"enable": False},
         "name":
             u"test-network-allow-ssh"
@@ -414,6 +424,7 @@ DEFAULT_FIREWALL_RULES = {
         "allowed": [{
             "IPProtocol": u"icmp"
         }],
+        "disabled": False,
         "logConfig": {"enable": False},
         "name":
             u"test-network-allow-icmp"
@@ -432,6 +443,7 @@ DEFAULT_FIREWALL_RULES = {
         }, {
             "IPProtocol": u"icmp"
         }],
+        "disabled": False,
         "logConfig": {"enable": False},
         "name":
             u"test-network-allow-internal"
@@ -449,6 +461,7 @@ DEFAULT_FIREWALL_RULES = {
             },
         ],
         "logConfig": {"enable": False},
+        "disabled": False,
         "name":
             u"test-network-allow-rdp"
     },
@@ -465,6 +478,7 @@ DEFAULT_FIREWALL_RULES = {
             },
         ],
         "logConfig": {"enable": False},
+        "disabled": False,
         "name":
             u"test-network-allow-ssh"
     }
@@ -480,7 +494,7 @@ SAMPLE_ENFORCER_PROJECTRESULTS_ASCIIPB = """
     rules_before {
       json: '[{"allowed": [{"IPProtocol": "icmp"}], "description": '
             '"Allow ICMP from anywhere", "direction": "INGRESS", '
-            '"logConfig": {"enable": false}, '
+            '"disabled": false, "logConfig": {"enable": false}, '
             '"name": "test-network-allow-icmp", '
             '"network": "https://www.googleapis.com/compute/v1/projects/'
             'test-project/global/networks/test-network", "priority": 1000, '
@@ -489,6 +503,7 @@ SAMPLE_ENFORCER_PROJECTRESULTS_ASCIIPB = """
             '{"IPProtocol": "tcp", "ports": ["1-65535"]}, {"IPProtocol": '
             '"udp", "ports": ["1-65535"]}], "description": "Allow internal '
             'traffic on the default network.", "direction": "INGRESS", '
+            '"disabled": false, '
             '"logConfig": {"enable": false}, '
             '"name": "test-network-allow-internal", "network": '
             '"https://www.googleapis.com/compute/v1/projects/test-project/'
@@ -496,6 +511,7 @@ SAMPLE_ENFORCER_PROJECTRESULTS_ASCIIPB = """
             '["10.240.0.0/16"]},'
             ' {"allowed": [{"IPProtocol": "tcp", "ports": ["3389"]}], '
             '"description": "Allow RDP from anywhere", "direction": "INGRESS", '
+            '"disabled": false, '
             '"logConfig": {"enable": false}, '
             '"name": "test-network-allow-rdp", "network": '
             '"https://www.googleapis.com/compute/v1/projects/test-project/'
@@ -503,18 +519,20 @@ SAMPLE_ENFORCER_PROJECTRESULTS_ASCIIPB = """
             '["0.0.0.0/0"]}, '
             '{"allowed": [{"IPProtocol": "tcp", "ports": ["22"]}], '
             '"description": "Allow SSH from anywhere", "direction": "INGRESS", '
+            '"disabled": false, '
             '"logConfig": {"enable": false}, '
             '"name": "test-network-allow-ssh", "network": '
             '"https://www.googleapis.com/compute/v1/projects/test-project/'
             'global/networks/test-network", "priority": 1000, "sourceRanges": '
             '["0.0.0.0/0"]}]'
-      hash: "97dbbc795617157184e572041a55a7330ad552dbd69f50d8dd7d70de40b41f3b"
+      hash: "79736b5815ec9285d3281df4c7dfb59bb25d0972a19d591c0e17cdc0d70ff21f"
     }
     rules_after {
       json: '[{"allowed": [{"IPProtocol": "icmp"}, {"IPProtocol": "tcp", '
             '"ports": ["1-65535"]}, {"IPProtocol": "udp", "ports": ["1-65535"]'
             '}], "description": "Allow internal traffic from a range of IP '
             'addresses.", "direction": "INGRESS", '
+            '"disabled": false, '
             '"logConfig": {"enable": false}, '
             '"name": "test-network-allow-internal-0", "network": '
             '"https://www.googleapis.com/compute/v1/projects/test-project/'
@@ -524,6 +542,7 @@ SAMPLE_ENFORCER_PROJECTRESULTS_ASCIIPB = """
             '"ports": ["1-65535"]}, {"IPProtocol": "udp", "ports": ["1-65535"]'
             '}], "description": "Allow communication between instances.", '
             '"direction": "INGRESS", '
+            '"disabled": false, '
             '"logConfig": {"enable": false}, '
             '"name": "test-network-allow-internal-1", '
             '"network": '
@@ -534,13 +553,14 @@ SAMPLE_ENFORCER_PROJECTRESULTS_ASCIIPB = """
             '{"IPProtocol": "tcp", "ports": ["22"]}, {"IPProtocol": "udp", '
             '"ports": ["9999"]}], "description": "Allow public traffic from '
             'specific IP addresses.", "direction": "INGRESS", '
+            '"disabled": false, '
             '"logConfig": {"enable": false}, '
             '"name": "test-network-allow-public-0", '
             '"network": "https://www.googleapis.com/compute/v1/projects/'
             'test-project/global/networks/test-network", "priority": 1000, '
             '"sourceRanges": '
             '["127.0.0.1/32", "127.0.0.2/32"]}]'
-      hash: "08c805139d046eb0e40ece533bb5df08b38464b3e569576f63cd8d6143a0fe95"
+      hash: "8e34ec2a6ab8a86dee8c6e98fc94cd9fe823a8732aa26e9438a281bc5fc326f8"
     }
     rules_added: "test-network-allow-internal-0"
     rules_added: "test-network-allow-internal-1"


### PR DESCRIPTION
* Support disabled rules, re-enable disabled rules by default when enforcing a project.
* Support ingress rules with no sourceRanges, the default if not set is to allow from all IPs.
* Support egress rules with no destinationRanges, the default if not set is to allow to all IPs.
* Fix tests and update hashes based on the addition of the 'disabled' key to the firewall rules dict.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
