### PR TITLE
Slack notifications for website build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,9 @@ deploy:
     condition: "($TRAVIS_SECURE_ENV_VARS = true) && ($TRAVIS_EVENT_TYPE != cron)"
   skip_cleanup: true
   no_promote: true
+notifications:
+  slack:
+    on_failure: always
+    on_pull_requests: false
+    rooms:
+      secure: FARoc4RRj7/lXoHerXFVtonb6G5O2QspYvRQnx+R8T0J+Nt4vk5YtwMY+Dve3pYmbY+SOyrKaGcqiPmltuV14T45XZM8QnNBZaC4tXImz6hfSuDoC+NcFZ7J9BQ39qJITrgqz4v5CFOUxCT6rTDe5qZJr7/kBhjcpEgRTWf+AGg7Up1+ZbmgIDltEzEw9c/EYF/KlxRnhIW6Ku6SAErLhdjCPosqsrcgZurFkKAQ27yDRBtdEalRhzzXfDjb2vo614WCmatK9FX7ry5Jp0Pw2piq++XMRLohj9IQ+17LeJOsff/57d1p3dV6AQzxnugPNnzePuo9lww59rvJocPc/6U/xujtLDCRxr9gS6m8Up18d6Guj9kln9E48HZB2VtKgJ6zb0RbzK331Zt0mEoQEAf83Ll2ItuMxdrjQT5cnRgy2seVrsWAFfktA1BIMxaHYsAcGvsW0LqjYv+X4C4zMkhr4clg/7mLpeScwS8kO1mYjCHdfkXs31dE4Kp5Q9umxsB6Lky6otpHjYo6nfZ6CAPnZz38elg9dOoNlNuzZQ2g5HY7cL87Pv5Fg8vv2XagnJG7sg7bCPlv8L8YD8ZevVSFxYYKN2cH21nnx0ElTgDEgDhTwp7x5sOypsN3n4R6r/6mgDrIg4d1w9oXAu7DiUmFPcZFqbSbZA7ycbpAAjI=


### PR DESCRIPTION
Updated travis config to notify private Slack channel when the forsetisecurity.org website build fails.