### PR TITLE
Switch to using firewalls.patch for firewall enforcer.

### DIFF
--- a/google/cloud/forseti/common/gcp_api/repository_mixins.py
+++ b/google/cloud/forseti/common/gcp_api/repository_mixins.py
@@ -403,19 +403,19 @@ class InsertResourceMixin(object):
         return self.execute_command(verb=verb, verb_arguments=arguments)
 
 
-class UpdateResourceMixin(object):
-    """Mixin that implements the Update API command for resources."""
+class _ModifyResourceBaseMixin(object):
+    """Base class for Patch and Update Mixins."""
 
-    def update(self, resource, data, target=None, verb='update', **kwargs):
-        """Update an existing resource.
+    def _modify_resource(self, resource, data, target, verb, **kwargs):
+        """Patch or update an existing resource.
 
         Args:
             self (GCPRespository): An instance of a GCPRespository class.
-            resource (str): Name of the parent resource to update the resource
+            resource (str): Name of the parent resource to modify the resource
                 under.
-            data (dict): The json representation of the resource to update, this
-                will replace the existing resource.
-            target (str): Name of the entity to update.
+            data (dict): The json representation of the resource to modify, this
+                will update the existing resource.
+            target (str): Name of the entity to modify.
             verb (str): The method to call on the API.
             **kwargs (dict): Optional additional arguments to pass to the api.
 
@@ -447,12 +447,65 @@ class UpdateResourceMixin(object):
 
         if self.read_only:
             LOGGER.info(
-                'Update called on a read only repository, no action taken on '
-                'target %s, resource %s for data %s.', target, resource, data)
+                '%s called on a read only repository, no action taken on '
+                'target %s, resource %s for data %s.', verb, target, resource,
+                data)
             resource_link = self._build_resource_link(**arguments)
             return _create_fake_operation(resource_link, verb, target)
 
         return self.execute_command(verb=verb, verb_arguments=arguments)
+
+
+class PatchResourceMixin(_ModifyResourceBaseMixin):
+    """Mixin that implements the Patch API command for resources."""
+
+    def patch(self, resource, data, target=None, verb='patch', **kwargs):
+        """Patch an existing resource.
+
+        Args:
+            self (GCPRespository): An instance of a GCPRespository class.
+            resource (str): Name of the parent resource to patch the resource
+                under.
+            data (dict): The json representation of the resource to patch, this
+                will update the existing resource.
+            target (str): Name of the entity to patch.
+            verb (str): The method to call on the API.
+            **kwargs (dict): Optional additional arguments to pass to the api.
+
+        Returns:
+            dict: The API response containing the async operation.
+
+        Raises:
+            ValueError: When get_key_field was not defined in the base
+                GCPRepository instance.
+        """
+        return self._modify_resource(resource, data, target, verb, **kwargs)
+
+
+class UpdateResourceMixin(_ModifyResourceBaseMixin):
+    """Mixin that implements the Update API command for resources."""
+
+    def update(self, resource, data, target=None, verb='update', **kwargs):
+        """Update an existing resource.
+
+        Args:
+            self (GCPRespository): An instance of a GCPRespository class.
+            resource (str): Name of the parent resource to update the resource
+                under.
+            data (dict): The json representation of the resource to update, this
+                will replace the existing resource.
+            target (str): Name of the entity to update.
+            verb (str): The method to call on the API.
+            **kwargs (dict): Optional additional arguments to pass to the api.
+
+        Returns:
+            dict: The API response containing the async operation.
+
+        Raises:
+            ValueError: When get_key_field was not defined in the base
+                GCPRepository instance.
+        """
+        return self._modify_resource(resource, data, target, verb, **kwargs)
 
 
 class DeleteResourceMixin(object):

--- a/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
+++ b/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
@@ -982,7 +982,7 @@ class FirewallEnforcer(object):
         return change_count
 
     def _update_rules(self, network):
-        """Update existing rules in the project firewall.
+        """Update existing rules in the project firewall using patch.
 
         Args:
             network (str): The network name to restrict rules to. If no network
@@ -1002,9 +1002,9 @@ class FirewallEnforcer(object):
                 self.expected_rules.rules[rule_name]
                 for rule_name in self._rules_to_update
             ], network)
-            update_function = self.compute_client.update_firewall_rule
+            patch_function = self.compute_client.patch_firewall_rule
             (successes, failures, change_errors) = self._apply_change(
-                update_function, rules)
+                patch_function, rules)
             self._updated_rules.extend(successes)
             change_count += len(successes)
             if failures:

