### PR TITLE
Allow grpc client to receive large messages.

### DIFF
--- a/google/cloud/forseti/services/client.py
+++ b/google/cloud/forseti/services/client.py
@@ -723,7 +723,9 @@ class ClientComposition(object):
         Raises:
             Exception: gRPC connected but services not registered
         """
-        self.channel = grpc.insecure_channel(endpoint)
+        self.gigabyte = 1024 ** 3
+        self.channel = grpc.insecure_channel(endpoint, options=[
+          ('grpc.max_receive_message_length', self.gigabyte)])
         self.config = ClientConfig({'channel': self.channel, 'handle': ''})
 
         self.explain = ExplainClient(self.config)

--- a/google/cloud/forseti/services/client.py
+++ b/google/cloud/forseti/services/client.py
@@ -725,7 +725,7 @@ class ClientComposition(object):
         """
         self.gigabyte = 1024 ** 3
         self.channel = grpc.insecure_channel(endpoint, options=[
-          ('grpc.max_receive_message_length', self.gigabyte)])
+            ('grpc.max_receive_message_length', self.gigabyte)])
         self.config = ClientConfig({'channel': self.channel, 'handle': ''})
 
         self.explain = ExplainClient(self.config)


### PR DESCRIPTION
Fixes #2682.  The problem is on the client end of the grpc. No need to make changes on the server end since the message is already being streamed.

This has been tested with the entire work of shakespeare, which is 5.8MB in size (i.e. great than the default 4MB grpc message).