### PR TITLE
Add verbose mode to jekyll build to prevent timeout on travis.

### DIFF
--- a/travis/jekyll_build.sh
+++ b/travis/jekyll_build.sh
@@ -19,7 +19,7 @@ trap 'return_code=$?' ERR
 # TODO(drmorris): change branch from "stable" to "master" when after release
 ./scripts/generate_sphinx_docs.sh "stable"
 
-JEKYLL_GITHUB_TOKEN=$JGT bundle exec jekyll build
+JEKYLL_GITHUB_TOKEN=$JGT bundle exec jekyll build -V
 
 bundle exec htmlproofer --check-img-http --check-html \
 --check-favicon --report-missing-names --report-script-embeds \


### PR DESCRIPTION
Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [ ] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [ ] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [ ] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [ ] My PR has been functionally tested.
- [ ] All of the [unit-tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) still pass.
- [ ] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
