### PR TITLE
Add a sample firewall rule to scan for SSH from anywhere

### DIFF
--- a/samples/scanner/scanners/firewall_rules/blacklist.yaml
+++ b/samples/scanner/scanners/firewall_rules/blacklist.yaml
@@ -157,6 +157,51 @@ rules:
         - IPProtocol: 'tcp'
           ports:
             - '3389'
+            
+    # This rule will trigger on policies that allow SSH from any IP range.
+    #
+    # Example triggering firewall rule:
+    #  {
+    #    "name": "firewall1",
+    #    "network": "https://www.googleapis.com/compute/v1/projects/yourproject/global/networks/default",
+    #    "priority": 1000,
+    #    "sourceRanges": ["0.0.0.0/0"],
+    #    "allowed": [
+    #      {
+    #        "IPProtocol": "tcp",
+    #        "ports": ["22"]
+    #      }
+    #    ],
+    #     "direction": "INGRESS"
+    #  }
+    #
+    # Example firewall rule that WON'T trigger:
+    #
+    #  {
+    #    "name": "firewall2",
+    #    "network": "https://www.googleapis.com/compute/v1/projects/yourproject/global/networks/default",
+    #    "priority": 1000,
+    #    "sourceRanges": ["10.128.0.0/9"],
+    #    "allowed": [
+    #      {
+    #        "IPProtocol": "tcp",
+    #        "ports": ["22"]
+    #      }
+    #    ],
+    #     "direction": "INGRESS"
+    #  }
+  - rule_id: 'no_ssh_from_anywhere'
+    description: Don't allow SSH from anywhere
+    mode: blacklist
+    match_policies:
+      - direction: ingress
+        allowed: ['*']
+        sourceRanges: ['0.0.0.0/0']
+    verify_policies:
+      - allowed:
+        - IPProtocol: 'tcp'
+          ports:
+            - '22'
 
 org_policy:
   resources:
@@ -168,3 +213,4 @@ org_policy:
           - 'prevent_allow_all_ingress'
           - 'disallow_all_ports'
           - 'no_rdp_to_linux'
+          - 'no_ssh_from_anywhere'


### PR DESCRIPTION
I would like to add this sample featuring the "sourceRanges: ['0.0.0.0/0']" in match policies because currently the default Firewall Rules Scanner triggers on internal ranges and the documentation for writing custom Firewall Rules is lacking on [the website](https://forsetisecurity.org/docs/latest/configure/scanner/rules.html).  


Signed-off-by: Cyril SABOURAULT <cyril74940@gmail.com>

Thanks for opening a Pull Request!
Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [unit-tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) still pass.
- [x] Running `pylint --rcfile=pylintrc` passes.

These guidelines and more can be found in our [contributing guidelines](https://github.com/GoogleCloudPlatform/forseti-security/blob/master/.github/CONTRIBUTING.md).