--- a/tests/common/gcp_api/compute_test.py
+++ b/tests/common/gcp_api/compute_test.py
@@ -34,10 +34,11 @@ ERROR_TEST_CASES = [
      api_errors.ApiExecutionError),
 ]
 
-# Test create, update and delete operations.
+# Test create, patch, update and delete operations.
 CUD_TEST_CASES = [
     ('delete', 'delete'),
     ('insert', 'insert'),
+    ('patch', 'patch'),
     ('update', 'update'),
 ]
 
@@ -136,7 +137,7 @@ class ComputeTest(unittest_utils.ForsetiTestCase):
 
     @parameterized.parameterized.expand(CUD_TEST_CASES)
     def test_cud_firewall_rule(self, name, verb):
-        """Test create/update/delete firewall rule."""
+        """Test create/patch/update/delete firewall rule."""
         mock_response = fake_compute.PENDING_OPERATION_TEMPLATE.format(
             verb=verb,
             resource_path='project1/global/firewalls/fake-firewall')
@@ -150,7 +151,7 @@ class ComputeTest(unittest_utils.ForsetiTestCase):
 
     @parameterized.parameterized.expand(CUD_TEST_CASES)
     def test_cud_firewall_rule_read_only(self, name, verb):
-        """Test create/update/delete firewall rule."""
+        """Test create/patch/update/delete firewall rule."""
         with mock.patch.object(self.gce_api_client.repository.firewalls,
                                'read_only', return_value=True):
             method = getattr(self.gce_api_client,
@@ -170,7 +171,7 @@ class ComputeTest(unittest_utils.ForsetiTestCase):
 
     @parameterized.parameterized.expand(CUD_TEST_CASES)
     def test_cud_firewall_rule_blocking(self, name, verb):
-        """Test create/update/delete firewall rule blocking until complete."""
+        """Test create/patch/update/delete firewall blocks until complete."""
         mock_pending = fake_compute.PENDING_OPERATION_TEMPLATE.format(
             verb=verb,
             resource_path='project1/global/firewalls/fake-firewall')
@@ -196,7 +197,7 @@ class ComputeTest(unittest_utils.ForsetiTestCase):
 
     @parameterized.parameterized.expand(CUD_TEST_CASES)
     def test_cud_firewall_rule_timeout(self, name, verb):
-        """Test create/update/delete firewall rule times out."""
+        """Test create/patch/update/delete firewall rule times out."""
         mock_pending = fake_compute.PENDING_OPERATION_TEMPLATE.format(
             verb=verb,
             resource_path='project1/global/firewalls/fake-firewall')
@@ -226,7 +227,7 @@ class ComputeTest(unittest_utils.ForsetiTestCase):
     @parameterized.parameterized.expand(CUD_TEST_CASES)
     @mock.patch('google.cloud.forseti.common.gcp_api.compute.LOGGER', autospec=True)
     def test_cud_firewall_rule_retry(self, name, verb, mock_logger):
-        """Test create/update/delete firewall rule times out."""
+        """Test create/patch/update/delete firewall rule times out."""
         mock_pending = fake_compute.PENDING_OPERATION_TEMPLATE.format(
             verb=verb,
             resource_path='project1/global/firewalls/fake-firewall')

--- a/tests/enforcer/gce_firewall_enforcer_test.py
+++ b/tests/enforcer/gce_firewall_enforcer_test.py
@@ -961,7 +961,7 @@ class FirewallEnforcerTest(constants.EnforcerTestCase):
         """Validate apply_change works with no errors."""
         delete_function = self.gce_api_client.delete_firewall_rule
         insert_function = self.gce_api_client.insert_firewall_rule
-        update_function = self.gce_api_client.update_firewall_rule
+        update_function = self.gce_api_client.patch_firewall_rule
 
         test_rules = [
             copy.deepcopy(constants.EXPECTED_FIREWALL_RULES[

--- a/tests/enforcer/project_enforcer_test.py
+++ b/tests/enforcer/project_enforcer_test.py
@@ -555,7 +555,7 @@ class ProjectEnforcerTest(constants.EnforcerTestCase):
         ]
 
         with mock.patch.object(self.gce_api_client,
-                               'update_firewall_rule') as mock_updater:
+                               'patch_firewall_rule') as mock_updater:
             mock_updater.return_value = {
                 'status': 'DONE',
                 'name': 'test-net-allow-corp-internal-0',


### PR DESCRIPTION
The compute.firewalls.update API does not properly handle EGRESS rules and other new firewall fields.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
